### PR TITLE
Multiple output ports in scheduler node

### DIFF
--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -84,7 +84,7 @@ SOFTWARE.
                         label += "~";
                     }
 
-                    label += Math.abs(this.offset) + " " + this._("delay.label.min");
+                    label += Math.abs(this.offset) + " " + this._("node-red-contrib-chronos/chronos-config:common.label.min");
                 }
             }
 

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -13,7 +13,8 @@
             "custom":       "Benutzerdefiniert",
             "fullMessage":  "Komplette Nachricht",
             "offset":       "Versatz",
-            "random":       "Zufällig"
+            "random":       "Zufällig",
+            "min":          "min."
         },
         "list":
         {

--- a/nodes/locales/de/delay.json
+++ b/nodes/locales/de/delay.json
@@ -4,7 +4,6 @@
         "label":
         {
             "outputPort":  "Verzögerte Nachricht",
-            "min":         "min.",
             "when":        "Wann"
         },
         "status":

--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -99,5 +99,11 @@ SOFTWARE.
                 </li>
             </ul>
         </dd>
+        <dt>Separate Ausgabe-Ports für Zeitereignisse</dt>
+        <dd>
+            Wenn aktiviert, wird für jedes Zeitereignis, das eine Nachricht als
+            Ausgabe erzeugt, ein eigener Ausgabe-Port erstellt und die Nachricht
+            des Zeitereignisses wird an den zugehörigen Ausgabe-Port geschickt.
+        </dd>
     </dl>
 </script>

--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -6,7 +6,8 @@
             "inputPort":   "Ein-/Ausschalten",
             "outputPort":  "Geplante Nachricht",
             "schedule":    "Zeitplan",
-            "output":      "Ausgabe"
+            "output":      "Ausgabe",
+            "multiPort":   "Separate Ausgabe-Ports für Zeitereignisse"
         },
         "status":
         {

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -13,7 +13,8 @@
             "custom":       "Custom",
             "fullMessage":  "full message",
             "offset":       "Offset",
-            "random":       "Randomized"
+            "random":       "Randomized",
+            "min":          "min."
         },
         "list":
         {

--- a/nodes/locales/en-US/delay.json
+++ b/nodes/locales/en-US/delay.json
@@ -4,7 +4,6 @@
         "label":
         {
             "outputPort":  "delayed message",
-            "min":         "min.",
             "when":        "When"
         },
         "status":

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -92,5 +92,11 @@ SOFTWARE.
                 </li>
             </ul>
         </dd>
+        <dt>Dedicated output ports for schedule events</dt>
+        <dd>
+            If selected, for each event which produces a message as output, a
+            dedicated output port will be created and the output message of the
+            event will be sent to the assigned output port.
+        </dd>
     </dl>
 </script>

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -6,7 +6,8 @@
             "inputPort":   "enable/disable",
             "outputPort":  "scheduled message",
             "schedule":    "Schedule",
-            "output":      "Output"
+            "output":      "Output",
+            "multiPort":   "Dedicated output ports for schedule events"
         },
         "status":
         {

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -37,6 +37,10 @@ SOFTWARE.
             <ol id="node-input-scheduleList"></ol>
         </div>
     </div>
+    <div class="form-row">
+        <input id="node-input-multiPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+        <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -62,7 +66,7 @@ SOFTWARE.
         },
         outputLabels: function(index)
         {
-            return this._("scheduler.label.outputPort");
+            return (this.schedule[index] ? this.schedule[index].label : this._("scheduler.status.noSchedule")) || this._("scheduler.label.outputPort");
         },
         defaults:
         {
@@ -85,6 +89,14 @@ SOFTWARE.
                     // just a simple check if there are any events, no detailed check of the content
                     return v.length > 0;
                 }
+            },
+            multiPort:
+            {
+                value: false
+            },
+            outputs:
+            {
+                value: 1
             }
         },
         oneditprepare: function()
@@ -323,8 +335,11 @@ SOFTWARE.
         {
             let node = this;
             let scheduleList = $("#node-input-scheduleList").editableList("items");
+            let multiPort = $("#node-input-multiPort").prop("checked");
 
             node.schedule = [];
+            node.outputs = 0;
+
             scheduleList.each(function(index)
             {
                 let data = {trigger: {}, output: {}};
@@ -351,6 +366,39 @@ SOFTWARE.
                     data.output.property = {name: outType.typedInput("value"),
                                             type: propValue.typedInput("type"),
                                             value: propValue.typedInput("value")};
+                }
+
+                if ((data.output.type == "msg") || (data.output.type == "fullMsg"))
+                {
+                    if (multiPort)
+                    {
+                        data.output.port = node.outputs++;
+
+                        if ((data.trigger.type == "time") || (data.trigger.type == "custom"))
+                        {
+                            data.label = data.trigger.value;
+                        }
+                        else
+                        {
+                            data.label = node._("node-red-contrib-chronos/chronos-config:common.list." + data.trigger.type + "." + data.trigger.value);
+                        }
+
+                        if (data.trigger.offset != 0)
+                        {
+                            data.label += ((data.trigger.offset > 0) ? " + " : " - ");
+
+                            if (data.trigger.random)
+                            {
+                                data.label += "~";
+                            }
+
+                            data.label += Math.abs(data.trigger.offset) + " " + node._("node-red-contrib-chronos/chronos-config:common.label.min");
+                        }
+                    }
+                    else
+                    {
+                        node.outputs = 1;
+                    }
                 }
 
                 node.schedule.push(data);

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -51,6 +51,16 @@ module.exports = function(RED)
             time.init(RED, node.config.latitude, node.config.longitude, node.config.sunPositions);
 
             node.schedule = settings.schedule;
+            node.multiPort = settings.multiPort;
+
+            node.ports = [];
+            if (node.multiPort)
+            {
+                for (let i=0; i<settings.outputs; ++i)
+                {
+                    node.ports.push(null);
+                }
+            }
 
             let valid = true;
             for (let i=0; i<node.schedule.length; ++i)
@@ -297,14 +307,28 @@ module.exports = function(RED)
                     msg[data.output.property.name] = data.output.property.value;
                 }
 
-                node.send(msg);
+                sendMessage(data, msg);
             }
             else if (data.output.type == "fullMsg")
             {
-                node.send(data.output.value);
+                sendMessage(data, data.output.value);
             }
 
             setUpTimer(data, true);
+        }
+
+        function sendMessage(data, msg)
+        {
+            if (node.multiPort)
+            {
+                node.ports[data.output.port] = msg;
+                node.send(node.ports);
+                node.ports[data.output.port] = null;
+            }
+            else
+            {
+                node.send(msg);
+            }
         }
     }
 


### PR DESCRIPTION
There is a new option in scheduler node which creates dedicated output ports for each schedule event that produces output messages. The output messages will then be delivered to the output ports corresponding to the events.