### PR TITLE
"Evaluate only" mode for time filter node

### DIFF
--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -41,6 +41,10 @@ SOFTWARE.
         <input id="node-input-allMustMatch" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
         <label for="node-input-allMustMatch" style="margin-bottom: 0px; width: auto;" data-i18n="filter.label.allMustMatch"></label>
     </div>
+    <div class="form-row">
+        <input id="node-input-annotateOnly" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+        <label for="node-input-annotateOnly" style="margin-bottom: 0px; width: auto;" data-i18n="filter.label.annotateOnly"></label>
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -90,6 +94,10 @@ SOFTWARE.
                 }
             },
             allMustMatch:
+            {
+                value: false
+            },
+            annotateOnly:
             {
                 value: false
             }
@@ -536,6 +544,20 @@ SOFTWARE.
 
                     operator.change();
                     item[0].appendChild(fragment);
+                }
+            });
+
+            $("#node-input-annotateOnly").change(function()
+            {
+                if ($(this).prop("checked"))
+                {
+                    $("#node-input-allMustMatch").attr("disabled", true);
+                    $("label[for='node-input-allMustMatch']").addClass("disabled");
+                }
+                else
+                {
+                    $("#node-input-allMustMatch").attr("disabled", false);
+                    $("label[for='node-input-allMustMatch']").removeClass("disabled");
                 }
             });
 

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -52,6 +52,7 @@ module.exports = function(RED)
 
             node.conditions = settings.conditions;
             node.allMustMatch = settings.allMustMatch;
+            node.annotateOnly = settings.annotateOnly;
 
             let valid = true;
             for (let i=0; i<node.conditions.length; ++i)
@@ -113,6 +114,7 @@ module.exports = function(RED)
 
                         let now = time.getCurrentTime();
                         let result = false;
+                        let evaluation = [];
 
                         for (let i=0; i<node.conditions.length; ++i)
                         {
@@ -174,6 +176,10 @@ module.exports = function(RED)
                                 {
                                     result = cond.operands[now.month()];
                                 }
+                                else
+                                {
+                                    result = false;
+                                }
                             }
                             catch (e)
                             {
@@ -199,14 +205,28 @@ module.exports = function(RED)
                                 result = false;
                             }
 
-                            if ((node.allMustMatch && !result) ||
-                                (!node.allMustMatch && result))
+                            if (node.annotateOnly)
+                            {
+                                evaluation.push(result);
+                            }
+                            else if ((node.allMustMatch && !result) ||
+                                     (!node.allMustMatch && result))
                             {
                                 break;
                             }
                         }
 
-                        if (result)
+                        if (node.annotateOnly)
+                        {
+                            if ("evaluation" in msg)
+                            {
+                                msg._evaluation = msg.evaluation;
+                            }
+                            msg.evaluation = evaluation;
+
+                            node.send(msg);
+                        }
+                        else if (result)
                         {
                             node.send(msg);
                         }

--- a/nodes/locales/de/filter.json
+++ b/nodes/locales/de/filter.json
@@ -4,7 +4,8 @@
         "label":
         {
             "outputPort":    "Bedingte Nachricht",
-            "allMustMatch":  "Alle Bedingungen müssen zutreffen"
+            "allMustMatch":  "Alle Bedingungen müssen zutreffen",
+            "annotateOnly":  "Nur annotieren, nicht filtern"
         }
     }
 }

--- a/nodes/locales/en-US/filter.json
+++ b/nodes/locales/en-US/filter.json
@@ -4,7 +4,8 @@
         "label":
         {
             "outputPort":    "conditional message",
-            "allMustMatch":  "All conditions must match"
+            "allMustMatch":  "All conditions must match",
+            "annotateOnly":  "Annotate only, do not filter"
         }
     }
 }


### PR DESCRIPTION
You can now activate a mode in time filter node which only annotates incoming messages with the evaluation results of all conditions as an array and forwards the messages in any case. Then it is possible to connect for instance a function node to form more complex filter expressions from the evaluation annotations.