### PR TITLE
Compare against custom timestamp in switch and filter node

### DIFF
--- a/nodes/common/time.js
+++ b/nodes/common/time.js
@@ -69,6 +69,11 @@ function getCurrentTime()
     return moment();
 }
 
+function getTimeFrom(source)
+{
+    return moment(source);
+}
+
 function getUserTime(day, value)
 {
     let ret = null;
@@ -192,6 +197,7 @@ module.exports =
 {
     init: init,
     getCurrentTime: getCurrentTime,
+    getTimeFrom: getTimeFrom,
     getUserTime: getUserTime,
     getSunTime: getSunTime,
     getMoonTime: getMoonTime,

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -31,6 +31,11 @@ SOFTWARE.
         <label for="node-input-config"><i class="fa fa-cog"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.config"></span></label>
         <input type="text" id="node-input-config" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.config">
     </div>
+    <div class="form-row">
+        <label for="node-input-baseTime"><i class="fa fa-clock-o"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.baseTime"></span></label>
+        <input type="text" id="node-input-baseTime" style="width: 70%;">
+        <input id="node-input-baseTimeType" type="hidden">
+    </div>
     <div class="form-row node-input-conditionList-row" style="padding-top: 10px">
         <label for="node-input-conditionList"><i class="fa fa-sliders"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.conditions"></span></label>
         <div class="form-row">
@@ -84,6 +89,15 @@ SOFTWARE.
                 type:     "chronos-config",
                 required: true
             },
+            baseTime:
+            {
+                value:    "",
+                validate: RED.validators.typedInput("baseTimeType")
+            },
+            baseTimeType:
+            {
+                value: "msgIngress"
+            },
             conditions:
             {
                 value: [{operator: "before", operands: {type: "time", value: ""}}],
@@ -105,6 +119,16 @@ SOFTWARE.
         oneditprepare: function()
         {
             let node = this;
+
+            const msgIngressInput =
+            {
+                value: "msgIngress",
+                label: node._("node-red-contrib-chronos/chronos-config:common.label.msgIngress"),
+                hasValue: false
+            };
+
+            let baseTime = $("#node-input-baseTime")
+                            .typedInput({types: [msgIngressInput, "global", "flow", "msg"], typeField: "#node-input-baseTimeType"});
 
             let conditionList = $("#node-input-conditionList").css("min-width", "500px").css("min-height", "150px").editableList(
             {

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -6,6 +6,8 @@
             "inputPort":    "Eingehende Nachricht",
             "name":         "Name",
             "config":       "Konfiguration",
+            "baseTime":     "Basiszeit",
+            "msgIngress":   "Nachrichteneingang",
             "conditions":   "Bedingungen",
             "time":         "Uhrzeit",
             "sun":          "Sonnenstand",
@@ -88,6 +90,7 @@
             "noConditions":     "Keine Bedingungen kongiguriert",
             "invalidConfig":    "Konfiguration enthält ungültige Werte",
             "invalidTime":      "Ungültige Uhrzeit angegeben",
+            "invalidBaseTime":  "Ungültige Basiszeit angegeben: __baseTime__",
             "invalidName":      "Ungültiger benutzerdefinierter Sonnenstand angegeben",
             "unavailableTime":  "Kein Zeitpunkt für Ereignis verfügbar"
         }

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -24,7 +24,7 @@ SOFTWARE.
 
 <script type="text/x-red" data-help-name="chronos-filter">
     <p>
-        Filtert Nachrichten anhand ihres Eingangszeitpunkts und -datums.
+        Filtert Nachrichten anhand eines bestimmten Zeitpunkts.
     </p>
     <h3>Details</h3>
     <p>
@@ -45,6 +45,29 @@ SOFTWARE.
         <dd>
             Ein Verweis auf den zu verwendenden Konfigurationsknoten.
         </dd>
+        <dt>Basiszeit</dt>
+        <dd>
+            Die Basiszeit wird für den Vergleich mit den Operanden der Bedingungen
+            verwendet. Folgende Möglichkeiten gibt es:
+            <ul>
+                <li>
+                    <i>Nachrichteneingang</i>: Zeitpunkt des Eintreffens der
+                    Nachricht.
+                </li>
+                <li>
+                    <i>global.</i>: Zeitstempel aus einer globalen Variable als
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+                <li>
+                    <i>flow.</i>: Zeitstempel aus einer Flow-Variable als
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+                <li>
+                    <i>msg.</i>: Zeitstempel aus einer Nachrichteneigenschaft
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+            </ul>
+        </dd>
         <dt>Bedingungen</dt>
         <dd>
             Liste der Bedingungen zum Filtern der Nachrichten. Neue Einträge
@@ -54,28 +77,29 @@ SOFTWARE.
             folgenden Möglichkeiten:
             <ul>
                 <li>
-                    <i>Vor</i>: Prüft ob der Eingangszeitpunkt der Nachricht vor
-                    der spezifizierten Zeit ist.
+                    <i>Vor</i>: Prüft ob die Basiszeit früher als die
+                    spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Nach</i>: Prüft ob der Eingangszeitpunkt der Nachricht zur
-                    oder nach der spezifizierten Zeit ist.
+                    <i>Nach</i>: Prüft ob die Basiszeit gleich oder später als
+                    die spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Zwischen</i>: Prüft ob der Eingangszeitpunkt der Nachricht
-                    zu oder zwischen den zwei spezifizierten Zeiten liegt.
+                    <i>Zwischen</i>: Prüft ob die Basiszeit gleich oder später
+                    als die erste und früher als die zweite spezifizierte Zeit
+                    ist.
                 </li>
                 <li>
-                    <i>Außerhalb</i>: Prüft ob der Eingangszeitpunkt der Nachricht
-                    vor der ersten oder nach der zweiten spezifizierten Zeit ist.
+                    <i>Außerhalb</i>: Prüft ob die Basiszeit früher als die
+                    erste oder später als die zweite spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Wochentage</i>: Prüft ob das Eingangsdatum der Nachricht
-                    an einem der ausgewählten Wochentage ist.
+                    <i>Wochentage</i>: Prüft ob die Basiszeit auf den ausgewählten
+                    Wochentag zutrifft.
                 </li>
                 <li>
-                    <i>Monate</i>: Prüft ob das Eingangsdatum der Nachricht
-                    in einem der ausgewählten Monate ist.
+                    <i>Monate</i>: Prüft ob die Basiszeit auf einen der
+                    ausgewählten Monate zutrifft.
                 </li>
             </ul>
             Für die Zeiteingabe, abhängig von der Auswahl auf der linken Seite,
@@ -121,9 +145,9 @@ SOFTWARE.
     </p>
     <h3>Ausgaben</h3>
     <p>
-        Wenn eine oder mehrere Bedingungen auf den Zeitpunkt oder das Datum des
-        Nachrichteneingangs zutreffen oder wenn <i>Nur annotieren, nicht filtern</i>
-        aktiviert ist, wird die Nachricht zum Ausgabe-Port gesendet.
+        Wenn eine oder mehrere Bedingungen auf die konfigurierte Basiszeit
+        zutreffen oder wenn <i>Nur annotieren, nicht filtern</i> aktiviert ist,
+        wird die Nachricht zum Ausgabe-Port gesendet.
     </p>
     <p>
         Nur wenn <i>Nur annotieren, nicht filtern</i> aktiviert ist:

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -24,13 +24,15 @@ SOFTWARE.
 
 <script type="text/x-red" data-help-name="chronos-switch">
     <p>
-        Leitet Nachrichten anhand ihres Eingangszeitpunkts und -datums an
-        unterschiedliche Ausgabe-Ports.
+        Leitet Nachrichten anhand eines bestimmten Zeitpunkts an unterschiedliche
+        Ausgabe-Ports.
     </p>
     <h3>Details</h3>
     <p>
-        Dieser Knoten leitet eingehende Nachrichten anhand des Zeitpunkts und
-        Datums beim Eintreffen an davon abhängige Ausgabe-Ports um.
+        Dieser Knoten leitet eingehende Nachrichten anhand des Zeitpunkts beim
+        Eintreffen oder eines Zeitstempels aus einer Nachrichteneigenschaft,
+        einer globalen Variable oder einer Flow-Variable an davon abhängige
+        Ausgabe-Ports um.
     </p>
     <p>
         Für weitere Informationen bitte die ausführliche Dokumentation im
@@ -45,6 +47,29 @@ SOFTWARE.
         <dd>
             Ein Verweis auf den zu verwendenden Konfigurationsknoten.
         </dd>
+        <dt>Basiszeit</dt>
+        <dd>
+            Die Basiszeit wird für den Vergleich mit den Operanden der Bedingungen
+            verwendet. Folgende Möglichkeiten gibt es:
+            <ul>
+                <li>
+                    <i>Nachrichteneingang</i>: Zeitpunkt des Eintreffens der
+                    Nachricht.
+                </li>
+                <li>
+                    <i>global.</i>: Zeitstempel aus einer globalen Variable als
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+                <li>
+                    <i>flow.</i>: Zeitstempel aus einer Flow-Variable als
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+                <li>
+                    <i>msg.</i>: Zeitstempel aus einer Nachrichteneigenschaft
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                </li>
+            </ul>
+        </dd>
         <dt>Bedingungen</dt>
         <dd>
             Liste der Bedingungen zum Umleiten der Nachrichten. Neue Einträge
@@ -54,28 +79,29 @@ SOFTWARE.
             folgenden Möglichkeiten:
             <ul>
                 <li>
-                    <i>Vor</i>: Prüft ob der Eingangszeitpunkt der Nachricht vor
-                    der spezifizierten Zeit ist.
+                    <i>Vor</i>: Prüft ob die Basiszeit früher als die
+                    spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Nach</i>: Prüft ob der Eingangszeitpunkt der Nachricht zur
-                    oder nach der spezifizierten Zeit ist.
+                    <i>Nach</i>: Prüft ob die Basiszeit gleich oder später als
+                    die spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Zwischen</i>: Prüft ob der Eingangszeitpunkt der Nachricht
-                    zu oder zwischen den zwei spezifizierten Zeiten liegt.
+                    <i>Zwischen</i>: Prüft ob die Basiszeit gleich oder später
+                    als die erste und früher als die zweite spezifizierte Zeit
+                    ist.
                 </li>
                 <li>
-                    <i>Außerhalb</i>: Prüft ob der Eingangszeitpunkt der Nachricht
-                    vor der ersten oder nach der zweiten spezifizierten Zeit ist.
+                    <i>Außerhalb</i>: Prüft ob die Basiszeit früher als die
+                    erste oder später als die zweite spezifizierte Zeit ist.
                 </li>
                 <li>
-                    <i>Wochentage</i>: Prüft ob das Eingangsdatum der Nachricht
-                    an einem der ausgewählten Wochentage ist.
+                    <i>Wochentage</i>: Prüft ob die Basiszeit auf den ausgewählten
+                    Wochentag zutrifft.
                 </li>
                 <li>
-                    <i>Monate</i>: Prüft ob das Eingangsdatum der Nachricht
-                    in einem der ausgewählten Monate ist.
+                    <i>Monate</i>: Prüft ob die Basiszeit auf einen der
+                    ausgewählten Monate zutrifft.
                 </li>
                 <li>
                     <i>Sonst</i>: Wird angewendet wenn alle anderen Bedingungen
@@ -122,7 +148,7 @@ SOFTWARE.
     </p>
     <h3>Ausgaben</h3>
     <p>
-        Jeder Ausgabe-Port gehört zu einer konfigurierten Bedingung, welche auf
-        den Eingangszeitpunkt oder das -datum angewendet wird.
+        Jeder Ausgabe-Port gehört zu einer konfigurierten Bedingung, welche mit
+        der Basiszeit verglichen wird.
     </p>
 </script>

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -6,6 +6,8 @@
             "inputPort":    "input message",
             "name":         "Name",
             "config":       "Configuration",
+            "baseTime":     "Base Time",
+            "msgIngress":   "message ingress",
             "conditions":   "Conditions",
             "time":         "Time of Day",
             "sun":          "Sun Position",
@@ -88,6 +90,7 @@
             "noConditions":     "No conditions configured",
             "invalidConfig":    "Configuration contains invalid values",
             "invalidTime":      "Invalid time specified",
+            "invalidBaseTime":  "Invalid base time specified: __baseTime__",
             "invalidName":      "Invalid custom sun position specified",
             "unavailableTime":  "No time available for event"
         }

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -24,7 +24,7 @@ SOFTWARE.
 
 <script type="text/x-red" data-help-name="chronos-filter">
     <p>
-        Filters messages based on their ingress time and date.
+        Filters messages based on specific times.
     </p>
    <h3>Details</h3>
     <p>
@@ -44,6 +44,28 @@ SOFTWARE.
         <dd>
             A reference to the configuration node to be used.
         </dd>
+        <dt>Base Time</dt>
+        <dd>
+            The base time is used for comparison with the operands of the
+            conditions. This can be one of:
+            <ul>
+                <li>
+                    <i>message ingress</i>: Ingress time of the input message.
+                </li>
+                <li>
+                    <i>global.</i>: Timestamp from a global variable as number
+                    of milliseconds elapsed since the UNIX epoch.
+                </li>
+                <li>
+                    <i>flow.</i>: Timestamp from a flow variable as number of
+                    milliseconds elapsed since the UNIX epoch.
+                </li>
+                <li>
+                    <i>msg.</i>: Timestamp from a message property as number of
+                    milliseconds elapsed since the UNIX epoch.
+                </li>
+            </ul>
+        </dd>
         <dt>Conditions</dt>
         <dd>
             The list containing the conditions for filtering messages. New entries
@@ -52,28 +74,28 @@ SOFTWARE.
             side, the following possibilities are available:
             <ul>
                 <li>
-                    <i>before</i>: Checks if the message ingress time is before
-                    the specified time.
+                    <i>before</i>: Checks if the base time is earlier than the
+                    specified time.
                 </li>
                 <li>
-                    <i>after</i>: Checks if the message ingress time is at or
-                    after the specified time.
+                    <i>after</i>: Checks if the base time is equal to or later
+                    than the specified time.
                 </li>
                 <li>
-                    <i>between</i>: Checks if the message ingress time is at or
-                    between the two specified times.
+                    <i>between</i>: Checks if the base time is equal to or later
+                    than the first and earlier than the second specified time.
                 </li>
                 <li>
-                    <i>outside</i>: Checks if the message ingress time is before
-                    the first or after the second specified time.
+                    <i>outside</i>: Checks if the base time is earlier than the
+                    first or later than the second specified time.
                 </li>
                 <li>
-                    <i>week days</i>: Checks if the message ingress date is at
-                    one of the selected week days.
+                    <i>week days</i>: Checks if the base time matches one of
+                    the selected week days.
                 </li>
                 <li>
-                    <i>months</i>: Checks if the message ingress date is at one
-                    of the selected months.
+                    <i>months</i>: Checks if the base time matches one of the
+                    selected months.
                 </li>
             </ul>
             For the time input, depending on the selection on the left side, the
@@ -119,9 +141,9 @@ SOFTWARE.
     </p>
     <h3>Outputs</h3>
     <p>
-        If one or multiple conditions match the message's ingress time and date
-        or if <i>Annotate only, do not filter</i> is activated, the message
-        is sent out.
+        If one or multiple conditions match the configured base time or if
+        <i>Annotate only, do not filter</i> is activated, the message is sent
+        out.
     </p>
     <p>
         Only if <i>Annotate only, do not filter</i> is activated:

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -24,12 +24,13 @@ SOFTWARE.
 
 <script type="text/x-red" data-help-name="chronos-switch">
     <p>
-        Routes messages based on their ingress time and date.
+        Routes messages based on specific times.
     </p>
     <h3>Details</h3>
     <p>
         This node routes incoming messages to output ports based on the time
-        and date of arrival.
+        of arrival or a timestamp specified via a message property, global
+        variable or flow variable.
     </p>
     <p>
         For more information, please refer to the detailed documentation in the
@@ -43,6 +44,28 @@ SOFTWARE.
         <dd>
             A reference to the configuration node to be used.
         </dd>
+        <dt>Base Time</dt>
+        <dd>
+            The base time is used for comparison with the operands of the
+            conditions. This can be one of:
+            <ul>
+                <li>
+                    <i>message ingress</i>: Ingress time of the input message.
+                </li>
+                <li>
+                    <i>global.</i>: Timestamp from a global variable as number
+                    of milliseconds elapsed since the UNIX epoch.
+                </li>
+                <li>
+                    <i>flow.</i>: Timestamp from a flow variable as number of
+                    milliseconds elapsed since the UNIX epoch.
+                </li>
+                <li>
+                    <i>msg.</i>: Timestamp from a message property as number of
+                    milliseconds elapsed since the UNIX epoch.
+                </li>
+            </ul>
+        </dd>
         <dt>Conditions</dt>
         <dd>
             The list containing the conditions for routing messages to output
@@ -52,28 +75,28 @@ SOFTWARE.
             available:
             <ul>
                 <li>
-                    <i>before</i>: Checks if the message ingress time is before
-                    the specified time.
+                    <i>before</i>: Checks if the base time is earlier than the
+                    specified time.
                 </li>
                 <li>
-                    <i>after</i>: Checks if the message ingress time is at or
-                    after the specified time.
+                    <i>after</i>: Checks if the base time is equal to or later
+                    than the specified time.
                 </li>
                 <li>
-                    <i>between</i>: Checks if the message ingress time is at or
-                    between the two specified times.
+                    <i>between</i>: Checks if the base time is equal to or later
+                    than the first and earlier than the second specified time.
                 </li>
                 <li>
-                    <i>outside</i>: Checks if the message ingress time is before
-                    the first or after the second specified time.
+                    <i>outside</i>: Checks if the base time is earlier than the
+                    first or later than the second specified time.
                 </li>
                 <li>
-                    <i>week days</i>: Checks if the message ingress date is at
-                    one of the selected week days.
+                    <i>week days</i>: Checks if the base time matches one of
+                    the selected week days.
                 </li>
                 <li>
-                    <i>months</i>: Checks if the message ingress date is at one
-                    of the selected months.
+                    <i>months</i>: Checks if the base time matches one of the
+                    selected months.
                 </li>
                 <li>
                     <i>otherwise</i>: Evaluates to true if all other conditions
@@ -119,6 +142,6 @@ SOFTWARE.
     <h3>Outputs</h3>
     <p>
         Each output port is dedicated to a specific condition which is evaluated
-        against the message's ingress time and date.
+        against the base time.
     </p>
 </script>

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -31,6 +31,11 @@ SOFTWARE.
         <label for="node-input-config"><i class="fa fa-cog"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.config"></span></label>
         <input type="text" id="node-input-config" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.config">
     </div>
+    <div class="form-row">
+        <label for="node-input-baseTime"><i class="fa fa-clock-o"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.baseTime"></span></label>
+        <input type="text" id="node-input-baseTime" style="width: 70%;">
+        <input id="node-input-baseTimeType" type="hidden">
+    </div>
     <div class="form-row node-input-conditionList-row" style="padding-top: 10px">
         <label for="node-input-conditionList"><i class="fa fa-sliders"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.conditions"></span></label>
         <div class="form-row">
@@ -80,6 +85,15 @@ SOFTWARE.
                 type:     "chronos-config",
                 required: true
             },
+            baseTime:
+            {
+                value:    "",
+                validate: RED.validators.typedInput("baseTimeType")
+            },
+            baseTimeType:
+            {
+                value: "msgIngress"
+            },
             conditions:
             {
                 value: [{operator: "before", operands: {type: "time", value: "", offset: 0, random: false}, label: ""}],
@@ -101,6 +115,16 @@ SOFTWARE.
         oneditprepare: function()
         {
             let node = this;
+
+            const msgIngressInput =
+            {
+                value: "msgIngress",
+                label: node._("node-red-contrib-chronos/chronos-config:common.label.msgIngress"),
+                hasValue: false
+            };
+
+            let baseTime = $("#node-input-baseTime")
+                            .typedInput({types: [msgIngressInput, "global", "flow", "msg"], typeField: "#node-input-baseTimeType"});
 
             let conditionList = $("#node-input-conditionList").css("min-width", "510px").css("min-height", "150px").editableList(
             {

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -50,54 +50,69 @@ module.exports = function(RED)
             node.status({});
             time.init(RED, node.config.latitude, node.config.longitude, node.config.sunPositions);
 
+            node.baseTime = settings.baseTime;
+            node.baseTimeType = settings.baseTimeType;
             node.conditions = settings.conditions;
             node.stopOnFirstMatch = settings.stopOnFirstMatch;
 
-            let valid = true;
-            let otherwise = false;
-            for (let i=0; i<node.conditions.length; ++i)
+            // backward compatibility to v1.5.0
+            if (!node.baseTimeType)
             {
-                let cond = node.conditions[i];
-
-                // check for valid user time
-                if ((cond.operator == "before") || (cond.operator == "after"))
-                {
-                    if ((cond.operands.type == "time") && !time.isValidUserTime(cond.operands.value))
-                    {
-                        valid = false;
-                        break;
-                    }
-                }
-                else if ((cond.operator == "between") || (cond.operator == "outside"))
-                {
-                    if ((cond.operands[0].type == "time") && !time.isValidUserTime(cond.operands[0].value))
-                    {
-                        valid = false;
-                        break;
-                    }
-                    if ((cond.operands[1].type == "time") && !time.isValidUserTime(cond.operands[1].value))
-                    {
-                        valid = false;
-                        break;
-                    }
-                }
-                else if (cond.operator == "otherwise")
-                {
-                    // only one otherwise condition is allowed
-                    if (otherwise)
-                    {
-                        valid = false;
-                        break;
-                    }
-
-                    otherwise = true;
-                }
+                node.baseTimeType = "msgIngress";
             }
 
-            // otherwise condition must not be the only one
-            if ((node.conditions.length == 1) && otherwise)
+            let valid = true;
+            if ((node.baseTimeType != "msgIngress") && !node.baseTime)
             {
                 valid = false;
+            }
+            else
+            {
+                let otherwise = false;
+                for (let i=0; i<node.conditions.length; ++i)
+                {
+                    let cond = node.conditions[i];
+
+                    // check for valid user time
+                    if ((cond.operator == "before") || (cond.operator == "after"))
+                    {
+                        if ((cond.operands.type == "time") && !time.isValidUserTime(cond.operands.value))
+                        {
+                            valid = false;
+                            break;
+                        }
+                    }
+                    else if ((cond.operator == "between") || (cond.operator == "outside"))
+                    {
+                        if ((cond.operands[0].type == "time") && !time.isValidUserTime(cond.operands[0].value))
+                        {
+                            valid = false;
+                            break;
+                        }
+                        if ((cond.operands[1].type == "time") && !time.isValidUserTime(cond.operands[1].value))
+                        {
+                            valid = false;
+                            break;
+                        }
+                    }
+                    else if (cond.operator == "otherwise")
+                    {
+                        // only one otherwise condition is allowed
+                        if (otherwise)
+                        {
+                            valid = false;
+                            break;
+                        }
+
+                        otherwise = true;
+                    }
+                }
+
+                // otherwise condition must not be the only one
+                if ((node.conditions.length == 1) && otherwise)
+                {
+                    valid = false;
+                }
             }
 
             if (!valid)
@@ -129,147 +144,199 @@ module.exports = function(RED)
                             };
                         }
 
-                        let now = time.getCurrentTime();
-                        let ports = [];
-
-                        for (let i=0; i<node.conditions.length; ++i)
+                        let baseTime = getBaseTime(msg);
+                        if (baseTime)
                         {
-                            ports.push(null);
-                        }
+                            node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss"));
 
-                        let numMatches = 0;
-                        let otherwiseIndex = -1;
-                        for (let i=0; i<node.conditions.length; ++i)
-                        {
-                            try
-                            {
-                                let cond = node.conditions[i];
+                            let ports = [];
 
-                                if ((cond.operator == "before") || (cond.operator == "after"))
-                                {
-                                    let targetTime = time.getTime(now.clone(), cond.operands.type, cond.operands.value);
-
-                                    if (cond.operands.offset != 0)
-                                    {
-                                        let offset = cond.operands.random ? Math.round(Math.random() * cond.operands.offset) : cond.operands.offset;
-                                        targetTime.add(offset, "minutes");
-                                    }
-
-                                    node.debug("Check if " + cond.operator + " " + targetTime.format("YYYY-MM-DD HH:mm:ss"));
-                                    if (((cond.operator == "before") && now.isBefore(targetTime)) ||
-                                        ((cond.operator == "after") && now.isSameOrAfter(targetTime)))
-                                    {
-                                        ports[i] = true;
-                                        numMatches++;
-                                    }
-                                }
-                                else if ((cond.operator == "between") || (cond.operator == "outside"))
-                                {
-                                    let time1 = time.getTime(now.clone(), cond.operands[0].type, cond.operands[0].value);
-                                    let time2 = time.getTime(now.clone(), cond.operands[1].type, cond.operands[1].value);
-
-                                    if (cond.operands[0].offset != 0)
-                                    {
-                                        let offset = cond.operands[0].random ? Math.round(Math.random() * cond.operands[0].offset) : cond.operands[0].offset;
-                                        time1.add(offset, "minutes");
-                                    }
-                                    if (cond.operands[1].offset != 0)
-                                    {
-                                        let offset = cond.operands[1].random ? Math.round(Math.random() * cond.operands[1].offset) : cond.operands[1].offset;
-                                        time2.add(offset, "minutes");
-                                    }
-
-                                    if (time2.isSameOrBefore(time1))
-                                    {
-                                        if (cond.operands[1].type == "time")
-                                        {
-                                            time2.add(1, "days");
-                                        }
-                                        else
-                                        {
-                                            time2 = time.getTime(time2.add(1, "day"), cond.operands[1].type, cond.operands[1].value);
-                                        }
-                                    }
-
-                                    node.debug("Check if " + cond.operator + " " + time1.format("YYYY-MM-DD HH:mm:ss") + " and " + time2.format("YYYY-MM-DD HH:mm:ss"));
-                                    if (((cond.operator == "between") && (now.isSameOrAfter(time1) && now.isSameOrBefore(time2))) ||
-                                        ((cond.operator == "outside") && (now.isBefore(time1) || now.isAfter(time2))))
-                                    {
-                                        ports[i] = true;
-                                        numMatches++;
-                                    }
-                                }
-                                else if ((cond.operator == "weekdays"))
-                                {
-                                    if (cond.operands[now.day()])
-                                    {
-                                        ports[i] = true;
-                                        numMatches++;
-                                    }
-                                }
-                                else if ((cond.operator == "months"))
-                                {
-                                    if (cond.operands[now.month()])
-                                    {
-                                        ports[i] = true;
-                                        numMatches++;
-                                    }
-                                }
-                                else if (cond.operator == "otherwise")
-                                {
-                                    otherwiseIndex = i;
-                                }
-
-                                if (ports[i] && node.stopOnFirstMatch)
-                                {
-                                    break;
-                                }
-                            }
-                            catch (e)
-                            {
-                                if (e instanceof time.TimeError)
-                                {
-                                    let errMsg = RED.util.cloneMessage(msg);
-
-                                    if ("errorDetails" in errMsg)
-                                    {
-                                        errMsg._errorDetails = errMsg.errorDetails;
-                                    }
-                                    errMsg.errorDetails = e.details;
-
-                                    node.error(e.message, errMsg);
-                                }
-                                else
-                                {
-                                    node.error(e.message);
-                                    node.debug(e.stack);
-                                }
-                            }
-                        }
-
-                        if ((numMatches == 0) && (otherwiseIndex >= 0))
-                        {
-                            ports[otherwiseIndex] = msg;
-                        }
-                        else if (numMatches > 0)
-                        {
-                            let firstPort = true;
                             for (let i=0; i<node.conditions.length; ++i)
                             {
-                                if (ports[i])
+                                ports.push(null);
+                            }
+
+                            let numMatches = 0;
+                            let otherwiseIndex = -1;
+                            for (let i=0; i<node.conditions.length; ++i)
+                            {
+                                try
                                 {
-                                    ports[i] = firstPort ? msg : RED.util.cloneMessage(msg);
-                                    firstPort = false;
+                                    let cond = node.conditions[i];
+
+                                    if ((cond.operator == "before") || (cond.operator == "after"))
+                                    {
+                                        let targetTime = time.getTime(baseTime.clone(), cond.operands.type, cond.operands.value);
+
+                                        if (cond.operands.offset != 0)
+                                        {
+                                            let offset = cond.operands.random ? Math.round(Math.random() * cond.operands.offset) : cond.operands.offset;
+                                            targetTime.add(offset, "minutes");
+                                        }
+
+                                        node.debug("Check if " + cond.operator + " " + targetTime.format("YYYY-MM-DD HH:mm:ss"));
+                                        if (((cond.operator == "before") && baseTime.isBefore(targetTime)) ||
+                                            ((cond.operator == "after") && baseTime.isSameOrAfter(targetTime)))
+                                        {
+                                            ports[i] = true;
+                                            numMatches++;
+                                        }
+                                    }
+                                    else if ((cond.operator == "between") || (cond.operator == "outside"))
+                                    {
+                                        let time1 = time.getTime(baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
+                                        let time2 = time.getTime(baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
+
+                                        if (cond.operands[0].offset != 0)
+                                        {
+                                            let offset = cond.operands[0].random ? Math.round(Math.random() * cond.operands[0].offset) : cond.operands[0].offset;
+                                            time1.add(offset, "minutes");
+                                        }
+                                        if (cond.operands[1].offset != 0)
+                                        {
+                                            let offset = cond.operands[1].random ? Math.round(Math.random() * cond.operands[1].offset) : cond.operands[1].offset;
+                                            time2.add(offset, "minutes");
+                                        }
+
+                                        if (time2.isSameOrBefore(time1))
+                                        {
+                                            if (cond.operands[1].type == "time")
+                                            {
+                                                time2.add(1, "days");
+                                            }
+                                            else
+                                            {
+                                                time2 = time.getTime(time2.add(1, "day"), cond.operands[1].type, cond.operands[1].value);
+                                            }
+                                        }
+
+                                        node.debug("Check if " + cond.operator + " " + time1.format("YYYY-MM-DD HH:mm:ss") + " and " + time2.format("YYYY-MM-DD HH:mm:ss"));
+                                        if (((cond.operator == "between") && (baseTime.isSameOrAfter(time1) && baseTime.isSameOrBefore(time2))) ||
+                                            ((cond.operator == "outside") && (baseTime.isBefore(time1) || baseTime.isAfter(time2))))
+                                        {
+                                            ports[i] = true;
+                                            numMatches++;
+                                        }
+                                    }
+                                    else if ((cond.operator == "weekdays"))
+                                    {
+                                        if (cond.operands[baseTime.day()])
+                                        {
+                                            ports[i] = true;
+                                            numMatches++;
+                                        }
+                                    }
+                                    else if ((cond.operator == "months"))
+                                    {
+                                        if (cond.operands[baseTime.month()])
+                                        {
+                                            ports[i] = true;
+                                            numMatches++;
+                                        }
+                                    }
+                                    else if (cond.operator == "otherwise")
+                                    {
+                                        otherwiseIndex = i;
+                                    }
+
+                                    if (ports[i] && node.stopOnFirstMatch)
+                                    {
+                                        break;
+                                    }
+                                }
+                                catch (e)
+                                {
+                                    if (e instanceof time.TimeError)
+                                    {
+                                        let errMsg = RED.util.cloneMessage(msg);
+
+                                        if ("errorDetails" in errMsg)
+                                        {
+                                            errMsg._errorDetails = errMsg.errorDetails;
+                                        }
+                                        errMsg.errorDetails = e.details;
+
+                                        node.error(e.message, errMsg);
+                                    }
+                                    else
+                                    {
+                                        node.error(e.message);
+                                        node.debug(e.stack);
+                                    }
                                 }
                             }
-                        }
 
-                        node.send(ports);
+                            if ((numMatches == 0) && (otherwiseIndex >= 0))
+                            {
+                                ports[otherwiseIndex] = msg;
+                            }
+                            else if (numMatches > 0)
+                            {
+                                let firstPort = true;
+                                for (let i=0; i<node.conditions.length; ++i)
+                                {
+                                    if (ports[i])
+                                    {
+                                        ports[i] = firstPort ? msg : RED.util.cloneMessage(msg);
+                                        firstPort = false;
+                                    }
+                                }
+                            }
+
+                            node.send(ports);
+                        }
+                        else
+                        {
+                            let variable = node.baseTime;
+                            if ((node.baseTimeType == "global") || (node.baseTimeType == "flow"))
+                            {
+                                let ctx = RED.util.parseContextStore(node.baseTime);
+                                variable = ctx.key + (ctx.store ? " (" + ctx.store + ")" : "");
+                            }
+
+                            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidBaseTime", {baseTime: node.baseTimeType + "." + variable}), msg);
+                        }
                     }
 
                     done();
                 });
             }
+        }
+
+        function getBaseTime(msg)
+        {
+            let ret = null;
+
+            if (node.baseTimeType == "msgIngress")
+            {
+                ret = time.getCurrentTime();
+            }
+            else
+            {
+                let value = null;
+                switch (node.baseTimeType)
+                {
+                    case "global":
+                    case "flow":
+                    {
+                        let ctx = RED.util.parseContextStore(node.baseTime);
+                        value = node.context()[node.baseTimeType].get(ctx.key, ctx.store);
+                        break;
+                    }
+                    case "msg":
+                    {
+                        value = msg[node.baseTime];
+                        break;
+                    }
+                }
+
+                if (typeof value == "number")
+                {
+                    ret = time.getTimeFrom(value);
+                }
+            }
+
+            return ret ? (ret.isValid() ? ret : null) : null;
         }
     }
 


### PR DESCRIPTION
This change introduces the possibility to select different base times for switch and filter nodes. The base time can be either the message ingress time (as before) or a custom timestamp from a message property, a global variable or a flow variable. The timestamp must be a number containing the milliseconds since the UNIX epoch.