### PR TITLE
Enhanced input messages with control commands for scheduler node

### DIFF
--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -127,9 +127,9 @@ SOFTWARE.
     <h3>Eingabe</h3>
     <dt>Zeitplan aktivieren/deaktivieren</dt>
     <dd>
-        Eine Eingangsnachricht kann dazu verwendet werden, um den Zeitplan
-        oder einzelne Zeitereignisse zu aktivieren oder zu deaktivieren.
-        Das Aktivieren des Zeitplans führt auch dazu, dass programmierte
+        Um den Zeitplan oder einzelne Zeitereignisse zu aktivieren oder zu
+        deaktivieren, muss eine Nachricht an den Scheduler-Knoten geschickt
+        werden. Das Aktivieren des Zeitplans führt auch dazu, dass programmierte
         Zeitereignisse aus Kontextvariablen neu eingelesen werden.
     </dd>
     <dl class="message-properties">
@@ -143,6 +143,55 @@ SOFTWARE.
         boolescher Wert sein und ist dem Zeitereignis mit dem selben Index
         zugeordnet. Wenn der Wert wahr ist, wird das zugehörige Zeitereignis
         aktiviert, ansonsten deaktiviert.
+    </dd>
+    <dt>Scheduler-Knoten steuern</dt>
+    <dd>
+        Der Scheduler-Knoten kann auf verschiedene Weise dynamisch gesteuert
+        werden, indem eine Nachricht an den Knoten geschickt wird.
+    </dd>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">string | array</span></dt>
+        <dd>Steuert den Knoten abhängig von den angegebenen Kommandos</dd>
+    </dl>
+    <dd>
+        Wenn <code>msg.payload</code> eine Zeichenkette ist, wirkt sich das
+        angegebene Kommando auf den kompletten Zeitplan aus. Ist
+        <code>msg.payload</code> dagegen ein Array, muss jedes Element eine
+        Zeichenkette sein und ist dem Zeitereignis mit dem selben Index
+        zugeordnet. Das Kommando wirkt sich dann nur auf dieses Zeitereignis
+        aus.
+    </dd>
+    <dd>
+        Tipp: Es ist möglich, boolsche Werte und Zeichenketten in dem Array zu
+        mischen. Somit können mithilfe einer einzigen Nachricht einige
+        Zeitereignisse aktiviert oder deaktiviert und andere mit einem Kommando
+        gesteuert werden. Weiterhin ist es möglich, einzelne Array-Elemente auf
+        <code>null</code> zu setzen, um die dazugehörigen Zeitereignis zu
+        ignorieren.
+    </dd>
+    <dd>
+        Folgende Kommandos werden zurzeit unterstützt:
+        <ul>
+            <li>
+                <code>toggle</code>: Schaltet den Aktivierungszustand um (d.h.,
+                aktivierte Zeitereignisse werden deaktiviert und umgekehrt).
+            </li>
+            <li>
+                <code>reload</code>: Führt zu einer Neuberechnung von aktivierten
+                Zeitereignissen (programmierte Daten aus Kontextvariablen werden
+                ebenfalls erneut geladen).
+            </li>
+            <li>
+                <code>trigger</code>: Löst aktivierte Zeitereignisse aus, d.h.,
+                die Ausgabekonfiguration des Zeitereignisses wird angewendet, so
+                als wäre der geplante Zeitpunkt erreicht. Der reguläre Zeitpunkt
+                des Ereignisses wird dabei nicht verändert.
+            </li>
+            <li>
+                <code>trigger:force</code>: Wie oben, allerdings werden alle
+                Zeitereignisse ausgelöst, nicht nur aktivierte.
+            </li>
+        </ul>
     </dd>
     <dt>Zeitplan dynamisch programmieren</dt>
     <dd>

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -119,9 +119,9 @@ SOFTWARE.
     <h3>Input</h3>
     <dt>Enable/disable schedule</dt>
     <dd>
-        The input message can be used to either disable or re-enable the schedule
-        or parts of it. Enabling the schedule will also reload any programmed
-        schedule events from context variables.
+        To either disable or re-enable the schedule or parts of it, a message
+        must be sent to the node. Enabling the schedule will also reload any
+        programmed schedule events from context variables.
     </dd>
     <dl class="message-properties">
         <dt>payload<span class="property-type">boolean | array</span></dt>
@@ -133,6 +133,50 @@ SOFTWARE.
         each element must be a boolean value and corresponds to the event in the
         schedule at the same index. If the value is true, the matching event is
         enabled, otherwise it is disabled.
+    </dd>
+    <dt>Control scheduler node</dt>
+    <dd>
+        The scheduler node can be dynamically controlled in various ways using
+        an input message.
+    </dd>
+    <dl class="message-properties">
+        <dt>payload<span class="property-type">string | array</span></dt>
+        <dd>Controls the node depending on the passed command(s)</dd>
+    </dl>
+    <dd>
+        If <code>msg.payload</code> is a string value, the passed command
+        affects the whole schedule. If <code>msg.payload</code> is an array,
+        each element must be a string value and corresponds to the event in the
+        schedule at the same index affecting only this one.
+    </dd>
+    <dd>
+        Hint: You can also mix boolean values and string values in the array
+        in order to enable/disable certain events and apply control commands
+        to other events at the same time. It is also possible to set single
+        elements in the array to <code>null</code> in order to ignore the
+        corresponding events.
+    </dd>
+    <dd>
+        The following commands are currently supported:
+        <ul>
+            <li>
+                <code>toggle</code>: Toggles the activation state (i.e., enabled
+                events become disabled and vice versa).
+            </li>
+            <li>
+                <code>reload</code>: Forces enabled events to be recalculated
+                (also reloads programmed data from context variables).
+            </li>
+            <li>
+                <code>trigger</code>: Triggers enabled events, i.e., the output
+                is applied as if the scheduled time has been reached. This does
+                not change the regular schedule time.
+            </li>
+            <li>
+                <code>trigger:force</code>: Same as above, but triggers all events,
+                not just enabled ones.
+            </li>
+        </ul>
     </dd>
     <dt>Dynamically program schedule</dt>
     <dd>

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -279,15 +279,15 @@ module.exports = function(RED)
                                 {
                                     toggleTimer(node.schedule[i]);
                                 }
-                                else if (msg.payload == "reload")
+                                else if (msg.payload[i] == "reload")
                                 {
                                     reloadTimer(node.schedule[i]);
                                 }
-                                else if (msg.payload == "trigger")
+                                else if (msg.payload[i] == "trigger")
                                 {
                                     triggerEvent(node.schedule[i], false);
                                 }
-                                else if (msg.payload == "trigger:forced")
+                                else if (msg.payload[i] == "trigger:forced")
                                 {
                                     triggerEvent(node.schedule[i], true);
                                 }

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -298,7 +298,7 @@ describe("chronos", function()
                     .onFirstCall()
                     .returns({"sunrise": new Date("2000-01-01T08:00:00.000Z")})
                     .onSecondCall()
-                    .returns({"sunrise": "invalid"});
+                    .returns({"sunrise": [2010, 12]});
 
             (() => chronos.getTime(RED, node, moment(), "sun", "invalid")).should.throw(chronos.TimeError);
             (() => chronos.getTime(RED, node, moment(), "sun", "sunrise")).should.throw(chronos.TimeError);
@@ -336,7 +336,7 @@ describe("chronos", function()
                     .onFirstCall()
                     .returns({"rise": new Date("2000-01-01T22:00:00.000Z")})
                     .onSecondCall()
-                    .returns({"rise": "invalid"});
+                    .returns({"rise": [2010, 12]});
 
             (() => chronos.getTime(RED, node, moment(), "moon", "invalid")).should.throw(chronos.TimeError);
             (() => chronos.getTime(RED, node, moment(), "moon", "rise")).should.throw(chronos.TimeError);

--- a/test/scheduler_spec.js
+++ b/test/scheduler_spec.js
@@ -551,226 +551,224 @@ describe("scheduler node", function()
             sinon.restore();
         });
 
-        it("should switch on schedule", function(done)
+        it("should switch on schedule", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
 
-            helper.load([configNode, schedulerNode], flow, credentials, function()
-            {
-                try
-                {
-                    const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "setTimeout");
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
 
-                    sn1.on("input", function()
-                    {
-                        try
-                        {
-                            sn1.disabledSchedule.should.be.false();
-                            clock.setTimeout.should.be.calledOnce();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
-                    });
-
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.true();
-                    sn1.receive({payload: true});
-                }
-                catch (e)
-                {
-                    done(e);
-                }
-            });
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: true});
+            sn1.disabledSchedule.should.be.false();
+            clock.setTimeout.should.be.calledOnce();
         });
 
-        it("should switch off schedule", function(done)
+        it("should switch off schedule", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
 
-            helper.load([configNode, schedulerNode], flow, credentials, function()
-            {
-                try
-                {
-                    const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "clearTimeout");
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "clearTimeout");
 
-                    sn1.on("input", function()
-                    {
-                        try
-                        {
-                            sn1.disabledSchedule.should.be.true();
-                            clock.clearTimeout.should.be.calledOnce();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
-                    });
-
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.false();
-                    sn1.receive({payload: false});
-                }
-                catch (e)
-                {
-                    done(e);
-                }
-            });
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: false});
+            sn1.disabledSchedule.should.be.true();
+            clock.clearTimeout.should.be.calledOnce();
         });
 
-        it("should switch on schedule partly", function(done)
+        it("should switch on schedule partly", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
 
-            helper.load([configNode, schedulerNode], flow, credentials, function()
-            {
-                try
-                {
-                    const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "setTimeout");
+            await helper.load([configNode, schedulerNode], flow, credentials)
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
 
-                    sn1.on("input", function()
-                    {
-                        try
-                        {
-                            sn1.disabledSchedule.should.be.false();
-                            clock.setTimeout.should.be.calledOnce();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
-                    });
-
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.true();
-                    sn1.receive({payload: [false, true]});
-                }
-                catch (e)
-                {
-                    done(e);
-                }
-            });
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: [false, true]});
+            sn1.disabledSchedule.should.be.false();
+            clock.setTimeout.should.be.calledOnce();
         });
 
-        it("should switch on schedule fully", function(done)
+        it("should switch on schedule fully", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
 
-            helper.load([configNode, schedulerNode], flow, credentials, function()
-            {
-                try
-                {
-                    const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "setTimeout");
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
 
-                    sn1.on("input", function()
-                    {
-                        try
-                        {
-                            sn1.disabledSchedule.should.be.false();
-                            clock.setTimeout.should.be.calledTwice();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
-                    });
-
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.true();
-                    sn1.receive({payload: [true, true]});
-                }
-                catch (e)
-                {
-                    done(e);
-                }
-            });
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: [true, true]});
+            sn1.disabledSchedule.should.be.false();
+            clock.setTimeout.should.be.calledTwice();
         });
 
-        it("should switch off schedule partly", function(done)
+        it("should switch off schedule partly", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
 
-            helper.load([configNode, schedulerNode], flow, credentials, function()
-            {
-                try
-                {
-                    const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "clearTimeout");
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "clearTimeout");
 
-                    sn1.on("input", function()
-                    {
-                        try
-                        {
-                            sn1.disabledSchedule.should.be.false();
-                            clock.clearTimeout.should.be.calledTwice();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
-                    });
-
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.false();
-                    sn1.receive({payload: [false, true]});
-                }
-                catch (e)
-                {
-                    done(e);
-                }
-            });
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: [false, true]});
+            sn1.disabledSchedule.should.be.false();
+            clock.clearTimeout.should.be.calledTwice();
         });
 
-        it("should switch off schedule fully", function(done)
+        it("should switch off schedule fully", async function()
         {
             const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
 
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: [false, false]});
+            sn1.disabledSchedule.should.be.true();
+            clock.clearTimeout.should.be.calledTwice();
+        });
+
+        it("should toggle schedule (to on)", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: "toggle"});
+            sn1.disabledSchedule.should.be.true();
+            clock.clearTimeout.should.be.calledTwice();
+        });
+
+        it("should toggle schedule (to off)", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: "toggle"});
+            sn1.disabledSchedule.should.be.false();
+            clock.setTimeout.should.be.calledTwice();
+        });
+
+        it("should toggle schedule event (to off)", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: ["toggle", null]});
+            sn1.disabledSchedule.should.be.false();
+            clock.clearTimeout.should.be.calledOnce();
+        });
+
+        it("should toggle schedule event (to on)", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: [null, "toggle"]});
+            sn1.disabledSchedule.should.be.false();
+            clock.setTimeout.should.be.calledOnce();
+        });
+
+        it("should reload schedule", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: "reload"});
+            sn1.disabledSchedule.should.be.false();
+            clock.clearTimeout.should.be.calledTwice();
+            clock.setTimeout.should.be.calledTwice();
+        });
+
+        it("should not reload schedule", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.true();
+            sn1.receive({payload: "reload"});
+            sn1.disabledSchedule.should.be.true();
+            clock.clearTimeout.should.not.be.called();
+            clock.setTimeout.should.not.be.called();
+        });
+
+        it("should reload schedule event", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.disabledSchedule.should.be.false();
+            sn1.receive({payload: ["reload", null]});
+            sn1.disabledSchedule.should.be.false();
+            clock.clearTimeout.should.be.calledOnce();
+            clock.setTimeout.should.be.calledOnce();
+        });
+
+        it("should trigger schedule", function(done)
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], outputs: 1}, hlpNode, cfgNode];
+
             helper.load([configNode, schedulerNode], flow, credentials, function()
             {
                 try
                 {
                     const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "clearTimeout");
+                    const hn1 = helper.getNode("hn1");
+                    let count = 0;
 
-                    sn1.on("input", function()
+                    hn1.on("input", function(msg)
                     {
                         try
                         {
-                            sn1.disabledSchedule.should.be.true();
-                            clock.clearTimeout.should.be.calledTwice();
-                            done();
+                            count++;
+                            msg.should.have.property("payload", "test" + count);
+                            if (count == 2)
+                            {
+                                done();
+                            }
                         }
-                        catch(e)
+                        catch (e)
                         {
                             done(e);
                         }
                     });
 
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.disabledSchedule.should.be.false();
-                    sn1.receive({payload: [false, false]});
+                    sn1.receive({payload: "trigger"});
                 }
                 catch (e)
                 {
@@ -779,42 +777,192 @@ describe("scheduler node", function()
             });
         });
 
-        it("should handle invalid input message", function(done)
+        it("should not trigger disabled schedule", function(done)
         {
-            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], disabled: true, outputs: 1}, hlpNode, cfgNode];
 
             helper.load([configNode, schedulerNode], flow, credentials, function()
             {
                 try
                 {
                     const sn1 = helper.getNode("sn1");
-                    sinon.spy(clock, "setTimeout");
-                    sinon.spy(clock, "clearTimeout");
+                    const hn1 = helper.getNode("hn1");
 
-                    sn1.on("input", function()
+                    hn1.on("input", function(msg)
                     {
-                        try
-                        {
-                            clock.setTimeout.should.not.be.called();
-                            clock.clearTimeout.should.not.be.called();
-                            done();
-                        }
-                        catch(e)
-                        {
-                            done(e);
-                        }
+                        done("unexpected message received");
                     });
 
-                    // workaround: add dummy listener, otherwise listener above is not called
-                    sn1.on("input", function() {});
-
-                    sn1.receive({payload: "invalid"});
+                    sn1.receive({payload: "trigger"});
+                    done();
                 }
                 catch (e)
                 {
                     done(e);
                 }
             });
+        });
+
+        it("should force trigger disabled schedule", function(done)
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], disabled: true, outputs: 1}, hlpNode, cfgNode];
+
+            helper.load([configNode, schedulerNode], flow, credentials, function()
+            {
+                try
+                {
+                    const sn1 = helper.getNode("sn1");
+                    const hn1 = helper.getNode("hn1");
+                    let count = 0;
+
+                    hn1.on("input", function(msg)
+                    {
+                        try
+                        {
+                            count++;
+                            msg.should.have.property("payload", "test" + count);
+                            if (count == 2)
+                            {
+                                done();
+                            }
+                        }
+                        catch (e)
+                        {
+                            done(e);
+                        }
+                    });
+
+                    sn1.receive({payload: "trigger:forced"});
+                }
+                catch (e)
+                {
+                    done(e);
+                }
+            });
+        });
+
+        it("should trigger schedule event", function(done)
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], outputs: 1}, hlpNode, cfgNode];
+
+            helper.load([configNode, schedulerNode], flow, credentials, function()
+            {
+                try
+                {
+                    const sn1 = helper.getNode("sn1");
+                    const hn1 = helper.getNode("hn1");
+                    let count = 0;
+
+                    hn1.on("input", function(msg)
+                    {
+                        try
+                        {
+                            count++;
+                            if (count == 1)
+                            {
+                                msg.should.have.property("payload", "test1");
+                            }
+                            else if (count > 1)
+                            {
+                                done("unexpected message received");
+                            }
+                        }
+                        catch (e)
+                        {
+                            done(e);
+                        }
+                    });
+
+                    sn1.receive({payload: ["trigger", null]});
+                    done();
+                }
+                catch (e)
+                {
+                    done(e);
+                }
+            });
+        });
+
+        it("should not trigger disabled schedule events", function(done)
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], disabled: true, outputs: 1}, hlpNode, cfgNode];
+
+            helper.load([configNode, schedulerNode], flow, credentials, function()
+            {
+                try
+                {
+                    const sn1 = helper.getNode("sn1");
+                    const hn1 = helper.getNode("hn1");
+
+                    hn1.on("input", function(msg)
+                    {
+                        done("unexpected message received");
+                    });
+
+                    sn1.receive({payload: ["trigger", null]});
+                    done();
+                }
+                catch (e)
+                {
+                    done(e);
+                }
+            });
+        });
+
+        it("should force trigger disabled schedule event", function(done)
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", wires: [["hn1"]], schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test1"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test2"}}}], disabled: true, outputs: 1}, hlpNode, cfgNode];
+
+            helper.load([configNode, schedulerNode], flow, credentials, function()
+            {
+                try
+                {
+                    const sn1 = helper.getNode("sn1");
+                    const hn1 = helper.getNode("hn1");
+                    let count = 0;
+
+                    hn1.on("input", function(msg)
+                    {
+                        try
+                        {
+                            count++;
+                            if (count == 1)
+                            {
+                                msg.should.have.property("payload", "test1");
+                            }
+                            else if (count > 1)
+                            {
+                                done("unexpected message received");
+                            }
+                        }
+                        catch (e)
+                        {
+                            done(e);
+                        }
+                    });
+
+                    sn1.receive({payload: ["trigger:forced", null]});
+                    done();
+                }
+                catch (e)
+                {
+                    done(e);
+                }
+            });
+        });
+
+        it("should handle invalid input message", async function()
+        {
+            const flow = [{id: "sn1", type: "chronos-scheduler", name: "scheduler", config: "cn1", schedule: [{trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}, {trigger: {type: "time", value: "00:01", offset: 0, random: false}, output: {type: "msg", property: {name: "payload", type: "string", value: "test"}}}], disabled: true, outputs: 1}, cfgNode];
+
+            await helper.load([configNode, schedulerNode], flow, credentials);
+            const sn1 = helper.getNode("sn1");
+            sinon.spy(clock, "setTimeout");
+            sinon.spy(clock, "clearTimeout");
+
+            sn1.receive({payload: null});
+            clock.setTimeout.should.not.be.called();
+            clock.clearTimeout.should.not.be.called();
         });
     });
 });


### PR DESCRIPTION
This change adds support for control commands in input messages of scheduler nodes to:
- toggle activation state of complete schedule or single schedule events
- reload context variables and recalculate trigger time for complete schedule or single schedule events
- explicitly trigger output of complete schedule or single schedule events