### PR TITLE
Support for JSONata based switch/filter conditions

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -227,6 +227,38 @@ function getTime(RED, node, day, type, value)
     }
 }
 
+function applyOffset(time, offset, random)
+{
+    if (offset)
+    {
+        time.add(random ? Math.round(Math.random() * offset) : offset, "minutes");
+    }
+
+    return time;
+}
+
+function getJSONataExpression(RED, node, expr)
+{
+    const expression = RED.util.prepareJSONataExpression(expr, node);
+
+    expression.registerFunction("millisecond", ts => { return moment(ts).millisecond(); }, "<(sn):n>");
+    expression.registerFunction("second", ts => { return moment(ts).second(); }, "<(sn):n>");
+    expression.registerFunction("minute", ts => { return moment(ts).minute(); }, "<(sn):n>");
+    expression.registerFunction("hour", ts => { return moment(ts).hour(); }, "<(sn):n>");
+    expression.registerFunction("day", ts => { return moment(ts).date(); }, "<(sn):n>");
+    expression.registerFunction("dayOfWeek", ts => { return moment(ts).weekday() + 1; }, "<(sn):n>");
+    expression.registerFunction("dayOfYear", ts => { return moment(ts).dayOfYear(); }, "<(sn):n>");
+    expression.registerFunction("week", ts => { return moment(ts).week(); }, "<(sn):n>");
+    expression.registerFunction("month", ts => { return moment(ts).month() + 1; }, "<(sn):n>");
+    expression.registerFunction("quarter", ts => { return moment(ts).quarter(); }, "<(sn):n>");
+    expression.registerFunction("year", ts => { return moment(ts).year(); }, "<(sn):n>");
+    expression.registerFunction("time", (ts, time, offset, random) => { return applyOffset(getTime(RED, node, moment(ts), "time", time), offset, random).valueOf(); }, "<(sn)(sn)n?b?:n>");
+    expression.registerFunction("sunTime", (ts, pos, offset, random) => { return applyOffset(getTime(RED, node, moment(ts), "sun", pos), offset, random).valueOf(); }, "<(sn)sn?b?:n>");
+    expression.registerFunction("moonTime", (ts, pos, offset, random) => { return applyOffset(getTime(RED, node, moment(ts), "moon", pos), offset, random).valueOf(); }, "<(sn)sn?b?:n>");
+
+    return expression;
+}
+
 
 module.exports =
 {
@@ -240,5 +272,6 @@ module.exports =
     getUserDate: getUserDate,
     isValidUserTime: isValidUserTime,
     isValidUserDate: isValidUserDate,
+    getJSONataExpression: getJSONataExpression,
     TimeError: TimeError
 };

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -54,74 +54,69 @@ function validateCondition(node, cond)
     return true;
 }
 
-function convertCondition(node, cond)
+function convertCondition(RED, node, cond, num)
 {
     if ((typeof cond != "object") || !cond)
     {
-        return null;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Condition: Not an object or null"});
     }
 
     if (!/^(before|after|between|outside|days|weekdays|months|otherwise)$/.test(cond.operator))
     {
-        return null;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operator: Invalid value", value: cond.operator});
     }
 
     if ((cond.operator == "before") || (cond.operator == "after"))
     {
-        if (!validateOperand(node, cond.operands))
-        {
-            return null;
-        }
+        validateOperand(RED, node, cond.operands, num);
     }
 
     if ((cond.operator == "between") || (cond.operator == "outside"))
     {
         if (!cond.operands || !Array.isArray(cond.operands) || (cond.operands.length != 2))
         {
-            return null;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Not an array, invalid number of elements or null"});
         }
 
-        if (!validateOperand(node, cond.operands[0]) || !validateOperand(node, cond.operands[1]))
-        {
-            return null;
-        }
+        validateOperand(RED, node, cond.operands[0], num);
+        validateOperand(RED, node, cond.operands[1], num);
     }
 
     if (cond.operator == "days")
     {
         if ((typeof cond.operands != "object") || !cond.operands)
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Not an object or null"});
         }
 
         if (!/^(first|second|third|fourth|fifth|last|even|specific)$/.test(cond.operands.type))
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid type", value: cond.operands.type});
         }
 
         if (((cond.operands.type == "first") || (cond.operands.type == "last")) &&
             !/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday|day|workday|weekend)$/.test(cond.operands.day))
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid day", value: cond.operands.day});
         }
 
         if (((cond.operands.type == "second") || (cond.operands.type == "third") || (cond.operands.type == "fourth") || (cond.operands.type == "fifth")) &&
-            !/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday)$/.test(cond.operands.day))
+            !/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday|day)$/.test(cond.operands.day))
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid day", value: cond.operands.day});
         }
 
         if ((cond.operands.type == "specific") &&
             ((typeof cond.operands.day != "number") || (cond.operands.day < 1) || (cond.operands.day > 31) ||
-             ((typeof cond.operands.month != "undefined") &&
+             ((typeof cond.operands.month != "undefined") && (typeof cond.operands.month != "number") &&
               !/^(january|february|march|april|may|june|july|august|september|october|november|december)$/.test(cond.operands.month))))
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid day or month"});
         }
 
         if (typeof cond.operands.exclude != "boolean")
         {
-            return false;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid exclude", value: cond.operands.exclude});
         }
     }
 
@@ -129,7 +124,7 @@ function convertCondition(node, cond)
     {
         if ((typeof cond.operands != "object") || !cond.operands)
         {
-            return null;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Not an object or null"});
         }
 
         if ((("sunday" in cond.operands) && (typeof cond.operands.sunday != "boolean")) ||
@@ -140,7 +135,7 @@ function convertCondition(node, cond)
             (("friday" in cond.operands) && (typeof cond.operands.friday != "boolean")) ||
             (("saturday" in cond.operands) && (typeof cond.operands.saturday != "boolean")))
         {
-            return null;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid weekday property", value: cond.operands});
         }
     }
 
@@ -148,7 +143,7 @@ function convertCondition(node, cond)
     {
         if ((typeof cond.operands != "object") || !cond.operands)
         {
-            return null;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Not an object or null"});
         }
 
         if ((("january" in cond.operands) && (typeof cond.operands.january != "boolean")) ||
@@ -164,7 +159,7 @@ function convertCondition(node, cond)
             (("november" in cond.operands) && (typeof cond.operands.november != "boolean")) ||
             (("december" in cond.operands) && (typeof cond.operands.december != "boolean")))
         {
-            return null;
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid month property", value: cond.operands});
         }
     }
 
@@ -224,16 +219,16 @@ function convertCondition(node, cond)
     return convCond;
 }
 
-function validateOperand(node, operand)
+function validateOperand(RED, node, operand, num)
 {
     if ((typeof operand != "object") || !operand)
     {
-        return false;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Not an object or null"});
     }
 
     if (!/^(time|sun|moon|custom)$/.test(operand.type))
     {
-        return false;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid type", value: operand.type});
     }
 
     if ((typeof operand.value != "string") ||
@@ -241,23 +236,21 @@ function validateOperand(node, operand)
         ((operand.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(operand.value)) ||
         ((operand.type == "moon") && !/^(rise|set)$/.test(operand.value)))
     {
-        return false;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid value", value: operand.value});
     }
 
     if ((typeof operand.offset != "number") || (operand.offset < -300) || (operand.offset > 300))
     {
-        return false;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid offset", value: operand.offset});
     }
 
     if (typeof operand.random != "boolean")
     {
-        return false;
+        throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"), {condition: num, error: "Operand: Invalid random flag", value: operand.random});
     }
-
-    return true;
 }
 
-function evaluateCondition(RED, node, baseTime, cond, id)
+function evaluateCondition(RED, node, msg, baseTime, cond, id)
 {
     let result = false;
 
@@ -266,13 +259,154 @@ function evaluateCondition(RED, node, baseTime, cond, id)
         let ctx = RED.util.parseContextStore(cond.context.value);
         node.debug("[Condition:" + id + "] Load from context variable " + cond.context.type + "." + ctx.key + (ctx.store ? " (" + ctx.store + ")" : ""));
 
-        let ctxCond = convertCondition(node, node.context()[cond.context.type].get(ctx.key, ctx.store));
-        if (!ctxCond)
+        result = evaluateCondition(RED, node, msg, baseTime, convertCondition(RED, node, node.context()[cond.context.type].get(ctx.key, ctx.store), id), id);
+    }
+    else if (cond.operator == "expression")
+    {
+        let expression = null;
+
+        try
         {
-            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition", {condition: cond.context.type + "." + ctx.key + (ctx.store ? " (" + ctx.store + ")" : "")}), null);
+            expression = node.chronos.getJSONataExpression(RED, node, cond.expression);
+
+            // time switch/filter node specific JSONata extensions
+            expression.assign("baseTime", baseTime.valueOf());
+
+            expression.registerFunction("isBefore", (ts, type, value, offset, random) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "before", operands: {type: type,
+                                                          value: value, offset: (typeof offset != "undefined") ? offset : 0,
+                                                          random: (typeof random != "undefined") ? random : false}}, id), id);
+            }, "<(sn)ssn?b?:b>");
+
+            expression.registerFunction("isAfter", (ts, type, value, offset, random) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "after", operands: {type: type,
+                                                          value: value, offset: (typeof offset != "undefined") ? offset : 0,
+                                                          random: (typeof random != "undefined") ? random : false}}, id), id);
+            }, "<(sn)ssn?b?:b>");
+
+            expression.registerFunction("isBetween", (ts, type1, value1, offset1, random1, type2, value2, offset2, random2) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "between", operands: [{type: type1,
+                                                          value: value1, offset: offset1, random: random1},{type: type2,
+                                                          value: value2, offset: offset2, random: random2}]}, id), id);
+            }, "<(sn)ssnbssnb:b>");
+
+            expression.registerFunction("isOutside", (ts, type1, value1, offset1, random1, type2, value2, offset2, random2) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "outside", operands: [{type: type1,
+                                                          value: value1, offset: offset1, random: random1},{type: type2,
+                                                          value: value2, offset: offset2, random: random2}]}, id), id);
+            }, "<(sn)ssnbssnb:b>");
+
+            expression.registerFunction("isFirstDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "first",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isSecondDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "second",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isThirdDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "third",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isFourthDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "fourth",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isFifthDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "fifth",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isLastDay", (ts, day) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "last",
+                                                          day: day ? day : "day", exclude: false}}, id), id);
+            }, "<(sn)s?:b>");
+
+            expression.registerFunction("isEvenDay", (ts) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "even",
+                                                          exclude: false}}, id), id);
+            }, "<(sn):b>");
+
+            expression.registerFunction("isSpecificDay", (ts, day, month) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "days", operands: {type: "specific",
+                                                          day: day, month: month, exclude: false}}, id), id);
+            }, "<(sn)n(sn)?:b>");
+
+            expression.registerFunction("matchesWeekdays", (ts, days) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "weekdays", operands: days}, id), id);
+            }, "<(sn)o:b>");
+
+            expression.registerFunction("matchesMonths", (ts, months) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, {operator: "months", operands: months}, id), id);
+            }, "<(sn)o:b>");
+
+            expression.registerFunction("evaluateCondition", (ts, condition) =>
+            {
+                return evaluateCondition(RED, node, msg, node.chronos.getTimeFrom(node, ts),
+                                         convertCondition(RED, node, condition, id), id);
+            }, "<(sn)o:b>");
+
+            node.debug("[Condition:" + id + "] Check if '" + cond.expression + "' evaluates to true");
+            result = RED.util.evaluateJSONataExpression(expression, msg);
+        }
+        catch (e)
+        {
+            if (e instanceof node.chronos.TimeError)
+            {
+                throw e;
+            }
+            else
+            {
+                node.debug(e.code + ": " + e.message);
+                node.debug(e.stack);
+
+                const details = {condition: id, expression: cond.expression, code: e.code, description: e.message, position: e.position, token: e.token};
+                if (e.value)
+                {
+                    details.value = e.value;
+                }
+
+                throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.evaluationFailed"), details);
+            }
         }
 
-        result = evaluateCondition(RED, node, baseTime, ctxCond, id);
+        if (typeof result != "boolean")
+        {
+            throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.notBoolean"),
+                                             {condition: id, expression: cond.expression, result: result});
+        }
     }
     else if ((cond.operator == "before") || (cond.operator == "after"))
     {
@@ -323,7 +457,7 @@ function evaluateCondition(RED, node, baseTime, cond, id)
             const MONTHS = {january: 0, february: 1, march: 2, april: 3, may: 4, june: 5, july: 6, august: 7, september: 8, october: 9, november: 10, december: 11};
 
             node.debug("[Condition:" + id + "] Check if " + (cond.operands.exclude ? "not " : "") + cond.operands.day + ". of " + ((cond.operands.month == "any") ? "any month" : cond.operands.month));
-            result = ((baseTime.date() == cond.operands.day) && ((cond.operands.month == "any") || (baseTime.month() == MONTHS[cond.operands.month])));
+            result = ((baseTime.date() == cond.operands.day) && ((cond.operands.month == "any") || (baseTime.month() == ((typeof cond.operands.month == "string") ? MONTHS[cond.operands.month] : cond.operands.month - 1))));
         }
         else if (cond.operands.type == "even")
         {

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -310,6 +310,7 @@ SOFTWARE.
                     let daysBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
                     let weekdaysBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
                     let monthsBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
+                    let expressionBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 6px;"}).appendTo(fragment);
                     let contextBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 6px;"}).appendTo(fragment);
 
                     let operator = $("<select/>", {class: "node-input-operator", style: "width: 120px;"})
@@ -324,6 +325,7 @@ SOFTWARE.
                                         .append($("<option></option>").val("months").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.months")))
                                         .appendTo(operator);
                     let fromGrp = $("<optgroup></optgroup>").attr("label", node._("node-red-contrib-chronos/chronos-config:common.list.condition.sources"))
+                                        .append($("<option></option>").val("expression").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.source.expression")))
                                         .append($("<option></option>").val("context").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.source.context")))
                                         .appendTo(operator);
 
@@ -505,6 +507,11 @@ SOFTWARE.
                     $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: 40px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.list.month.december")).appendTo(monthsRow3);
 
+                    let expression = $("<input/>", {type: "text", class: "node-input-expression"})
+                                        .appendTo(expressionBox)
+                                        .typedInput({types: ["jsonata"]});
+                    expression.typedInput("width", "280px");
+
                     let context = $("<input/>", {type: "text", class: "node-input-context"})
                                         .appendTo(contextBox)
                                         .typedInput({types: ["global", "flow"]});
@@ -517,6 +524,7 @@ SOFTWARE.
                         daysBox.hide();
                         weekdaysBox.hide();
                         monthsBox.hide();
+                        expressionBox.hide();
                         contextBox.hide();
 
                         var value = $(this).val();
@@ -548,6 +556,11 @@ SOFTWARE.
                             case "months":
                             {
                                 monthsBox.show();
+                                break;
+                            }
+                            case "expression":
+                            {
+                                expressionBox.show();
                                 break;
                             }
                             case "context":
@@ -794,6 +807,11 @@ SOFTWARE.
                         november.prop("checked", data.operands[10]);
                         december.prop("checked", data.operands[11]);
                     }
+                    else if (data.operator == "expression")
+                    {
+                        expression.typedInput("value", data.expression);
+                        expression.typedInput("type", "jsonata");
+                    }
                     else if (data.operator == "context")
                     {
                         context.typedInput("value", data.context.value);
@@ -853,6 +871,7 @@ SOFTWARE.
                 let october = $(this).find(".node-input-october");
                 let november = $(this).find(".node-input-november");
                 let december = $(this).find(".node-input-december");
+                let expression = $(this).find(".node-input-expression");
                 let context = $(this).find(".node-input-context");
 
                 data.operator = operator.val();
@@ -920,6 +939,10 @@ SOFTWARE.
                     data.operands[9] = october.prop("checked");
                     data.operands[10] = november.prop("checked");
                     data.operands[11] = december.prop("checked");
+                }
+                else if (data.operator == "expression")
+                {
+                    data.expression = expression.typedInput("value");
                 }
                 else if (data.operator == "context")
                 {

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -163,7 +163,7 @@ module.exports = function(RED)
                             {
                                 try
                                 {
-                                    result = sfUtils.evaluateCondition(RED, node, baseTime, node.conditions[i], i+1);
+                                    result = sfUtils.evaluateCondition(RED, node, msg, baseTime, node.conditions[i], i+1);
                                 }
                                 catch (e)
                                 {
@@ -227,11 +227,11 @@ module.exports = function(RED)
                                         node.debug(err.stack);
                                         node.debug("Position: " + err.position + "  Token: " + err.token);
 
-                                        done(RED._("filter.error.evaluationFailed"));
+                                        done(RED._("node-red-contrib-chronos/chronos-config:common.error.evaluationFailed"));
                                     }
                                     else if (typeof value != "boolean")
                                     {
-                                        done(RED._("filter.error.notBoolean"));
+                                        done(RED._("node-red-contrib-chronos/chronos-config:common.error.notBoolean"));
                                     }
                                     else if (value)
                                     {

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -60,7 +60,7 @@ module.exports = function(RED)
             node.conditions = settings.conditions;
 
             node.evaluation = (typeof settings.evaluation != "undefined") ? settings.evaluation : "";
-            if (typeof settings.evaluationType == "undefined")
+            if (typeof settings.evaluationType == "undefined")  // backward compatibility to v1.11.1
             {
                 if (settings.annotateOnly)
                 {
@@ -216,15 +216,10 @@ module.exports = function(RED)
                             }
                             else if (node.evaluationType == "jsonata")
                             {
-                                let inputMsg = RED.util.cloneMessage(msg);
-                                if ("condition" in inputMsg)
-                                {
-                                    inputMsg._condition = inputMsg.condition;
-                                }
-                                inputMsg.condition = condResults;
+                                node.expression.assign("condition", condResults);
 
-                                node.debug("Evaluating: " + node.evaluation + " -> " + JSON.stringify(inputMsg));
-                                RED.util.evaluateJSONataExpression(node.expression, inputMsg, (err, value) =>
+                                node.debug("Evaluating: " + node.evaluation + " -> " + JSON.stringify(condResults));
+                                RED.util.evaluateJSONataExpression(node.expression, msg, (err, value) =>
                                 {
                                     if (err)
                                     {

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -61,7 +61,8 @@
                 },
                 "source":
                 {
-                    "context":  "Kontext"
+                    "expression":  "Ausdruck",
+                    "context":     "Kontext"
                 }
             },
             "dayType":
@@ -121,9 +122,11 @@
             "invalidConfig":     "Konfiguration enthält ungültige Werte",
             "invalidTime":       "Ungültige Uhrzeit angegeben",
             "invalidBaseTime":   "Ungültige Basiszeit angegeben: __baseTime__",
-            "invalidCondition":  "Ungültige Bedingung aus Kontextvariable: __condition__",
+            "invalidCondition":  "Ungültige Bedingung",
             "invalidName":       "Ungültiger benutzerdefinierter Sonnenstand angegeben",
-            "unavailableTime":   "Kein Zeitpunkt für Ereignis verfügbar"
+            "unavailableTime":   "Kein Zeitpunkt für Ereignis verfügbar",
+            "evaluationFailed":  "Fehler beim Auswerten des Ausdrucks",
+            "notBoolean":        "Ausdruck muss ein Wahrheitswert sein"
         }
     },
     "config":

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -137,6 +137,12 @@ SOFTWARE.
                     ausgewählten Monate zutrifft.
                 </li>
                 <li>
+                    Quelle <i>Ausdruck</i>: Das Ergebnis der Bedingung wird von
+                    dem angegebenen JSONata-Ausdruck abgeleitet. Es werden zusätzliche
+                    Zeitberechnungsfunktionen unterstützt und die Basiszeit kann
+                    über die Variable <code>$baseTime</code> abgefragt werden.
+                </li>
+                <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen
                     Kontextvariablen. Siehe Kapitel <i>Eingabe</i> weiter unten
                     für eine Beschreibung der benötigten Struktur der globalen

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -89,8 +89,8 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>JSONata</i>: Die Nachricht wird weitergeleitet, wenn der
-                    angegebene JSONata-Ausdruck wahr ist. Über die Eigenschaft
-                    <code>condition</code> können die Ergebnisse der Bedingungen
+                    angegebene JSONata-Ausdruck wahr ist. Über die Variable
+                    <code>$condition</code> können die Ergebnisse der Bedingungen
                     als Array von booleschen Werten abgefragt werden.
                 </li>
             </ul>

--- a/nodes/locales/de/filter.json
+++ b/nodes/locales/de/filter.json
@@ -9,11 +9,6 @@
             "logicalOr":   "Logisches ODER",
             "logicalAnd":  "Logisches UND",
             "annotation":  "Annotation"
-        },
-        "error":
-        {
-            "evaluationFailed":  "Fehler beim Auswerten des Ausdrucks",
-            "notBoolean":        "Ausdruck muss ein Wahrheitswert sein"
         }
     }
 }

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -116,6 +116,12 @@ SOFTWARE.
                     nicht zutreffen.
                 </li>
                 <li>
+                    Quelle <i>Ausdruck</i>: Das Ergebnis der Bedingung wird von
+                    dem angegebenen JSONata-Ausdruck abgeleitet. Es werden zusätzliche
+                    Zeitberechnungsfunktionen unterstützt und die Basiszeit kann
+                    über die Variable <code>$baseTime</code> abgefragt werden.
+                </li>
+                <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen
                     Kontextvariablen. Siehe Kapitel <i>Eingabe</i> weiter unten
                     für eine Beschreibung der benötigten Struktur der globalen

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -61,7 +61,8 @@
                 },
                 "source":
                 {
-                    "context":  "context"
+                    "expression":  "expression",
+                    "context":     "context"
                 }
             },
             "dayType":
@@ -121,9 +122,11 @@
             "invalidConfig":     "Configuration contains invalid values",
             "invalidTime":       "Invalid time specified",
             "invalidBaseTime":   "Invalid base time specified: __baseTime__",
-            "invalidCondition":  "Invalid condition from context variable: __condition__",
+            "invalidCondition":  "Invalid condition",
             "invalidName":       "Invalid custom sun position specified",
-            "unavailableTime":   "No time available for event"
+            "unavailableTime":   "No time available for event",
+            "evaluationFailed":  "Unable to evaluate expression",
+            "notBoolean":        "Expression must result in boolean value"
         }
     },
     "config":

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -87,7 +87,7 @@ SOFTWARE.
                 <li>
                     <i>expression</i>: The message is forwarded if the specified
                     JSONata expression evaluates to true. The results of the
-                    conditions can be accessed through the property <code>condition</code>
+                    conditions can be accessed through the variable <code>$condition</code>
                     which is an array of boolean values.
                 </li>
             </ul>

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -131,6 +131,12 @@ SOFTWARE.
                     selected months.
                 </li>
                 <li>
+                    Source <i>expression</i>: The condition result is taken from the
+                    provided JSONata expression. Additional time calculation functions
+                    are supported and the base time can be accessed through variable
+                    <code>$baseTime</code>.
+                </li>
+                <li>
                     Source <i>context</i>: Loads the condition from the specified
                     context variable. See chapter <i>Input</i> below for a description
                     of the required structure for the global or flow variable.

--- a/nodes/locales/en-US/filter.json
+++ b/nodes/locales/en-US/filter.json
@@ -9,11 +9,6 @@
             "logicalOr":   "logical OR",
             "logicalAnd":  "logical AND",
             "annotation":  "annotation"
-        },
-        "error":
-        {
-            "evaluationFailed":  "Unable to evaluate expression",
-            "notBoolean":        "Expression must result in boolean value"
         }
     }
 }

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -110,6 +110,12 @@ SOFTWARE.
                     do not match.
                 </li>
                 <li>
+                    Source <i>expression</i>: The condition result is taken from the
+                    provided JSONata expression. Additional time calculation functions
+                    are supported and the base time can be accessed through variable
+                    <code>$baseTime</code>.
+                </li>
+                <li>
                     Source <i>context</i>: Loads the condition from the specified
                     context variable. See chapter <i>Input</i> below for a description
                     of the required structure for the global or flow variable.

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -276,6 +276,7 @@ SOFTWARE.
                     let daysBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
                     let weekdaysBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
                     let monthsBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 2px;"}).appendTo(fragment);
+                    let expressionBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 6px;"}).appendTo(fragment);
                     let contextBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 6px;"}).appendTo(fragment);
                     $("<div/>", {class: "node-input-index", style: "position: absolute; width: auto; top: 50%; right: 26px; margin-top: -9px;"})
                                         .html("&#8594; " + (index + 1))
@@ -294,6 +295,7 @@ SOFTWARE.
                                         .append($("<option></option>").val("otherwise").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.otherwise")))
                                         .appendTo(operator);
                     let fromGrp = $("<optgroup></optgroup>").attr("label", node._("node-red-contrib-chronos/chronos-config:common.list.condition.sources"))
+                                        .append($("<option></option>").val("expression").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.source.expression")))
                                         .append($("<option></option>").val("context").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.source.context")))
                                         .appendTo(operator);
 
@@ -475,6 +477,11 @@ SOFTWARE.
                     $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: 40px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.list.month.december")).appendTo(monthsRow3);
 
+                    let expression = $("<input/>", {type: "text", class: "node-input-expression"})
+                                        .appendTo(expressionBox)
+                                        .typedInput({types: ["jsonata"]});
+                    expression.typedInput("width", "280px");
+
                     let context = $("<input/>", {type: "text", class: "node-input-context"})
                                         .appendTo(contextBox)
                                         .typedInput({types: ["global", "flow"]});
@@ -487,6 +494,7 @@ SOFTWARE.
                         daysBox.hide();
                         weekdaysBox.hide();
                         monthsBox.hide();
+                        expressionBox.hide();
                         contextBox.hide();
 
                         var value = $(this).val();
@@ -518,6 +526,11 @@ SOFTWARE.
                             case "months":
                             {
                                 monthsBox.show();
+                                break;
+                            }
+                            case "expression":
+                            {
+                                expressionBox.show();
                                 break;
                             }
                             case "context":
@@ -764,6 +777,11 @@ SOFTWARE.
                         november.prop("checked", data.operands[10]);
                         december.prop("checked", data.operands[11]);
                     }
+                    else if (data.operator == "expression")
+                    {
+                        expression.typedInput("value", data.expression);
+                        expression.typedInput("type", "jsonata");
+                    }
                     else if (data.operator == "context")
                     {
                         context.typedInput("value", data.context.value);
@@ -866,6 +884,7 @@ SOFTWARE.
                 let october = $(this).find(".node-input-october");
                 let november = $(this).find(".node-input-november");
                 let december = $(this).find(".node-input-december");
+                let expression = $(this).find(".node-input-expression");
                 let context = $(this).find(".node-input-context");
 
                 data.operator = operator.val();
@@ -1003,6 +1022,18 @@ SOFTWARE.
                         {
                             data.label += " " + MONTHS[i];
                         }
+                    }
+                }
+                else if (data.operator == "expression")
+                {
+                    data.expression = expression.typedInput("value");
+                    if (data.expression.length <= 50)
+                    {
+                        data.label = data.expression;
+                    }
+                    else
+                    {
+                        data.label = data.expression.substring(0, 49) + "...";
                     }
                 }
                 else if (data.operator == "context")

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -160,7 +160,7 @@ module.exports = function(RED)
                                         node.debug("[Condition:" + (i+1) + "] Otherwise");
                                         otherwiseIndex = i;
                                     }
-                                    else if (sfUtils.evaluateCondition(RED, node, baseTime, cond, i+1))
+                                    else if (sfUtils.evaluateCondition(RED, node, msg, baseTime, cond, i+1))
                                     {
                                         ports[i] = true;
                                         numMatches++;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "node-red-contrib-chronos",
     "version": "1.12.0",
-    "description": "Time-based Node-RED scheduling, queueing, routing, filtering and manipulating nodes",
+    "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
         "email": "devel@jrossbach.de"
@@ -34,7 +34,8 @@
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^9.2.4"
+        "sinon": "^9.2.4",
+        "jsonata": "^1.8.4"
     },
     "main": "none",
     "scripts": {

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -443,24 +443,28 @@ describe("chronos", function()
 
             expr = chronos.getJSONataExpression(RED, node, "$time($ts, '11:22')");
             expr.assign("ts", ts);
-            result = expr.evaluate({});
-            result.should.equal(1638440520000);
+            result = moment(expr.evaluate({}));
+            result.add(result.utcOffset(), "minutes");
+            result.valueOf().should.equal(1638444120000);
 
             expr = chronos.getJSONataExpression(RED, node, "$time($ts, '11:22', 0, false)");
             expr.assign("ts", ts);
-            result = expr.evaluate({});
-            result.should.equal(1638440520000);
+            result = moment(expr.evaluate({}));
+            result.add(result.utcOffset(), "minutes");
+            result.valueOf().should.equal(1638444120000);
 
             expr = chronos.getJSONataExpression(RED, node, "$time($ts, '11:22', 10, false)");
             expr.assign("ts", ts);
-            result = expr.evaluate({});
-            result.should.equal(1638441120000);
+            result = moment(expr.evaluate({}));
+            result.add(result.utcOffset(), "minutes");
+            result.valueOf().should.equal(1638444720000);
 
             sinon.stub(Math, "random").returns(0.5);
             expr = chronos.getJSONataExpression(RED, node, "$time($ts, '11:22', 20, true)");
             expr.assign("ts", ts);
-            result = expr.evaluate({});
-            result.should.equal(1638441120000);
+            result = moment(expr.evaluate({}));
+            result.add(result.utcOffset(), "minutes");
+            result.valueOf().should.equal(1638444720000);
 
             sinon.stub(sunCalc, "getTimes").returns({"sunset": new Date("2000-01-01T11:22:33.444Z")});
             expr = chronos.getJSONataExpression(RED, node, "$sunTime($ts, 'sunset', 0, false)");

--- a/test/common/sfutils_spec.js
+++ b/test/common/sfutils_spec.js
@@ -26,13 +26,14 @@
 const sinon = require("sinon");
 const sfutils = require("../../nodes/common/sfutils.js");
 const moment = require("moment");
+const jsonata = require("jsonata");
 
 require("should-sinon");
 
 describe("switch/filter utilities", function()
 {
     const RED = {"_": () => "", util: {}};
-    const node = {chronos: require("../../nodes/common/chronos.js"), debug: function() {}};
+    const node = {chronos: require("../../nodes/common/chronos.js"), debug: function() {}, locale: "UTC"};
 
     afterEach(function()
     {
@@ -75,27 +76,27 @@ describe("switch/filter utilities", function()
             const baseTime = moment("2021-03-15T10:00:00.000Z");
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12:00", offset: 0, random: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
             RED.util.parseContextStore.should.be.calledOnce().and.calledWith("testVariable");
             ctx.flow.get.should.be.calledOnce().and.calledWith("testKey", "testStore");
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 15, exclude: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 15, month: "march", exclude: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             ctx.flow.get.returns({operator: "days", operands: {type: "third", day: "monday", exclude: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             ctx.flow.get.returns({operator: "days", operands: {type: "even", exclude: true}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             ctx.flow.get.returns({operator: "weekdays", operands: {monday: true, wednesday: true, thursday: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             ctx.flow.get.returns({operator: "months", operands: {january: true, march: true, july: false}});
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             delete RED.util.parseContextStore;
         });
@@ -110,7 +111,7 @@ describe("switch/filter utilities", function()
             const condition = {operator: "context", context: {type: "flow", value: "testVariable"}};
             const baseTime = moment("2000-01-01T10:00:00.000Z");
 
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
             RED.util.parseContextStore.should.be.calledOnce().and.calledWith("testVariable");
             ctx.flow.get.should.be.calledOnce().and.calledWith("testKey", "testStore");
 
@@ -128,177 +129,336 @@ describe("switch/filter utilities", function()
             const baseTime = moment("2000-01-01T10:00:00.000Z");
 
             ctx.flow.get.returns("invalid");
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: 5});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "invalidOp"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: null});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: "invalid"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12_00"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "sun", value: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "moon", value: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12:00", offset: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12:00", offset: 301}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12:00", offset: -301}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "before", operands: {type: "time", value: "12:00", offset: 0, random: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: null});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: "invalid"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: {}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: []});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: [null, {type: "time", value: "12:00", offset: 0, random: false}]});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "between", operands: [{type: "time", value: "12:00", offset: 0, random: false}, null]});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: null});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: "invalid"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "first", day: "x-day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "last", day: "x-day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
-            ctx.flow.get.returns({operator: "days", operands: {type: "second", day: "day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            ctx.flow.get.returns({operator: "days", operands: {type: "second", day: "workday"}});
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
-            ctx.flow.get.returns({operator: "days", operands: {type: "third", day: "day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            ctx.flow.get.returns({operator: "days", operands: {type: "third", day: "workday"}});
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
-            ctx.flow.get.returns({operator: "days", operands: {type: "fourth", day: "day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            ctx.flow.get.returns({operator: "days", operands: {type: "fourth", day: "workday"}});
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
-            ctx.flow.get.returns({operator: "days", operands: {type: "fifth", day: "day"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            ctx.flow.get.returns({operator: "days", operands: {type: "fifth", day: "workday"}});
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 0}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 1, month: "invalid"}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 32}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "days", operands: {type: "specific", day: 1}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: null});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: "invalid"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {monday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {tuesday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {wednesday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {thursday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {friday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {saturday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "weekdays", operands: {sunday: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: null});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: "invalid"});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {january: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {february: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {march: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {april: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {may: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {june: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {july: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {august: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {september: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {october: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {november: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             ctx.flow.get.returns({operator: "months", operands: {december: 5}});
-            (() => sfutils.evaluateCondition(RED, node, baseTime, condition)).should.throw(node.chronos.TimeError);
+            (() => sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1)).should.throw(node.chronos.TimeError);
 
             delete RED.util.parseContextStore;
+        });
+
+        it("should fail due to invalid expression (syntax error)", function()
+        {
+            let baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+            let condition = {operator: "expression", expression: "my expression"};
+
+            sinon.stub(node.chronos, "getJSONataExpression").throws(function()
+            {
+                let e = new Error("some error");
+                e.code = 42;
+                e.position = "abc";
+                e.token = "xyz";
+                e.value = "val123";
+                return e;
+            });
+            RED.util.evaluateJSONataExpression = sinon.spy();
+
+            (() => sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition, 1)).should.throw(node.chronos.TimeError, {details: {condition: 1, expression: "my expression", code: 42, description: "some error", position: "abc", token: "xyz", value: "val123"}});
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            RED.util.evaluateJSONataExpression.should.not.be.called();
+
+            delete RED.util.evaluateJSONataExpression
+        });
+
+        it("should fail due to invalid expression (evaluation error)", function()
+        {
+            let baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+            let condition = {operator: "expression", expression: "my expression"};
+
+            let assign = sinon.spy();
+            let registerFunction = sinon.spy();
+            sinon.stub(node.chronos, "getJSONataExpression").returns({assign: assign, registerFunction: registerFunction});
+            RED.util.evaluateJSONataExpression = sinon.stub().throws(function()
+            {
+                let e = new Error("some error");
+                e.code = 42;
+                e.position = "abc";
+                e.token = "xyz";
+                return e;
+            });
+
+            (() => sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition, 1)).should.throw(node.chronos.TimeError, {details: {condition: 1, expression: "my expression", code: 42, description: "some error", position: "abc", token: "xyz"}});
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            assign.should.be.calledWith("baseTime", baseTime.valueOf());
+            registerFunction.should.have.callCount(15);
+            RED.util.evaluateJSONataExpression.should.be.calledWith(sinon.match.any, {payload: 42});
+
+            delete RED.util.evaluateJSONataExpression
+        });
+
+        it("should fail due to invalid expression (time error)", function()
+        {
+            let baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+            let condition = {operator: "expression", expression: "my expression"};
+
+            let assign = sinon.spy();
+            let registerFunction = sinon.spy();
+            sinon.stub(node.chronos, "getJSONataExpression").returns({assign: assign, registerFunction: registerFunction});
+            RED.util.evaluateJSONataExpression = sinon.stub().throws(function()
+            {
+                return new node.chronos.TimeError("some error", {foo: "bar"});
+            });
+
+            (() => sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition, 1)).should.throw(node.chronos.TimeError, {details: {foo: "bar"}});
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            assign.should.be.calledWith("baseTime", baseTime.valueOf());
+            registerFunction.should.have.callCount(15);
+            RED.util.evaluateJSONataExpression.should.be.calledWith(sinon.match.any, {payload: 42});
+
+            delete RED.util.evaluateJSONataExpression
+        });
+
+        it("should fail due to invalid expression (not boolean result)", function()
+        {
+            let baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+            let condition = {operator: "expression", expression: "my expression"};
+
+            let assign = sinon.spy();
+            let registerFunction = sinon.spy();
+            sinon.stub(node.chronos, "getJSONataExpression").returns({assign: assign, registerFunction: registerFunction});
+            RED.util.evaluateJSONataExpression = sinon.stub().returns(42);
+
+            (() => sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition, 1)).should.throw(node.chronos.TimeError, {details: {condition: 1, expression: "my expression", result: 42}});
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            assign.should.be.calledWith("baseTime", baseTime.valueOf());
+            registerFunction.should.have.callCount(15);
+            RED.util.evaluateJSONataExpression.should.be.calledWith(sinon.match.any, {payload: 42});
+
+            delete RED.util.evaluateJSONataExpression
+        });
+
+        it("should call expression function", function()
+        {
+            RED.util.prepareJSONataExpression = function(expr, node)
+            {
+                return jsonata(expr);
+            };
+            RED.util.evaluateJSONataExpression = function(expr, msg)
+            {
+                return expr.evaluate(msg);
+            };
+
+            try
+            {
+                let baseTime = node.chronos.getTimeFrom(node, "2021-01-01T10:00:00.000");
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isBefore($baseTime, 'time', '11:00', 20, false)"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isBefore($baseTime, 'time', '11:00')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isAfter($baseTime, 'time', '9:00', 20, false)"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isAfter($baseTime, 'time', '9:00')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isBetween($baseTime, 'time', '9:00', 20, false, 'time', '11:00', 30, true)"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isOutside($baseTime, 'time', '14:00', 0, false, 'time', '16:00', 0, false)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-01T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFirstDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFirstDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-02T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isSecondDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isSecondDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-03T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isThirdDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isThirdDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-04T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFourthDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFourthDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFifthDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isFifthDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-31T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isLastDay($baseTime, 'day')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isLastDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-01-22T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isSpecificDay($baseTime, 22, 1)"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isSpecificDay($baseTime, 22, 'january')"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isSpecificDay($baseTime, 22)"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$isEvenDay($baseTime)"}, 1).should.be.true();
+
+                baseTime = moment("2021-07-05T10:00:00.000Z").utc();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$matchesWeekdays($baseTime, {'monday': true, 'friday': true})"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$matchesMonths($baseTime, {'january': true, 'july': true})"}, 1).should.be.true();
+                sfutils.evaluateCondition(RED, node, {}, baseTime, {operator: "expression", expression: "$evaluateCondition($baseTime, {'operator': 'days', 'operands': {'type': 'even', 'exclude': true}})"}, 1).should.be.true();
+            }
+            catch (e)
+            {
+                console.log(e.message);
+                console.log(JSON.stringify(e.details));
+                console.log(e.stack);
+
+                throw e;
+            }
+
+            delete RED.util.prepareJSONataExpression;
+            delete RED.util.evaluateJSONataExpression;
         });
 
         it("should return true", function()
@@ -306,189 +466,208 @@ describe("switch/filter utilities", function()
             let baseTime = moment("2021-03-15T10:00:00.000Z").utc();  // Monday, March
 
             let condition = {operator: "before", operands: {type: "time", value: "12:00", offset: 0, random: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "before", operands: {type: "time", value: "9:45", offset: 30, random: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             sinon.stub(Math, "round").returnsArg(0);
             sinon.stub(Math, "random").returns(10);
 
             condition = {operator: "before", operands: {type: "time", value: "9:45", offset: 3, random: true}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             sinon.restore();
 
             condition = {operator: "after", operands: {type: "time", value: "8:00", offset: 0, random: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "between", operands: [{type: "time", value: "8:00", offset: 0, random: false}, {type: "time", value: "12:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "between", operands: [{type: "time", value: "23:00", offset: 0, random: false}, {type: "time", value: "12:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "between", operands: [{type: "time", value: "10:15", offset: -30, random: false}, {type: "time", value: "9:45", offset: 30, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
-            roundStub = sinon.stub(Math, "round").returnsArg(0);
-            randomStub = sinon.stub(Math, "random").returns(10);
+            sinon.stub(Math, "round").returnsArg(0);
+            sinon.stub(Math, "random").returns(10);
 
             condition = {operator: "between", operands: [{type: "time", value: "10:15", offset: -3, random: true}, {type: "time", value: "9:45", offset: 3, random: true}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             sinon.restore();
 
             condition = {operator: "outside", operands: [{type: "time", value: "12:00", offset: 0, random: false}, {type: "time", value: "14:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "outside", operands: [{type: "time", value: "5:00", offset: 0, random: false}, {type: "time", value: "6:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "outside", operands: [{type: "time", value: "23:00", offset: 0, random: false}, {type: "time", value: "4:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "weekdays", operands: [false, true, false, false, false, false, false]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             condition = {operator: "months", operands: [false, false, true, false, false, false, false, false, false, false, false, false]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-04T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "monday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-12T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "second", day: "tuesday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-20T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "third", day: "wednesday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-28T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "fourth", day: "thursday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-29T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "fifth", day: "friday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-02T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "saturday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-03T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "sunday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-05T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "fifth", day: "day", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-01T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-11-02T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-08-03T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-02T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-11-01T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-08-01T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-25T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "monday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-26T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "tuesday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-27T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "wednesday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-28T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "thursday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-29T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "friday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-30T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "saturday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-31T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "sunday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-31T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "day", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-29T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-10-30T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-11-30T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "workday", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-31T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-12-27T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2020-10-31T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "last", day: "weekend", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-04T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "even", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-08T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "specific", day: 8, month: "january", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
+
+            baseTime = moment("2021-01-08T10:00:00.000Z").utc();
+            condition = {operator: "days", operands: {type: "specific", day: 8, month: 1, exclude: false}};
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-21T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "specific", day: 21, month: "any", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-02T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "first", day: "day", exclude: true}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-07T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "even", exclude: true}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
 
             baseTime = moment("2021-01-05T10:00:00.000Z").utc();
             condition = {operator: "days", operands: {type: "specific", day: 3, month: "february", exclude: true}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.true();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.true();
+
+            let assign = sinon.spy();
+            let registerFunction = sinon.spy();
+            sinon.stub(node.chronos, "getJSONataExpression").returns({assign: assign, registerFunction: registerFunction});
+            RED.util.evaluateJSONataExpression = sinon.stub().returns(true);
+
+            baseTime = moment("2021-01-05T10:00:00.000Z").utc();
+            condition = {operator: "expression", expression: "my expression"};
+            sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition).should.be.true();
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            assign.should.be.calledWith("baseTime", baseTime.valueOf());
+            registerFunction.should.have.callCount(15);
+            RED.util.evaluateJSONataExpression.should.be.calledWith(sinon.match.any, {payload: 42});
+
+            delete RED.util.evaluateJSONataExpression
         });
 
         it("should return false", function()
@@ -496,31 +675,45 @@ describe("switch/filter utilities", function()
             const baseTime = moment("2021-03-15T10:00:00.000Z").utc();  // Monday, March
 
             let condition = {operator: "before", operands: {type: "time", value: "8:00", offset: 0, random: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "after", operands: {type: "time", value: "12:00", offset: 0, random: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "between", operands: [{type: "time", value: "4:00", offset: 0, random: false}, {type: "time", value: "6:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "between", operands: [{type: "time", value: "12:00", offset: 0, random: false}, {type: "time", value: "16:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "between", operands: [{type: "time", value: "23:00", offset: 0, random: false}, {type: "time", value: "8:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "outside", operands: [{type: "time", value: "8:00", offset: 0, random: false}, {type: "time", value: "12:00", offset: 0, random: false}]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "days", operands: {type: "specific", day: 14, month: "february", exclude: false}};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "weekdays", operands: [true, false, false, false, false, false, false]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
 
             condition = {operator: "months", operands: [false, true, false, false, false, false, false, false, false, false, false, false]};
-            sfutils.evaluateCondition(RED, node, baseTime, condition).should.be.false();
+            sfutils.evaluateCondition(RED, node, {}, baseTime, condition, 1).should.be.false();
+
+            let assign = sinon.spy();
+            let registerFunction = sinon.spy();
+            sinon.stub(node.chronos, "getJSONataExpression").returns({assign: assign, registerFunction: registerFunction});
+            RED.util.evaluateJSONataExpression = sinon.stub().returns(false);
+
+            condition = {operator: "expression", expression: "my expression"};
+            sfutils.evaluateCondition(RED, node, {payload: 42}, baseTime, condition).should.be.false();
+            node.chronos.getJSONataExpression.should.be.calledWith(RED, node, "my expression");
+            assign.should.be.calledWith("baseTime", baseTime.valueOf());
+            registerFunction.should.have.callCount(15);
+            RED.util.evaluateJSONataExpression.should.be.calledWith(sinon.match.any, {payload: 42});
+
+            delete RED.util.evaluateJSONataExpression
         });
     });
 


### PR DESCRIPTION
This change introduces the possibility to specify JSONata expressions as an additional source of data for the conditions of the time switch and filter nodes.