### PR TITLE
Release 1.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.17.0] - 2022-04-11
+
+### Added
+- Added possibility to activate dedicated output port for capturing schedule times of events.
+- Added support for user specified time zones per configuration node.
+- Added example flows for scheduler node (more will follow in future).
+
+### Changed
+- Improved tooltip texts for offset input.
+- Updated versions of dependencies where possible.
+- Dropped support for Node-RED versions older than 1.0.0.
+
+### Fixed
+- Fixed offset not being applied for sun/moon times when scheduled for next day.
+- Fixed offset being applied only if dividable by 5.
+
 ## [1.16.0] - 2022-01-08
 
 ### Added

--- a/examples/scheduler/Control scheduler.json
+++ b/examples/scheduler/Control scheduler.json
@@ -1,0 +1,244 @@
+[
+    {
+        "id": "4d39bd7ab87afe9a",
+        "type": "tab",
+        "label": "Control scheduler",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "3407bac2b472b961",
+        "type": "comment",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "info": "# Control scheduler\nDynamically control scheduler node.\n\n## Events\n- enable all events\n- disable all events\n- mixed enabling/disabling\n- toggle all events\n- mixed commands (including `null` for ignoring events)",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "35f6576b95517032",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "enable all",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "true",
+        "payloadType": "bool",
+        "x": 140,
+        "y": 140,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "6595994a7e3c86c3",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "disable all",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "false",
+        "payloadType": "bool",
+        "x": 140,
+        "y": 200,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "6c3627d05dc05f50",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "enable/disable some",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[true,true,false]",
+        "payloadType": "json",
+        "x": 170,
+        "y": 260,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "5c66595396731421",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "toggle all",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "toggle",
+        "payloadType": "str",
+        "x": 140,
+        "y": 320,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "c5d839de721175be",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "various commands",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[\"reload\",null,\"trigger\"]",
+        "payloadType": "json",
+        "x": 170,
+        "y": 380,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "3ac8cc78ef81d61e",
+        "type": "chronos-scheduler",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "schedule": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "20:15",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Test"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunset",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "bool",
+                        "value": "true"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "crontab",
+                    "value": "0 * * * *"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Chronos"
+                    }
+                }
+            }
+        ],
+        "multiPort": false,
+        "nextEventPort": false,
+        "disabled": false,
+        "outputs": 1,
+        "x": 420,
+        "y": 260,
+        "wires": [
+            [
+                "16fc525479cdad28"
+            ]
+        ]
+    },
+    {
+        "id": "16fc525479cdad28",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 590,
+        "y": 260,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/scheduler/External input for scheduler.json
+++ b/examples/scheduler/External input for scheduler.json
@@ -1,0 +1,234 @@
+[
+    {
+        "id": "4d39bd7ab87afe9a",
+        "type": "tab",
+        "label": "External input",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "3407bac2b472b961",
+        "type": "comment",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "info": "# External input\nFetch trigger and output from context variables or override via input message.\n\n## Events\n- fetch trigger from flow variable\n- fetch trigger and override output from global variable\n- override trigger via input message\n- override trigger and output via input message",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "3ac8cc78ef81d61e",
+        "type": "chronos-scheduler",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "schedule": [
+            {
+                "trigger": {
+                    "type": "flow",
+                    "value": "trigger"
+                },
+                "output": {
+                    "type": "fullMsg",
+                    "contentType": "json",
+                    "value": "{\"topic\": \"my/topic\", \"payload\": \"Test\"}"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "global",
+                    "value": "override"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "bool",
+                        "value": "true"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "crontab",
+                    "value": "0 * * * *"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Chronos"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "20:15",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "num",
+                        "value": "42"
+                    }
+                }
+            }
+        ],
+        "multiPort": false,
+        "nextEventPort": false,
+        "disabled": false,
+        "outputs": 1,
+        "x": 360,
+        "y": 180,
+        "wires": [
+            [
+                "16fc525479cdad28"
+            ]
+        ]
+    },
+    {
+        "id": "16fc525479cdad28",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 530,
+        "y": 180,
+        "wires": []
+    },
+    {
+        "id": "35f6576b95517032",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "override trigger",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[{\"type\":\"moon\",\"value\":\"rise\",\"offset\":0,\"random\":false},null,null,null]",
+        "payloadType": "json",
+        "x": 160,
+        "y": 140,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "6595994a7e3c86c3",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "override event",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "[null,{\"trigger\":{\"type\":\"crontab\",\"value\":\"0 2 * * * *\"},\"output\":{\"type\":\"flow\",\"property\":{\"name\":\"var1\",\"value\":\"my variable\"}}}]",
+        "payloadType": "json",
+        "x": 150,
+        "y": 220,
+        "wires": [
+            [
+                "3ac8cc78ef81d61e"
+            ]
+        ]
+    },
+    {
+        "id": "c5d839de721175be",
+        "type": "inject",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payloadType": "date",
+        "x": 140,
+        "y": 300,
+        "wires": [
+            [
+                "5191d9d43ebfe1c8"
+            ]
+        ]
+    },
+    {
+        "id": "5191d9d43ebfe1c8",
+        "type": "change",
+        "z": "4d39bd7ab87afe9a",
+        "name": "set env variables",
+        "rules": [
+            {
+                "t": "set",
+                "p": "trigger",
+                "pt": "flow",
+                "to": "{\"type\":\"time\",\"value\":\"13:05\",\"offset\":20,\"random\":true}",
+                "tot": "json"
+            },
+            {
+                "t": "set",
+                "p": "override",
+                "pt": "global",
+                "to": "{\"trigger\":{\"type\":\"sun\",\"value\":\"sunrise\",\"offset\":30,\"random\":false},\"output\":{\"type\":\"msg\",\"property\":{\"name\":\"payload\",\"value\":true}}}",
+                "tot": "json"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 390,
+        "y": 300,
+        "wires": [
+            []
+        ]
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/scheduler/Scheduler with multiple outputs.json
+++ b/examples/scheduler/Scheduler with multiple outputs.json
@@ -1,0 +1,163 @@
+[
+    {
+        "id": "4d39bd7ab87afe9a",
+        "type": "tab",
+        "label": "Scheduler with multiple outputs",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "3407bac2b472b961",
+        "type": "comment",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "info": "# Scheduler with multiple outputs\nScheduler node that is configured for dedicated outputs per schedule event.\n\n## Events\n- Fixed time\n- Sun time\n- Cron table",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "3ac8cc78ef81d61e",
+        "type": "chronos-scheduler",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "schedule": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "20:15",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Test"
+                    }
+                },
+                "port": 0,
+                "label": "20:15"
+            },
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunset",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "bool",
+                        "value": "true"
+                    }
+                },
+                "port": 1,
+                "label": "Sunset (end)"
+            },
+            {
+                "trigger": {
+                    "type": "crontab",
+                    "value": "0 * * * *"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Chronos"
+                    }
+                },
+                "port": 2,
+                "label": "0 * * * * - NaN min."
+            }
+        ],
+        "multiPort": true,
+        "nextEventPort": false,
+        "disabled": false,
+        "outputs": 3,
+        "x": 120,
+        "y": 160,
+        "wires": [
+            [
+                "16fc525479cdad28"
+            ],
+            [
+                "bda23117d01ce88b"
+            ],
+            [
+                "cd90770e054926b1"
+            ]
+        ]
+    },
+    {
+        "id": "16fc525479cdad28",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 310,
+        "y": 120,
+        "wires": []
+    },
+    {
+        "id": "bda23117d01ce88b",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 310,
+        "y": 160,
+        "wires": []
+    },
+    {
+        "id": "cd90770e054926b1",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 310,
+        "y": 200,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/scheduler/Scheduler with single output.json
+++ b/examples/scheduler/Scheduler with single output.json
@@ -1,0 +1,151 @@
+[
+    {
+        "id": "4d39bd7ab87afe9a",
+        "type": "tab",
+        "label": "Scheduler with single output",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "3407bac2b472b961",
+        "type": "comment",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "info": "# Scheduler with single output\nScheduler node that is configured for single output.\n\n## Events\n- Fixed time\n- Fixed time with random offset\n- Sun time\n- Custom sun time\n- Cron table",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "3ac8cc78ef81d61e",
+        "type": "chronos-scheduler",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "schedule": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "20:15",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Test"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "10:00",
+                    "offset": 30,
+                    "random": true
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "num",
+                        "value": "42"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunset",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "bool",
+                        "value": "true"
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "custom",
+                    "value": "BlueHourDawn",
+                    "offset": 0,
+                    "random": false
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "date",
+                        "value": ""
+                    }
+                }
+            },
+            {
+                "trigger": {
+                    "type": "crontab",
+                    "value": "0 * * * *"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "payload",
+                        "type": "str",
+                        "value": "Chronos"
+                    }
+                }
+            }
+        ],
+        "multiPort": false,
+        "nextEventPort": false,
+        "disabled": false,
+        "outputs": 1,
+        "x": 120,
+        "y": 160,
+        "wires": [
+            [
+                "16fc525479cdad28"
+            ]
+        ]
+    },
+    {
+        "id": "16fc525479cdad28",
+        "type": "debug",
+        "z": "4d39bd7ab87afe9a",
+        "name": "",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "false",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 290,
+        "y": 160,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -91,25 +91,9 @@ module.exports = function(RED)
                 {
                     if (msg)
                     {
-                        if (!send)  // Node-RED 0.x backward compatibility
+                        if (!send || !done)  // Node-RED 0.x not supported anymore
                         {
-                            send = () =>
-                            {
-                                node.send.apply(node, arguments);
-                            };
-                        }
-
-                        if (!done)  // Node-RED 0.x backward compatibility
-                        {
-                            done = () =>
-                            {
-                                var args = [...arguments];
-                                if (args.length > 0)
-                                {
-                                    args.push(msg);
-                                    node.error.apply(node, args);
-                                }
-                            };
+                            return;
                         }
 
                         for (let i=0; i<node.rules.length; ++i)

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -43,6 +43,11 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!node.chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else if (settings.rules.length == 0)
         {
             node.status({fill: "red", shape: "dot", text: "change.status.noRules"});
@@ -50,7 +55,7 @@ module.exports = function(RED)
         }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            node.chronos.printNodeInfo(node);
             node.status({});
 
             node.rules = settings.rules;

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -415,7 +415,7 @@ function evaluateCondition(RED, node, msg, baseTime, cond, id)
             targetTime.add(offset, "minutes");
         }
 
-        node.debug("[Condition:" + id + "] Check if " + cond.operator + " " + targetTime.format("HH:mm:ss"));
+        node.debug("[Condition:" + id + "] Check if " + cond.operator + " " + targetTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
         result = (((cond.operator == "before") && baseTime.isBefore(targetTime)) ||
                   ((cond.operator == "after") && baseTime.isSameOrAfter(targetTime)));
     }
@@ -435,7 +435,7 @@ function evaluateCondition(RED, node, msg, baseTime, cond, id)
             time2.add(offset, "minutes");
         }
 
-        node.debug("[Condition:" + id + "] Check if " + cond.operator + " " + time1.format("HH:mm:ss") + " and " + time2.format("HH:mm:ss"));
+        node.debug("[Condition:" + id + "] Check if " + cond.operator + " " + time1.format("YYYY-MM-DD HH:mm:ss (Z))") + " and " + time2.format("YYYY-MM-DD HH:mm:ss (Z)"));
         if (time2.isSameOrBefore(time1))
         {
             result = (((cond.operator == "between") && (baseTime.isSameOrAfter(time1) || baseTime.isSameOrBefore(time2))) ||

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -38,6 +38,10 @@ SOFTWARE.
     <div class="form-row">
         <iframe id="node-config-input-map" width="100%" height="200" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" style="border: 1px solid #CCCCCC; border-radius: 4px;"></iframe>
     </div>
+    <div class="form-row">
+        <label for="node-config-input-timezone"><i class="fa fa-globe"></i> <span data-i18n="config.label.timezone"></span></label>
+        <input type="text" id="node-config-input-timezone" data-i18n="[placeholder]config.label.hostTZ">
+    </div>
     <div class="form-row node-input-sunPositionList-row" style="padding-top: 10px">
         <label for="node-input-sunPositionList" style="width: auto;"><i class="fa fa-calendar-o"></i> <span data-i18n="config.label.sunPositions"></span></label>
         <div class="form-row">
@@ -58,6 +62,10 @@ SOFTWARE.
         defaults:
         {
             name:
+            {
+                value: ""
+            },
+            timezone:
             {
                 value: ""
             },

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -31,6 +31,7 @@ module.exports = function(RED)
         RED.nodes.createNode(this, config);
 
         this.name = config.name;
+        this.timezone = config.timezone;
         this.latitude = parseFloat(this.credentials.latitude);
         this.longitude = parseFloat(this.credentials.longitude);
 

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -261,7 +261,7 @@ SOFTWARE.
             {
                 min: -300,
                 max: 300,
-                step: 5,
+                step: 1,
                 change: function(event, ui)
                 {
                     var value = parseInt($(this).spinner("value"), 10);

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -76,25 +76,9 @@ module.exports = function(RED)
                 {
                     if (msg)
                     {
-                        if (!send)  // Node-RED 0.x backward compatibility
+                        if (!send || !done)  // Node-RED 0.x not supported anymore
                         {
-                            send = () =>
-                            {
-                                node.send.apply(node, arguments);
-                            };
-                        }
-
-                        if (!done)  // Node-RED 0.x backward compatibility
-                        {
-                            done = () =>
-                            {
-                                var args = [...arguments];
-                                if (args.length > 0)
-                                {
-                                    args.push(msg);
-                                    node.error.apply(node, args);
-                                }
-                            };
+                            return;
                         }
 
                         if (!node.ignoreCtrlProps && ("drop" in msg))

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -44,9 +44,14 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            chronos.printNodeInfo(node);
             node.status({});
 
             node.whenType = settings.whenType;
@@ -228,7 +233,7 @@ module.exports = function(RED)
                 }
             }
 
-            node.debug("Starting timer for delayed message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss"));
+            node.debug("Starting timer for delayed message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
             node.delayTimer = setTimeout(() =>
             {
                 delete node.delayTimer;

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -360,7 +360,7 @@ SOFTWARE.
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
                                         .appendTo(time1Row2);
-                    let offset1 = $("<input/>", {class: "node-input-offset1", style: "width: 50px !important;"})
+                    let offset1 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset1", style: "width: 50px !important;"})
                                         .appendTo(time1Row2)
                                         .spinner(offsetInput);
                     let random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
@@ -372,7 +372,7 @@ SOFTWARE.
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
                                         .appendTo(time2Row2);
-                    let offset2 = $("<input/>", {class: "node-input-offset2", style: "width: 50px !important;"})
+                    let offset2 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset2", style: "width: 50px !important;"})
                                         .appendTo(time2Row2)
                                         .spinner(offsetInput);
                     let random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -292,7 +292,7 @@ SOFTWARE.
                     {
                         min: -300,
                         max: 300,
-                        step: 5,
+                        step: 1,
                         change: validateInput
                     };
 

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -45,6 +45,11 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!node.chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else if (settings.conditions.length == 0)
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.noConditions"});
@@ -52,7 +57,7 @@ module.exports = function(RED)
         }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            node.chronos.printNodeInfo(node);
             node.status({});
 
             node.baseTime = settings.baseTime;
@@ -137,7 +142,7 @@ module.exports = function(RED)
                         let baseTime = sfUtils.getBaseTime(RED, node, msg);
                         if (baseTime)
                         {
-                            node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss"));
+                            node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
 
                             let result = false;
                             let condResults = [];

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -129,25 +129,9 @@ module.exports = function(RED)
                 {
                     if (msg)
                     {
-                        if (!send)  // Node-RED 0.x backward compatibility
+                        if (!send || !done)  // Node-RED 0.x not supported anymore
                         {
-                            send = () =>
-                            {
-                                node.send.apply(node, arguments);
-                            };
-                        }
-
-                        if (!done)  // Node-RED 0.x backward compatibility
-                        {
-                            done = () =>
-                            {
-                                var args = [...arguments];
-                                if (args.length > 0)
-                                {
-                                    args.push(msg);
-                                    node.error.apply(node, args);
-                                }
-                            };
+                            return;
                         }
 
                         let baseTime = sfUtils.getBaseTime(RED, node, msg);

--- a/nodes/locales/de/config.html
+++ b/nodes/locales/de/config.html
@@ -33,7 +33,9 @@ SOFTWARE.
         abhängigen Zeitpunkte benötigt. Aus Datenschutzgründen werden die
         Koordinaten als geschützte Zugangsdaten gespeichert und damit nicht
         zusammen mit Flows exportiert. Die Karte kann verwendet werden, um die
-        eingegebenen Koordinaten zu überprüfen.
+        eingegebenen Koordinaten zu überprüfen. Falls eine Zeitzone verwendet
+        werden soll, die von der Zeitzone des Node-RED Hosts abweicht, kann
+        diese auch angegeben werden.
         Zusätzlich bietet der Knoten die Möglichkeit, benutzerdefinierte
         Sonnenständig anzulegen, die ähnlich wie die vorgegebenen Sonnenstände
         in den anderen Nodes verwendet werden können.
@@ -55,6 +57,18 @@ SOFTWARE.
     <dt>Längengrad</dt>
     <dd>
         Der Längengrad als Dezimalzahl zwischen -180° und 180°.
+    </dd>
+    <dt>Zeitzone</dt>
+    <dd>
+        <p>
+            Der Name einer <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">internationalen Zeitzone</a>.
+            Wenn nicht angegeben, wird die konfigurierte Zeitzone des Hosts
+            verwendet, auf dem Node-RED ausgeführt wird.
+        </p>
+        <p>
+            <b>Hinweis:</b> Es findet keine automatische Berechnung der Zeitzone
+            aus den geografischen Koordinaten statt!
+        </p>
     </dd>
     <dt>Benutzerdefinierte Sonnenstände</dt>
     <dd>

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -20,6 +20,10 @@
             "preserveCtrlProps":  "Steuereigenschaften in Nachrichten beibehalten",
             "ignoreCtrlProps":    "Steuereigenschaften in Nachrichten ignorieren"
         },
+        "tooltip":
+        {
+            "offset":  "Versatz (in Minuten)"
+        },
         "list":
         {
             "sun":

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -142,6 +142,8 @@
             "node":          "Konfiguration",
             "latitude":      "Breitengrad",
             "longitude":     "Längengrad",
+            "timezone":      "Zeitzone",
+            "hostTZ":        "aus System-Einstellungen",
             "sunPositions":  "Benutzerdefinierte Sonnenstände",
             "angle":         "Winkel",
             "riseName":      "Name (aufgehend)",

--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -122,6 +122,15 @@ SOFTWARE.
             angelegt, da zur Konfigurationszeit nicht feststeht, ob das Zeitereignis
             eine Nachricht als Ausgabe erzeugt oder nicht.
         </dd>
+        <dt>Ausgabe-Port für Ereigniszeiten</dt>
+        <dd>
+            Wenn aktiviert, wird ein zusätzlicher Ausgabe-Port erzeugt. Dieser
+            Ausgabe-Port sendet eine Nachricht immer dann, wenn sich das Datum
+            und die Zeit eines beliebigen Zeitereignisses aktualisieren. Die
+            Nachricht enthält einen Zeitstempel für das nächste Zeitereignis in
+            <code>msg.payload</code> und ein Array mit Zeitstempeln aller
+            Zeitereignisse in <code>msg.events</code>.
+        </dd>
         <dt>Mit inaktivem Zeitplan starten</dt>
         <dd>
             Wenn aktiviert, wird der Zeitplan beim Starten des Knotens initial

--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -3,15 +3,17 @@
     {
         "label":
         {
-            "node":         "Zeitplaner",
-            "inputPort":    "Ein-/Ausschalten",
-            "outputPort":   "Geplante Nachricht",
-            "schedule":     "Zeitplan",
-            "output":       "Ausgabe",
-            "crontab":      "Cron-Tabelle",
-            "fullMessage":  "Komplette Nachricht",
-            "multiPort":    "Separate Ausgabe-Ports für Zeitereignisse",
-            "disabled":     "Mit inaktivem Zeitplan starten"
+            "node":           "Zeitplaner",
+            "inputPort":      "Ein-/Ausschalten",
+            "outputPort":     "Geplante Nachricht",
+            "eventTimes":     "Ereigniszeiten",
+            "schedule":       "Zeitplan",
+            "output":         "Ausgabe",
+            "crontab":        "Cron-Tabelle",
+            "fullMessage":    "Komplette Nachricht",
+            "multiPort":      "Separate Ausgabe-Ports für Zeitereignisse",
+            "nextEventPort":  "Ausgabe-Port für Ereigniszeiten",
+            "disabled":       "Mit inaktivem Zeitplan starten"
         },
         "status":
         {

--- a/nodes/locales/en-US/config.html
+++ b/nodes/locales/en-US/config.html
@@ -32,7 +32,9 @@ SOFTWARE.
         and longitude. That is required for the calculation of times based on
         sun and moon position. For privacy protection reasons, the coordinates
         are stored as credentials and therefore are not exported with the flows.
-        The map can be used to validate the entered coordinates.
+        The map can be used to validate the entered coordinates. If a time zone
+        that differs from the time zone of the Node-RED host is required, this
+        can also be specified.
         Additionally custom sun positions can be defined in this node. They can
         be used in the other nodes in a similar way as the predefined sun
         positions.
@@ -53,6 +55,18 @@ SOFTWARE.
     <dt>Longitude</dt>
     <dd>
         The longitude as floating point value between -180° and 180°.
+    </dd>
+    <dt>Time Zone</dt>
+    <dd>
+        <p>
+            The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>.
+            If omitted, the time zone configured on the host which runs Node-RED
+            is used.
+        </p>
+        <p>
+            <b>Note:</b> A programmatic calculation of the time zone from the
+            geographical coordinates is not performed!
+        </p>
     </dd>
     <dt>Custom Sun Positions</dt>
     <dd>

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -142,6 +142,8 @@
             "node":          "configuration",
             "latitude":      "Latitude",
             "longitude":     "Longitude",
+            "timezone":      "Time Zone",
+            "hostTZ":        "from system settings",
             "sunPositions":  "Custom Sun Positions",
             "angle":         "Angle",
             "riseName":      "Rise Name",

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -20,6 +20,10 @@
             "preserveCtrlProps":  "Preserve control properties in messages",
             "ignoreCtrlProps":    "Ignore control properties in messages"
         },
+        "tooltip":
+        {
+            "offset":  "Offset (in minutes)"
+        },
         "list":
         {
             "sun":

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -114,6 +114,15 @@ SOFTWARE.
             will always be created as it is not known at configuration time, if
             the event will produce an output message or not.
         </dd>
+        <dt>
+        <dt>Output port for event times</dt>
+        <dd>
+            If selected, an additional output port will be added. This output
+            port emits a message whenever the date and time of any of the
+            schedule events is updated. The message contains the timestamp of
+            the next schedule event in <code>msg.payload</code> and an array
+            with timestamps from all schedule events in <code>msg.events</code>.
+        </dd>
         <dt>Start with disabled schedule</dt>
         <dd>
             If selected, the configured schedule will be initially disabled when

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -3,15 +3,17 @@
     {
         "label":
         {
-            "node":         "scheduler",
-            "inputPort":    "enable/disable",
-            "outputPort":   "scheduled message",
-            "schedule":     "Schedule",
-            "output":       "Output",
-            "crontab":      "cron table",
-            "fullMessage":  "full message",
-            "multiPort":    "Dedicated output ports for schedule events",
-            "disabled":     "Start with disabled schedule"
+            "node":           "scheduler",
+            "inputPort":      "enable/disable",
+            "outputPort":     "scheduled message",
+            "eventTimes":     "event times",
+            "schedule":       "Schedule",
+            "output":         "Output",
+            "crontab":        "cron table",
+            "fullMessage":    "full message",
+            "multiPort":      "Dedicated output ports for schedule events",
+            "nextEventPort":  "Output port for event times",
+            "disabled":       "Start with disabled schedule"
         },
         "status":
         {

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -389,7 +389,7 @@ SOFTWARE.
             let until = $("#node-input-until")
                             .typedInput({types: [nextMsgInput, timeInput, sunTimeInput, moonTimeInput, customInput, "jsonata"], typeField: $("#node-input-untilType")});
             let untilOffset = $("#node-input-untilOffset")
-                            .spinner({min: -300, max: 300, step: 5, change: validateInput});
+                            .spinner({min: -300, max: 300, step: 1, change: validateInput});
 
             $("#node-input-intervalUnit").change(function()
             {

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -55,6 +55,11 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else if ((settings.mode == "advanced") && !cronosjs.validate(settings.crontab))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
@@ -62,7 +67,7 @@ module.exports = function(RED)
         }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            chronos.printNodeInfo(node);
             node.status({});
 
             node.mode = settings.mode;
@@ -343,7 +348,7 @@ module.exports = function(RED)
 
                 ret.print = function()
                 {
-                    return this.time.format("YYYY-MM-DD HH:mm:ss");
+                    return this.time.format("YYYY-MM-DD HH:mm:ss (Z)");
                 };
             }
 
@@ -357,7 +362,7 @@ module.exports = function(RED)
 
             if (!untilTime.isExceededAt(node.sendTime))
             {
-                node.debug("Starting timer for repeated message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss"));
+                node.debug("Starting timer for repeated message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
                 node.repeatTimer = setTimeout(() =>
                 {
                     delete node.repeatTimer;
@@ -482,7 +487,7 @@ module.exports = function(RED)
 
             if (!untilTime.isExceededAt(node.sendTime))
             {
-                node.debug("Starting timer for repeated message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss"));
+                node.debug("Starting timer for repeated message at " + node.sendTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
                 node.repeatTimer = setTimeout(() =>
                 {
                     delete node.repeatTimer;

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -97,25 +97,9 @@ module.exports = function(RED)
                 {
                     if (msg)
                     {
-                        if (!send)  // Node-RED 0.x backward compatibility
+                        if (!send || !done)  // Node-RED 0.x not supported anymore
                         {
-                            send = () =>
-                            {
-                                node.send.apply(node, arguments);
-                            };
-                        }
-
-                        if (!done)  // Node-RED 0.x backward compatibility
-                        {
-                            done = () =>
-                            {
-                                var args = [...arguments];
-                                if (args.length > 0)
-                                {
-                                    args.push(msg);
-                                    node.error.apply(node, args);
-                                }
-                            };
+                            return;
                         }
 
                         tearDownRepeatTimer();

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -42,6 +42,10 @@ SOFTWARE.
         <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
     </div>
     <div class="form-row">
+        <input id="node-input-nextEventPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+        <label for="node-input-nextEventPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.nextEventPort"></label>
+    </div>
+    <div class="form-row">
         <input id="node-input-disabled" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
         <label for="node-input-disabled" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.disabled"></label>
     </div>
@@ -70,7 +74,35 @@ SOFTWARE.
         },
         outputLabels: function(index)
         {
-            return (this.schedule[index] ? this.schedule[index].label : this._("scheduler.status.noSchedule")) || this._("scheduler.label.outputPort");
+            if (this.multiPort)
+            {
+                if (this.nextEventPort)
+                {
+                    if (index == (this.outputs - 1))
+                    {
+                        return this._("scheduler.label.eventTimes");
+                    }
+                    else
+                    {
+                        return this.schedule[index] ? this.schedule[index].label : this._("scheduler.status.noSchedule");
+                    }
+                }
+                else
+                {
+                    return this.schedule[index] ? this.schedule[index].label : this._("scheduler.status.noSchedule");
+                }
+            }
+            else
+            {
+                if (this.nextEventPort)
+                {
+                    return (index == 0) ? this._("scheduler.label.outputPort") : this._("scheduler.label.eventTimes");
+                }
+                else
+                {
+                    return this._("scheduler.label.outputPort");
+                }
+            }
         },
         defaults:
         {
@@ -95,6 +127,10 @@ SOFTWARE.
                 }
             },
             multiPort:
+            {
+                value: false
+            },
+            nextEventPort:
             {
                 value: false
             },
@@ -402,6 +438,7 @@ SOFTWARE.
             let node = this;
             let scheduleList = $("#node-input-scheduleList").editableList("items");
             let multiPort = $("#node-input-multiPort").prop("checked");
+            let nextEventPort = $("#node-input-nextEventPort").prop("checked");
 
             node.schedule = [];
             node.outputs = 0;
@@ -482,6 +519,11 @@ SOFTWARE.
 
                 node.schedule.push(data);
             });
+
+            if (nextEventPort)
+            {
+                ++node.outputs;
+            }
         },
         oneditresize: function(size)
         {

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -243,7 +243,7 @@ SOFTWARE.
                     {
                         min: -300,
                         max: 300,
-                        step: 5,
+                        step: 1,
                         change: function(event, ui)
                         {
                             var value = parseInt($(this).spinner("value"), 10);

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -272,7 +272,7 @@ SOFTWARE.
                     triggerType._prevType = "time";
 
                     let offsetBox = $("<div/>", {style: "display: inline-block;"}).appendTo(triggerRow);
-                    let offsetLabel = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.label.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
+                    let offsetLabel = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
                                         .html("<span style='margin-left: 6px; margin-right: 6px;'>&#8597;</span>")
                                         .appendTo(offsetBox);
                     let triggerOffset = $("<input/>", {class: "node-input-triggerOffset", style: "width: 50px !important;"})

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -46,6 +46,11 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else if (settings.schedule.length == 0)
         {
             node.status({fill: "red", shape: "dot", text: "scheduler.status.noSchedule"});
@@ -53,7 +58,7 @@ module.exports = function(RED)
         }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            chronos.printNodeInfo(node);
             node.status({});
 
             node.disabledSchedule = (typeof settings.disabled == "undefined") ? false : settings.disabled;
@@ -576,7 +581,7 @@ module.exports = function(RED)
                         }
                     }
 
-                    node.debug("[Timer:" + data.id + "] Starting timer for trigger at " + data.triggerTime.format("YYYY-MM-DD HH:mm:ss"));
+                    node.debug("[Timer:" + data.id + "] Starting timer for trigger at " + data.triggerTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
                     data.timer = setTimeout(handleTimeout, data.triggerTime.diff(now), data, true);
                 }
 

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -584,6 +584,12 @@ module.exports = function(RED)
                         else
                         {
                             data.triggerTime = chronos.getTime(RED, node, data.triggerTime.add(1, "days"), data.config.trigger.type, data.config.trigger.value);
+
+                            if (data.config.trigger.offset != 0)
+                            {
+                                let offset = data.config.trigger.random ? Math.round(Math.random() * data.config.trigger.offset) : data.config.trigger.offset;
+                                data.triggerTime.add(offset, "minutes");
+                            }
                         }
                     }
 

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -239,25 +239,9 @@ module.exports = function(RED)
 
                 node.on("input", (msg, send, done) =>
                 {
-                    if (!send)  // Node-RED 0.x backward compatibility
+                    if (!send || !done)  // Node-RED 0.x not supported anymore
                     {
-                        send = () =>
-                        {
-                            node.send.apply(node, arguments);
-                        };
-                    }
-
-                    if (!done)  // Node-RED 0.x backward compatibility
-                    {
-                        done = () =>
-                        {
-                            var args = [...arguments];
-                            if (args.length > 0)
-                            {
-                                args.push(msg);
-                                node.error.apply(node, args);
-                            }
-                        };
+                        return;
                     }
 
                     if (typeof msg.payload == "boolean")

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -258,7 +258,7 @@ SOFTWARE.
                     {
                         min: -300,
                         max: 300,
-                        step: 5,
+                        step: 1,
                         change: validateInput
                     };
 

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -330,7 +330,7 @@ SOFTWARE.
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
                                         .appendTo(time1Row2);
-                    let offset1 = $("<input/>", {class: "node-input-offset1", style: "width: 50px !important;"})
+                    let offset1 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset1", style: "width: 50px !important;"})
                                         .appendTo(time1Row2)
                                         .spinner(offsetInput);
                     let random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
@@ -342,7 +342,7 @@ SOFTWARE.
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
                                         .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
                                         .appendTo(time2Row2);
-                    let offset2 = $("<input/>", {class: "node-input-offset2", style: "width: 50px !important;"})
+                    let offset2 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset2", style: "width: 50px !important;"})
                                         .appendTo(time2Row2)
                                         .spinner(offsetInput);
                     let random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -45,6 +45,11 @@ module.exports = function(RED)
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
         }
+        else if (!node.chronos.validateTimeZone(node))
+        {
+            node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
+            node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
+        }
         else if (settings.conditions.length == 0)
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.noConditions"});
@@ -52,7 +57,7 @@ module.exports = function(RED)
         }
         else
         {
-            node.debug("Starting node with configuration '" + node.config.name + "' (latitude " + node.config.latitude + ", longitude " + node.config.longitude + ")");
+            node.chronos.printNodeInfo(node);
             node.status({});
 
             node.baseTime = settings.baseTime;
@@ -122,7 +127,7 @@ module.exports = function(RED)
                         let baseTime = sfUtils.getBaseTime(RED, node, msg);
                         if (baseTime)
                         {
-                            node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss"));
+                            node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
 
                             let ports = [];
 

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -114,25 +114,9 @@ module.exports = function(RED)
                 {
                     if (msg)
                     {
-                        if (!send)  // Node-RED 0.x backward compatibility
+                        if (!send || !done)  // Node-RED 0.x not supported anymore
                         {
-                            send = () =>
-                            {
-                                node.send.apply(node, arguments);
-                            };
-                        }
-
-                        if (!done)  // Node-RED 0.x backward compatibility
-                        {
-                            done = () =>
-                            {
-                                var args = [...arguments];
-                                if (args.length > 0)
-                                {
-                                    args.push(msg);
-                                    node.error.apply(node, args);
-                                }
-                            };
+                            return;
                         }
 
                         let baseTime = sfUtils.getBaseTime(RED, node, msg);

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dependencies": {
         "cronosjs": "^1.7.1",
         "moment": "^2.29.2",
+        "moment-timezone": "^0.5.34",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",

--- a/package.json
+++ b/package.json
@@ -23,20 +23,20 @@
     "bugs": "https://github.com/jensrossbach/node-red-contrib-chronos/issues",
     "dependencies": {
         "cronosjs": "^1.7.1",
-        "moment": "^2.28.0",
+        "moment": "^2.29.2",
         "os-locale": "^5.0.0",
-        "suncalc": "^1.8.0"
+        "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^7.21.0",
-        "mocha": "^8.3.0",
-        "node-red": "^1.3.1",
+        "eslint": "^8.12.0",
+        "mocha": "^9.2.0",
+        "node-red": "^2.2.2",
         "node-red-node-test-helper": "^0.2.7",
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
         "sinon": "^9.2.4",
-        "jsonata": "^1.8.4"
+        "jsonata": "^1.8.6"
     },
     "main": "none",
     "scripts": {
@@ -44,7 +44,11 @@
         "test": "mocha \"test/**/*_spec.js\"",
         "coverage": "nyc --reporter=html npm run test"
     },
+    "engines": {
+        "node": ">=12.0.0"
+    },
     "node-red": {
+        "version": ">=1.0.0",
         "nodes": {
             "chronos-config": "nodes/config.js",
             "chronos-scheduler": "nodes/scheduler.js",

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -72,7 +72,7 @@ describe("chronos", function()
             // fake current time to be deterministic
             sinon.stub(Date, "now").returns(new Date("2000-01-01T00:00:00.000Z"));
 
-            const node = {locale: "en-US"};
+            const node = {locale: "en-US", config: {timezone: ""}};
             const res = chronos.getCurrentTime(node);
 
             res.valueOf().should.equal(946684800000);
@@ -83,7 +83,7 @@ describe("chronos", function()
     {
         it("should return time from string", function()
         {
-            const node = {locale: "en-US"};
+            const node = {locale: "en-US", config: {timezone: ""}};
             const res = chronos.getTimeFrom(node, "2000-01-01T00:00:00.000Z");
 
             res.valueOf().should.equal(946684800000);
@@ -91,7 +91,7 @@ describe("chronos", function()
 
         it("should return time from Unix epoch", function()
         {
-            const node = {locale: "en-US"};
+            const node = {locale: "en-US", config: {timezone: ""}};
             const res = chronos.getTimeFrom(node, 946684800000);
 
             res.valueOf().should.equal(946684800000);
@@ -103,7 +103,7 @@ describe("chronos", function()
         it("should return date from string", function()
         {
             const RED = {"_": () => ""};
-            const node = {locale: "en-US"};
+            const node = {locale: "en-US", config: {timezone: ""}};
             const res = chronos.getUserDate(RED, node, "2000-01-01");
 
             res.year().should.equal(2000);

--- a/test/common/sfutils_spec.js
+++ b/test/common/sfutils_spec.js
@@ -33,7 +33,7 @@ require("should-sinon");
 describe("switch/filter utilities", function()
 {
     const RED = {"_": () => "", util: {}};
-    const node = {chronos: require("../../nodes/common/chronos.js"), debug: function() {}, locale: "UTC"};
+    const node = {chronos: require("../../nodes/common/chronos.js"), debug: function() {}, locale: "UTC", config: {timezone: ""}};
 
     afterEach(function()
     {


### PR DESCRIPTION
### Added
- Added possibility to activate dedicated output port for capturing schedule times of events.
- Added support for user specified time zones per configuration node.
- Added example flows for scheduler node (more will follow in future).

### Changed
- Improved tooltip texts for offset input.
- Updated versions of dependencies where possible.
- Dropped support for Node-RED versions older than 1.0.0.

### Fixed
- Fixed offset not being applied for sun/moon times when scheduled for next day.
- Fixed offset being applied only if dividable by 5.