### PR TITLE
Release 1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.2] - 2022-09-25
+
+### Added
+- Added example flows for time change node.
+
+### Changed
+- Updated versions of dependencies where possible.
+
+### Fixed
+- Listeners for flows-started events in scheduler node are now correctly unregistered on node closing.
+
 ## [1.18.1] - 2022-09-11
 
 ### Added

--- a/examples/time-change/Change message property.json
+++ b/examples/time-change/Change message property.json
@@ -1,0 +1,133 @@
+[
+    {
+        "id": "671609705841dfab",
+        "type": "tab",
+        "label": "Change message property",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "04b2823017743f50",
+        "type": "comment",
+        "z": "671609705841dfab",
+        "name": "",
+        "info": "# Change message propery\nChanges property `msg.payload` several times before sending it to the output by chaining the following change rules:\n1. Sets property to current date and time (numerical timestamp).\n2. Adds one month to the property.\n3. Subtracts three days from the property.\n4. Converts the property from a numerical timestamp to a human readable date-time string.",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "806dd38711a1c66b",
+        "type": "inject",
+        "z": "671609705841dfab",
+        "name": "input message",
+        "props": [
+            {
+                "p": "payload"
+            }
+        ],
+        "repeat": "",
+        "crontab": "",
+        "once": false,
+        "onceDelay": 0.1,
+        "topic": "",
+        "payload": "Change me!",
+        "payloadType": "str",
+        "x": 180,
+        "y": 140,
+        "wires": [
+            [
+                "4f4d3bfdbe4e8ace"
+            ]
+        ]
+    },
+    {
+        "id": "4f4d3bfdbe4e8ace",
+        "type": "chronos-change",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "rules": [
+            {
+                "action": "set",
+                "target": {
+                    "type": "msg",
+                    "name": "payload"
+                },
+                "type": "now"
+            },
+            {
+                "action": "change",
+                "target": {
+                    "type": "msg",
+                    "name": "payload"
+                },
+                "type": "add",
+                "value": 1,
+                "unit": "months"
+            },
+            {
+                "action": "change",
+                "target": {
+                    "type": "msg",
+                    "name": "payload"
+                },
+                "type": "subtract",
+                "value": 3,
+                "unit": "days"
+            },
+            {
+                "action": "change",
+                "target": {
+                    "type": "msg",
+                    "name": "payload"
+                },
+                "type": "toString",
+                "format": "YYYY-MM-DD HH:mm:ss"
+            }
+        ],
+        "x": 360,
+        "y": 140,
+        "wires": [
+            [
+                "ff49410550fef9fa"
+            ]
+        ]
+    },
+    {
+        "id": "ff49410550fef9fa",
+        "type": "debug",
+        "z": "671609705841dfab",
+        "name": "changed message",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 550,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "timezone": "",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -245,7 +245,7 @@ module.exports = function(RED)
             {
                 updateStatus();
 
-                RED.events.on("flows:started", () =>
+                const lazyInit = () =>
                 {
                     if (node.eventTimesPending)
                     {
@@ -254,11 +254,14 @@ module.exports = function(RED)
                     }
 
                     node.initializing = false;
-                });
+                };
+
+                RED.events.on("flows:started", lazyInit);
 
                 node.on("close", () =>
                 {
                     stopTimers();
+                    RED.events.removeListener("flows:started", lazyInit);
                 });
 
                 node.on("input", (msg, send, done) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.18.1",
+    "version": "1.18.2",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -23,20 +23,20 @@
     "bugs": "https://github.com/jensrossbach/node-red-contrib-chronos/issues",
     "dependencies": {
         "cronosjs": "^1.7.1",
-        "moment": "^2.29.2",
-        "moment-timezone": "^0.5.34",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.37",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^8.12.0",
-        "mocha": "^9.2.0",
-        "node-red": "^2.2.2",
-        "node-red-node-test-helper": "^0.2.7",
+        "eslint": "^8.24.0",
+        "mocha": "^10.0.0",
+        "node-red": "^3.0.2",
+        "node-red-node-test-helper": "^0.3.0",
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^9.2.4",
+        "sinon": "^14.0.0",
         "jsonata": "^1.8.6"
     },
     "main": "none",

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -363,7 +363,6 @@ describe("chronos", function()
             sinon.stub(sunCalc, "getMoonTimes").returns({"rise": new Date("2000-01-01T22:00:00.000Z")});
 
             let res = chronos.getTime(RED, node, moment(), "moon", "rise");
-            console.log(res.format());
             res.utcOffset().should.equal(240);  // +4h
             res.utc();
             res.year().should.equal(2000);


### PR DESCRIPTION
### Added
- Added example flows for time change node.

### Changed
- Updated versions of dependencies where possible.

### Fixed
- Listeners for flows-started events in scheduler node are now correctly unregistered on node closing.