### PR TITLE
Release 1.18.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.18.3] - 2022-10-30
+
+### Changed
+- Updated versions of some development dependencies (used for unit testing).
+
+### Fixed
+- Fixed non-working time zone shift for sun/moon time calculation.
+- Listeners for flows-started events in scheduler node are now only registered if next event time option is activated and immediately unregistered upon receiving event.
+
 ## [1.18.2] - 2022-09-25
 
 ### Added

--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -213,7 +213,7 @@ function getSunTime(RED, node, day, type)
         {
             if (node.config.timezone)
             {
-                ret.tz(node.config.timezone, true);
+                ret.tz(node.config.timezone);
             }
 
             ret.locale(node.locale);
@@ -244,7 +244,7 @@ function getMoonTime(RED, node, day, type)
         {
             if (node.config.timezone)
             {
-                ret.tz(node.config.timezone, true);
+                ret.tz(node.config.timezone);
             }
 
             ret.locale(node.locale);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.18.2",
+    "version": "1.18.3",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -30,14 +30,14 @@
     },
     "devDependencies": {
         "eslint": "^8.24.0",
+        "jsonata": "^1.8.6",
         "mocha": "^10.0.0",
         "node-red": "^3.0.2",
         "node-red-node-test-helper": "^0.3.0",
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^14.0.0",
-        "jsonata": "^1.8.6"
+        "sinon": "^14.0.0"
     },
     "main": "none",
     "scripts": {

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -293,10 +293,10 @@ describe("chronos", function()
 
             let res = chronos.getTime(RED, node, moment(), "sun", "sunrise");
             res.utcOffset().should.equal(240);  // +4h
-            res.utc();
             res.year().should.equal(2000);
             res.month().should.equal(0);
             res.date().should.equal(1);
+            res.hour().should.equal(12);
             res.minute().should.equal(0);
             res.second().should.equal(0);
         });
@@ -360,14 +360,14 @@ describe("chronos", function()
         {
             const RED = {"_": () => ""};
             const node = {locale: "en-US", config: {latitude: 0, longitude: 0, timezone: "Asia/Dubai"}};
-            sinon.stub(sunCalc, "getMoonTimes").returns({"rise": new Date("2000-01-01T22:00:00.000Z")});
+            sinon.stub(sunCalc, "getMoonTimes").returns({"rise": new Date("2000-01-01T18:00:00.000Z")});
 
             let res = chronos.getTime(RED, node, moment(), "moon", "rise");
             res.utcOffset().should.equal(240);  // +4h
-            res.utc();
             res.year().should.equal(2000);
             res.month().should.equal(0);
             res.date().should.equal(1);
+            res.hour().should.equal(22);
             res.minute().should.equal(0);
             res.second().should.equal(0);
         });


### PR DESCRIPTION
### Changed
- Updated versions of some development dependencies (used for unit testing).

### Fixed
- Fixed non-working time zone shift for sun/moon time calculation.
- Listeners for flows-started events in scheduler node are now only registered if next event time option is activated and immediately unregistered upon receiving event.