### PR TITLE
Possibility to retrieve location coordinates from ENV variables

### DIFF
--- a/nodes/config.html
+++ b/nodes/config.html
@@ -31,11 +31,13 @@ SOFTWARE.
         <div style="display: inline-block; width: auto; vertical-align: middle;">
             <div>
                 <label for="node-config-input-latitude"><i class="fa fa-map-marker"></i> <span data-i18n="config.label.latitude"></span></label>
-                <input id="node-config-input-latitude" data-i18n="[placeholder]config.label.latitude">
+                <input type="text" id="node-config-input-latitude" style="width: 60%;">
+                <input id="node-config-input-latitudeType" type="hidden">
             </div>
             <div style="margin-top: 12px;">
                 <label for="node-config-input-longitude"><i class="fa fa-map-marker"></i> <span data-i18n="config.label.longitude"></span></label>
-                <input id="node-config-input-longitude" data-i18n="[placeholder]config.label.longitude">
+                <input type="text" id="node-config-input-longitude" style="width: 60%;">
+                <input id="node-config-input-longitudeType" type="hidden">
             </div>
         </div>
         <div style="display: inline-block; width: auto; margin-left: 10px;">
@@ -71,6 +73,14 @@ SOFTWARE.
             name:
             {
                 value: ""
+            },
+            latitudeType:
+            {
+                value: "num"
+            },
+            longitudeType:
+            {
+                value: "num"
             },
             timezone:
             {
@@ -143,19 +153,23 @@ SOFTWARE.
 
             const updateMap = function()
             {
-                let latitude = parseFloat($("#node-config-input-latitude").spinner("value"));
-                let longitude = parseFloat($("#node-config-input-longitude").spinner("value"));
-
-                if (!Number.isNaN(latitude) && !Number.isNaN(longitude))
+                if (($("#node-config-input-latitude").typedInput("type") == "num") &&
+                    ($("#node-config-input-longitude").typedInput("type") == "num"))
                 {
-                    $("#node-config-input-map").attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
-                                                            + (longitude - 0.001) + ","
-                                                            + (latitude - 0.001) + ","
-                                                            + (longitude + 0.001) + ","
-                                                            + (latitude + 0.001)
-                                                            + "&layer=mapnik&marker="
-                                                            + latitude + ","
-                                                            + longitude);
+                    let latitude = parseFloat($("#node-config-input-latitude").typedInput("value"));
+                    let longitude = parseFloat($("#node-config-input-longitude").typedInput("value"));
+
+                    if (!Number.isNaN(latitude) && !Number.isNaN(longitude))
+                    {
+                        $("#node-config-input-map").attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
+                                                                + (longitude - 0.001) + ","
+                                                                + (latitude - 0.001) + ","
+                                                                + (longitude + 0.001) + ","
+                                                                + (latitude + 0.001)
+                                                                + "&layer=mapnik&marker="
+                                                                + latitude + ","
+                                                                + longitude);
+                    }
                 }
             };
 
@@ -184,24 +198,6 @@ SOFTWARE.
                 updateMap();
             };
 
-            const latitudeInput =
-            {
-                min: -90,
-                max: 90,
-                step: 0.000001,
-                numberFormat: "n",
-                change: validateInput
-            };
-
-            const longitudeInput =
-            {
-                min: -180,
-                max: 180,
-                step: 0.000001,
-                numberFormat: "n",
-                change: validateInput
-            };
-
             const sunAngleInput =
             {
                 min: -90,
@@ -217,8 +213,11 @@ SOFTWARE.
                 {
                     navigator.geolocation.getCurrentPosition(pos =>
                     {
-                        $("#node-config-input-latitude").spinner("value", pos.coords.latitude);
-                        $("#node-config-input-longitude").spinner("value", pos.coords.longitude);
+                        $("#node-config-input-latitude").typedInput("value", pos.coords.latitude);
+                        $("#node-config-input-longitude").typedInput("value", pos.coords.longitude);
+                        $("#node-config-input-latitude").typedInput("type", "num");
+                        $("#node-config-input-longitude").typedInput("type", "num");
+
                         updateMap();
                     });
                 });
@@ -228,8 +227,11 @@ SOFTWARE.
                 $("#node-config-input-locationDetection").hide();
             }
 
-            $("#node-config-input-latitude").spinner(latitudeInput);
-            $("#node-config-input-longitude").spinner(longitudeInput);
+            let latitude = $("#node-config-input-latitude")
+                            .typedInput({types: ["num", "env"], typeField: "#node-config-input-latitudeType"});
+            let longitude = $("#node-config-input-longitude")
+                            .typedInput({types: ["num", "env"], typeField: "#node-config-input-longitudeType"});
+
             updateMap();
 
             let sunPositionList = $("#node-input-sunPositionList").css("min-width", "500px").css("min-height", "150px").editableList(
@@ -267,6 +269,32 @@ SOFTWARE.
                     setName.val(data.setName);
 
                     item[0].appendChild(fragment);
+                }
+            });
+
+            latitude.on("change", function(event, type, value)
+            {
+                if ((type == "num") && (longitude.typedInput("type") == "num"))
+                {
+                    updateMap();
+                    $("#node-config-input-map").show();
+                }
+                else if (type == "env")
+                {
+                    $("#node-config-input-map").hide();
+                }
+            });
+
+            longitude.on("change", function(event, type, value)
+            {
+                if ((type == "num") && (latitude.typedInput("type") == "num"))
+                {
+                    updateMap();
+                    $("#node-config-input-map").show();
+                }
+                else if (type == "env")
+                {
+                    $("#node-config-input-map").hide();
                 }
             });
 

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -32,8 +32,32 @@ module.exports = function(RED)
 
         this.name = config.name;
         this.timezone = config.timezone;
-        this.latitude = parseFloat(this.credentials.latitude);
-        this.longitude = parseFloat(this.credentials.longitude);
+
+        if (config.latitudeType === "env")
+        {
+            this.latitude = parseFloat(
+                                RED.util.evaluateNodeProperty(
+                                            this.credentials.latitude,
+                                            config.latitudeType,
+                                            this));
+        }
+        else
+        {
+            this.latitude = parseFloat(this.credentials.latitude);
+        }
+
+        if (config.longitudeType === "env")
+        {
+            this.longitude = parseFloat(
+                                RED.util.evaluateNodeProperty(
+                                            this.credentials.longitude,
+                                            config.longitudeType,
+                                            this));
+        }
+        else
+        {
+            this.longitude = parseFloat(this.credentials.longitude);
+        }
 
         if (validateCustomTimes(config.sunPositions))
         {

--- a/nodes/locales/de/config.html
+++ b/nodes/locales/de/config.html
@@ -52,11 +52,13 @@ SOFTWARE.
     </dd>
     <dt>Breitengrad</dt>
     <dd>
-        Der Breitengrad als Dezimalzahl zwischen -90° und 90°.
+        Der Breitengrad als Dezimalzahl zwischen -90° und 90° oder der Name
+        einer Umgebungsvariable, die den Breitengrad enthält.
     </dd>
     <dt>Längengrad</dt>
     <dd>
-        Der Längengrad als Dezimalzahl zwischen -180° und 180°.
+        Der Längengrad als Dezimalzahl zwischen -180° und 180° oder der Name
+        einer Umgebungsvariable, die den Längengrad enthält.
     </dd>
     <dt>Lokalisierung</dt>
     <dd>

--- a/nodes/locales/en-US/config.html
+++ b/nodes/locales/en-US/config.html
@@ -50,11 +50,13 @@ SOFTWARE.
     </dd>
     <dt>Latitude</dt>
     <dd>
-        The latitude as floating point value between -90° and 90°.
+        The latitude as floating point value between -90° and 90° or the name
+        of an environment variable containing the latitude.
     </dd>
     <dt>Longitude</dt>
     <dd>
-        The longitude as floating point value between -180° and 180°.
+        The longitude as floating point value between -180° and 180° or the name
+        of an environment variable containing the longitude.
     </dd>
     <dt>Location Detection</dt>
     <dd>


### PR DESCRIPTION
This pull request adds a new feature that allows to retrieve the location coordinates (latitude and longitude) in configuration nodes from environment variables. This can be done by selecting the environment input instead of the number input.

**Note:**
Due to the new input possibilities, the coordinate input fields are no longer spinner fields.