### PR TITLE
Support base time for time switch/filter node as datetime string

### DIFF
--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -874,7 +874,7 @@ function getBaseTime(RED, node, msg)
             }
         }
 
-        if (typeof value == "number")
+        if ((typeof value == "number") || (typeof value == "string"))
         {
             ret = node.chronos.getTimeFrom(node, value);
         }

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -56,15 +56,24 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
+                    eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>flow</i>: Zeitstempel aus einer Flow-Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit
+                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -58,15 +58,24 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
+                    eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>flow</i>: Zeitstempel aus einer Flow-Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit
+                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -54,15 +54,21 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch.
+                    of milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -54,15 +54,21 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch.
+                    of milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
             </ul>
         </dd>


### PR DESCRIPTION
This pull request adds a new feature that allows to provide the basetime for time switch and filter nodes as datetime strings in context variables and message properties additionally to Unix epoch timestamps.