### PR TITLE
Add conversion to ISO string shortcuts to change node

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -230,18 +230,32 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };
 
-                    const formatInput =
+                    const customFormatInput =
                     {
-                        value: "format",
-                        label: node._("change.label.format"),
-                        icon: "fa fa-gears",
+                        value: "custom",
+                        label: node._("change.label.customFormat"),
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^.+$/
+                    };
+
+                    const iso8601FormatInput =
+                    {
+                        value: "iso8601",
+                        label: node._("change.label.iso8601Format"),
+                        hasValue: false
+                    };
+
+                    const iso8601UTCFormatInput =
+                    {
+                        value: "iso8601utc",
+                        label: node._("change.label.iso8601UTCFormat"),
+                        hasValue: false
                     };
 
                     const partInput =
@@ -350,9 +364,9 @@ SOFTWARE.
                                         .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
                                         .appendTo(startEndOfBox);
 
-                    let stringFormat = $("<input/>", {type: "text", class: "node-input-stringFormat", title: node._("change.label.format"), placeholder: "YYYY-MM-DD HH:mm:ss"})
+                    let stringFormat = $("<input/>", {type: "text", class: "node-input-stringFormat", title: node._("change.label.format"), placeholder: node._("change.label.formatPlaceholder")})
                                         .appendTo(toStringBox)
-                                        .typedInput({types: [formatInput]});
+                                        .typedInput({types: [customFormatInput, iso8601FormatInput, iso8601UTCFormatInput]});
                     stringFormat.typedInput("width", "280px");
 
                     action.change(function()
@@ -546,6 +560,11 @@ SOFTWARE.
                         }
                         else if (data.type == "toString")
                         {
+                            if (data.formatType)
+                            {
+                                stringFormat.typedInput("type", data.formatType);
+                            }
+
                             stringFormat.typedInput("value", data.format);
                         }
                         changeType.val(data.type);
@@ -626,6 +645,7 @@ SOFTWARE.
                     }
                     else if (data.type == "toString")
                     {
+                        data.formatType = stringFormat.typedInput("type");
                         data.format = stringFormat.typedInput("value");
                     }
                 }

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -78,7 +78,11 @@ module.exports = function(RED)
                         break;
                     }
                 }
-                else if ((rule.action == "change") && (rule.type == "toString") && !rule.format)
+                else if (
+                    (rule.action == "change") &&
+                    (rule.type == "toString") &&
+                    ((rule.formatType == "custom") || !rule.formatType) &&
+                    !rule.format)
                 {
                     valid = false;
                     break;
@@ -247,7 +251,20 @@ module.exports = function(RED)
                                             }
                                             case "toString":
                                             {
-                                                output = input.format(rule.format);
+                                                if ((rule.formatType == "custom") ||
+                                                    !rule.formatType)  // backward compatibility to v1.19.1 and below
+                                                {
+                                                    output = input.format(rule.format);
+                                                }
+                                                else if (rule.formatType == "iso8601")
+                                                {
+                                                    output = input.toISOString(true);
+                                                }
+                                                else if (rule.formatType == "iso8601utc")
+                                                {
+                                                    output = input.toISOString();
+                                                }
+
                                                 break;
                                             }
                                         }

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -405,7 +405,7 @@ SOFTWARE.
             {
                 value: "custom",
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                icon: "fa fa-wrench",
+                icon: "fa fa-user-o",
                 hasValue: true,
                 validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
             };

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -267,7 +267,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -148,11 +148,14 @@ SOFTWARE.
                     </li>
                     <li>
                         <i>Konvertieren</i>: Konvertiert den Zeitstempel des
-                        Ziels in eine Zeichenkettenrepräsentation. Das Format
-                        der Zeichnkette kann über das Texteingabefeld
-                        angegeben werden und muss den Regeln von
-                        <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
-                        entsprechen.
+                        Ziels in eine Zeichenkettenrepräsentation. Wenn
+                        <i>Benutzerdef. Format</i> ausgewählt wurde, wird das
+                        Format der Zeichnkette über das Texteingabefeld
+                        angegeben und muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
+                        entsprechen. Es kann auch eine der beiden ISO-String
+                        Optionen ausgewählt werden um in einen ISO-8601
+                        String in lokaler (entsprechend der konfigurierten
+                        Zeitzone) oder UTC Zeit zu konvertieren.
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -3,12 +3,16 @@
     {
         "label":
         {
-            "node":    "Änderung",
-            "rules":   "Änderungsregeln",
-            "to":      "auf",
-            "now":     "Aktuelle Zeit",
-            "date":    "Datum & Uhrzeit",
-            "format":  "Format"
+            "node":               "Änderung",
+            "rules":              "Änderungsregeln",
+            "to":                 "auf",
+            "now":                "Aktuelle Zeit",
+            "date":               "Datum & Uhrzeit",
+            "format":             "Format",
+            "customFormat":       "Benutzerdef. Format",
+            "iso8601Format":      "ISO-8601 String",
+            "iso8601UTCFormat":   "ISO-8601 String (UTC)",
+            "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
         {

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -144,9 +144,12 @@ SOFTWARE.
                     </li>
                     <li>
                         <i>Convert</i>: Converts the target timestamp to a
-                        string representation. The format of the string is
-                        specified via the text box and must follow the rules
-                        from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                        string representation. If <i>custom format</i> is
+                        selected, the format of the string is specified via the
+                        text box and must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                        It's also possible to select one of the ISO string
+                        options to convert into ISO-8601 strings either in local
+                        (according to the configured time zone) or UTC time.
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -3,12 +3,16 @@
     {
         "label":
         {
-            "node":    "time change",
-            "rules":   "Change Rules",
-            "to":      "to",
-            "now":     "current time",
-            "date":    "date & time",
-            "format":  "Format"
+            "node":               "time change",
+            "rules":              "Change Rules",
+            "to":                 "to",
+            "now":                "current time",
+            "date":               "date & time",
+            "format":             "Format",
+            "customFormat":       "custom format",
+            "iso8601Format":      "ISO-8601 string",
+            "iso8601UTCFormat":   "ISO-8601 string (UTC)",
+            "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
         {

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -372,7 +372,7 @@ SOFTWARE.
             {
                 value: "custom",
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                icon: "fa fa-wrench",
+                icon: "fa fa-user-o",
                 hasValue: true,
                 validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
             };

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -254,7 +254,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]+$/
                     };

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -233,7 +233,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };


### PR DESCRIPTION
This pull request adds a feature that extends the convert rule in time change nodes to generate ISO-8601 strings easily by selecting the appropriate entry from the dropdown menu.

Additionally, the icons for custom / user specific data have been changed from a wrench to a user symbol.