### PR TITLE
Release 1.20

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,7 +1,7 @@
 # Action for quality assurance (checking code with ESLint and running unit tests)
 name: Quality Assurance
 
-# Trigger workflow on pushes to master including Javascript files and any pull requests for master
+# Trigger workflow on pushes to main including Javascript files and any pull requests for main
 on:
   push:
     branches: [ main ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.20.0] - 2024-02-03
+### Added
+- Added possibility to retrieve location coordinates (latitude and longitude) in configuration from environment variables.
+- Added possibility to specify basetimes for time switch/filter nodes from context variables or message properties as datetime strings additionally to Unix epoch timestamps.
+- Added dropdown menu to convert rule of time change node that allows to easily create ISO-8601 strings.
+- Added more properties accessible to JSONata expressions of scheduler node output configurations.
+
+### Changed
+- Changed icons for custom / user defined data from wrench to user symbol.
+- Updated versions of dependencies where possible.
+
+### Fixed
+- Fixed references to old default branch name.
+
 ## [1.19.1] - 2024-01-28
 ### Changed
 - Replaced usage of deprecated synchronous variant of `RED.util.evaluateJSONataExpression` by asynchronous variant as synchronous variant will not work anymore starting with Node-RED 4.0.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 A collection of Node-RED nodes for date and time based scheduling, repeating, queueing, routing, filtering and manipulating. Automatically calculated times from sun events (sunrise, sunset, dusk, dawn, ...) or moon events (moonrise, moonset) are supported as well.
 
-If you encountered a bug, would like to propose a new feature or simply want to share your opinion about the software, please have a look at the [contribution guide](https://github.com/jensrossbach/node-red-contrib-chronos/blob/master/CONTRIBUTING.md) on the GitHub repository to learn more about how to contribute to this project. If you need help or have questions, please check out the [instructions for getting support](https://github.com/jensrossbach/node-red-contrib-chronos/blob/master/SUPPORT.md).
+If you encountered a bug, would like to propose a new feature or simply want to share your opinion about the software, please have a look at the [contribution guide](https://github.com/jensrossbach/node-red-contrib-chronos/blob/main/CONTRIBUTING.md) on the GitHub repository to learn more about how to contribute to this project. If you need help or have questions, please check out the [instructions for getting support](https://github.com/jensrossbach/node-red-contrib-chronos/blob/main/SUPPORT.md).
 
-To see what has changed in recent versions of the software, please have a look at the project's [change log](https://github.com/jensrossbach/node-red-contrib-chronos/blob/master/CHANGELOG.md).
+To see what has changed in recent versions of the software, please have a look at the project's [change log](https://github.com/jensrossbach/node-red-contrib-chronos/blob/main/CHANGELOG.md).
 
 #### Scheduler
 Schedules the transmission of messages or setting of global/flow variables at specific times.

--- a/nodes/change.html
+++ b/nodes/change.html
@@ -230,18 +230,32 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };
 
-                    const formatInput =
+                    const customFormatInput =
                     {
-                        value: "format",
-                        label: node._("change.label.format"),
-                        icon: "fa fa-gears",
+                        value: "custom",
+                        label: node._("change.label.customFormat"),
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^.+$/
+                    };
+
+                    const iso8601FormatInput =
+                    {
+                        value: "iso8601",
+                        label: node._("change.label.iso8601Format"),
+                        hasValue: false
+                    };
+
+                    const iso8601UTCFormatInput =
+                    {
+                        value: "iso8601utc",
+                        label: node._("change.label.iso8601UTCFormat"),
+                        hasValue: false
                     };
 
                     const partInput =
@@ -350,9 +364,9 @@ SOFTWARE.
                                         .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
                                         .appendTo(startEndOfBox);
 
-                    let stringFormat = $("<input/>", {type: "text", class: "node-input-stringFormat", title: node._("change.label.format"), placeholder: "YYYY-MM-DD HH:mm:ss"})
+                    let stringFormat = $("<input/>", {type: "text", class: "node-input-stringFormat", title: node._("change.label.format"), placeholder: node._("change.label.formatPlaceholder")})
                                         .appendTo(toStringBox)
-                                        .typedInput({types: [formatInput]});
+                                        .typedInput({types: [customFormatInput, iso8601FormatInput, iso8601UTCFormatInput]});
                     stringFormat.typedInput("width", "280px");
 
                     action.change(function()
@@ -546,6 +560,11 @@ SOFTWARE.
                         }
                         else if (data.type == "toString")
                         {
+                            if (data.formatType)
+                            {
+                                stringFormat.typedInput("type", data.formatType);
+                            }
+
                             stringFormat.typedInput("value", data.format);
                         }
                         changeType.val(data.type);
@@ -626,6 +645,7 @@ SOFTWARE.
                     }
                     else if (data.type == "toString")
                     {
+                        data.formatType = stringFormat.typedInput("type");
                         data.format = stringFormat.typedInput("value");
                     }
                 }

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -78,7 +78,11 @@ module.exports = function(RED)
                         break;
                     }
                 }
-                else if ((rule.action == "change") && (rule.type == "toString") && !rule.format)
+                else if (
+                    (rule.action == "change") &&
+                    (rule.type == "toString") &&
+                    ((rule.formatType == "custom") || !rule.formatType) &&
+                    !rule.format)
                 {
                     valid = false;
                     break;
@@ -247,7 +251,20 @@ module.exports = function(RED)
                                             }
                                             case "toString":
                                             {
-                                                output = input.format(rule.format);
+                                                if ((rule.formatType == "custom") ||
+                                                    !rule.formatType)  // backward compatibility to v1.19.1 and below
+                                                {
+                                                    output = input.format(rule.format);
+                                                }
+                                                else if (rule.formatType == "iso8601")
+                                                {
+                                                    output = input.toISOString(true);
+                                                }
+                                                else if (rule.formatType == "iso8601utc")
+                                                {
+                                                    output = input.toISOString();
+                                                }
+
                                                 break;
                                             }
                                         }

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -874,7 +874,7 @@ function getBaseTime(RED, node, msg)
             }
         }
 
-        if (typeof value == "number")
+        if ((typeof value == "number") || (typeof value == "string"))
         {
             ret = node.chronos.getTimeFrom(node, value);
         }

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -31,11 +31,13 @@ SOFTWARE.
         <div style="display: inline-block; width: auto; vertical-align: middle;">
             <div>
                 <label for="node-config-input-latitude"><i class="fa fa-map-marker"></i> <span data-i18n="config.label.latitude"></span></label>
-                <input id="node-config-input-latitude" data-i18n="[placeholder]config.label.latitude">
+                <input type="text" id="node-config-input-latitude" style="width: 60%;">
+                <input id="node-config-input-latitudeType" type="hidden">
             </div>
             <div style="margin-top: 12px;">
                 <label for="node-config-input-longitude"><i class="fa fa-map-marker"></i> <span data-i18n="config.label.longitude"></span></label>
-                <input id="node-config-input-longitude" data-i18n="[placeholder]config.label.longitude">
+                <input type="text" id="node-config-input-longitude" style="width: 60%;">
+                <input id="node-config-input-longitudeType" type="hidden">
             </div>
         </div>
         <div style="display: inline-block; width: auto; margin-left: 10px;">
@@ -71,6 +73,14 @@ SOFTWARE.
             name:
             {
                 value: ""
+            },
+            latitudeType:
+            {
+                value: "num"
+            },
+            longitudeType:
+            {
+                value: "num"
             },
             timezone:
             {
@@ -143,19 +153,23 @@ SOFTWARE.
 
             const updateMap = function()
             {
-                let latitude = parseFloat($("#node-config-input-latitude").spinner("value"));
-                let longitude = parseFloat($("#node-config-input-longitude").spinner("value"));
-
-                if (!Number.isNaN(latitude) && !Number.isNaN(longitude))
+                if (($("#node-config-input-latitude").typedInput("type") == "num") &&
+                    ($("#node-config-input-longitude").typedInput("type") == "num"))
                 {
-                    $("#node-config-input-map").attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
-                                                            + (longitude - 0.001) + ","
-                                                            + (latitude - 0.001) + ","
-                                                            + (longitude + 0.001) + ","
-                                                            + (latitude + 0.001)
-                                                            + "&layer=mapnik&marker="
-                                                            + latitude + ","
-                                                            + longitude);
+                    let latitude = parseFloat($("#node-config-input-latitude").typedInput("value"));
+                    let longitude = parseFloat($("#node-config-input-longitude").typedInput("value"));
+
+                    if (!Number.isNaN(latitude) && !Number.isNaN(longitude))
+                    {
+                        $("#node-config-input-map").attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
+                                                                + (longitude - 0.001) + ","
+                                                                + (latitude - 0.001) + ","
+                                                                + (longitude + 0.001) + ","
+                                                                + (latitude + 0.001)
+                                                                + "&layer=mapnik&marker="
+                                                                + latitude + ","
+                                                                + longitude);
+                    }
                 }
             };
 
@@ -184,24 +198,6 @@ SOFTWARE.
                 updateMap();
             };
 
-            const latitudeInput =
-            {
-                min: -90,
-                max: 90,
-                step: 0.000001,
-                numberFormat: "n",
-                change: validateInput
-            };
-
-            const longitudeInput =
-            {
-                min: -180,
-                max: 180,
-                step: 0.000001,
-                numberFormat: "n",
-                change: validateInput
-            };
-
             const sunAngleInput =
             {
                 min: -90,
@@ -217,8 +213,11 @@ SOFTWARE.
                 {
                     navigator.geolocation.getCurrentPosition(pos =>
                     {
-                        $("#node-config-input-latitude").spinner("value", pos.coords.latitude);
-                        $("#node-config-input-longitude").spinner("value", pos.coords.longitude);
+                        $("#node-config-input-latitude").typedInput("value", pos.coords.latitude);
+                        $("#node-config-input-longitude").typedInput("value", pos.coords.longitude);
+                        $("#node-config-input-latitude").typedInput("type", "num");
+                        $("#node-config-input-longitude").typedInput("type", "num");
+
                         updateMap();
                     });
                 });
@@ -228,8 +227,11 @@ SOFTWARE.
                 $("#node-config-input-locationDetection").hide();
             }
 
-            $("#node-config-input-latitude").spinner(latitudeInput);
-            $("#node-config-input-longitude").spinner(longitudeInput);
+            let latitude = $("#node-config-input-latitude")
+                            .typedInput({types: ["num", "env"], typeField: "#node-config-input-latitudeType"});
+            let longitude = $("#node-config-input-longitude")
+                            .typedInput({types: ["num", "env"], typeField: "#node-config-input-longitudeType"});
+
             updateMap();
 
             let sunPositionList = $("#node-input-sunPositionList").css("min-width", "500px").css("min-height", "150px").editableList(
@@ -267,6 +269,32 @@ SOFTWARE.
                     setName.val(data.setName);
 
                     item[0].appendChild(fragment);
+                }
+            });
+
+            latitude.on("change", function(event, type, value)
+            {
+                if ((type == "num") && (longitude.typedInput("type") == "num"))
+                {
+                    updateMap();
+                    $("#node-config-input-map").show();
+                }
+                else if (type == "env")
+                {
+                    $("#node-config-input-map").hide();
+                }
+            });
+
+            longitude.on("change", function(event, type, value)
+            {
+                if ((type == "num") && (latitude.typedInput("type") == "num"))
+                {
+                    updateMap();
+                    $("#node-config-input-map").show();
+                }
+                else if (type == "env")
+                {
+                    $("#node-config-input-map").hide();
                 }
             });
 

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -32,8 +32,32 @@ module.exports = function(RED)
 
         this.name = config.name;
         this.timezone = config.timezone;
-        this.latitude = parseFloat(this.credentials.latitude);
-        this.longitude = parseFloat(this.credentials.longitude);
+
+        if (config.latitudeType === "env")
+        {
+            this.latitude = parseFloat(
+                                RED.util.evaluateNodeProperty(
+                                            this.credentials.latitude,
+                                            config.latitudeType,
+                                            this));
+        }
+        else
+        {
+            this.latitude = parseFloat(this.credentials.latitude);
+        }
+
+        if (config.longitudeType === "env")
+        {
+            this.longitude = parseFloat(
+                                RED.util.evaluateNodeProperty(
+                                            this.credentials.longitude,
+                                            config.longitudeType,
+                                            this));
+        }
+        else
+        {
+            this.longitude = parseFloat(this.credentials.longitude);
+        }
 
         if (validateCustomTimes(config.sunPositions))
         {

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -405,7 +405,7 @@ SOFTWARE.
             {
                 value: "custom",
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                icon: "fa fa-wrench",
+                icon: "fa fa-user-o",
                 hasValue: true,
                 validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
             };

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -267,7 +267,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -148,11 +148,14 @@ SOFTWARE.
                     </li>
                     <li>
                         <i>Konvertieren</i>: Konvertiert den Zeitstempel des
-                        Ziels in eine Zeichenkettenrepräsentation. Das Format
-                        der Zeichnkette kann über das Texteingabefeld
-                        angegeben werden und muss den Regeln von
-                        <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
-                        entsprechen.
+                        Ziels in eine Zeichenkettenrepräsentation. Wenn
+                        <i>Benutzerdef. Format</i> ausgewählt wurde, wird das
+                        Format der Zeichnkette über das Texteingabefeld
+                        angegeben und muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
+                        entsprechen. Es kann auch eine der beiden ISO-String
+                        Optionen ausgewählt werden um in einen ISO-8601
+                        String in lokaler (entsprechend der konfigurierten
+                        Zeitzone) oder UTC Zeit zu konvertieren.
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -3,12 +3,16 @@
     {
         "label":
         {
-            "node":    "Änderung",
-            "rules":   "Änderungsregeln",
-            "to":      "auf",
-            "now":     "Aktuelle Zeit",
-            "date":    "Datum & Uhrzeit",
-            "format":  "Format"
+            "node":               "Änderung",
+            "rules":              "Änderungsregeln",
+            "to":                 "auf",
+            "now":                "Aktuelle Zeit",
+            "date":               "Datum & Uhrzeit",
+            "format":             "Format",
+            "customFormat":       "Benutzerdef. Format",
+            "iso8601Format":      "ISO-8601 String",
+            "iso8601UTCFormat":   "ISO-8601 String (UTC)",
+            "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
         {

--- a/nodes/locales/de/config.html
+++ b/nodes/locales/de/config.html
@@ -52,11 +52,13 @@ SOFTWARE.
     </dd>
     <dt>Breitengrad</dt>
     <dd>
-        Der Breitengrad als Dezimalzahl zwischen -90° und 90°.
+        Der Breitengrad als Dezimalzahl zwischen -90° und 90° oder der Name
+        einer Umgebungsvariable, die den Breitengrad enthält.
     </dd>
     <dt>Längengrad</dt>
     <dd>
-        Der Längengrad als Dezimalzahl zwischen -180° und 180°.
+        Der Längengrad als Dezimalzahl zwischen -180° und 180° oder der Name
+        einer Umgebungsvariable, die den Längengrad enthält.
     </dd>
     <dt>Lokalisierung</dt>
     <dd>

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -56,15 +56,24 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
+                    eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>flow</i>: Zeitstempel aus einer Flow-Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit
+                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -58,15 +58,24 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
+                    eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>flow</i>: Zeitstempel aus einer Flow-Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit
+                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
                 <li>
                     <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung.
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
+                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
+                    geparst werden kann.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -144,9 +144,12 @@ SOFTWARE.
                     </li>
                     <li>
                         <i>Convert</i>: Converts the target timestamp to a
-                        string representation. The format of the string is
-                        specified via the text box and must follow the rules
-                        from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                        string representation. If <i>custom format</i> is
+                        selected, the format of the string is specified via the
+                        text box and must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                        It's also possible to select one of the ISO string
+                        options to convert into ISO-8601 strings either in local
+                        (according to the configured time zone) or UTC time.
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -3,12 +3,16 @@
     {
         "label":
         {
-            "node":    "time change",
-            "rules":   "Change Rules",
-            "to":      "to",
-            "now":     "current time",
-            "date":    "date & time",
-            "format":  "Format"
+            "node":               "time change",
+            "rules":              "Change Rules",
+            "to":                 "to",
+            "now":                "current time",
+            "date":               "date & time",
+            "format":             "Format",
+            "customFormat":       "custom format",
+            "iso8601Format":      "ISO-8601 string",
+            "iso8601UTCFormat":   "ISO-8601 string (UTC)",
+            "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
         {

--- a/nodes/locales/en-US/config.html
+++ b/nodes/locales/en-US/config.html
@@ -50,11 +50,13 @@ SOFTWARE.
     </dd>
     <dt>Latitude</dt>
     <dd>
-        The latitude as floating point value between -90° and 90°.
+        The latitude as floating point value between -90° and 90° or the name
+        of an environment variable containing the latitude.
     </dd>
     <dt>Longitude</dt>
     <dd>
-        The longitude as floating point value between -180° and 180°.
+        The longitude as floating point value between -180° and 180° or the name
+        of an environment variable containing the longitude.
     </dd>
     <dt>Location Detection</dt>
     <dd>

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -54,15 +54,21 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch.
+                    of milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
             </ul>
         </dd>

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -54,15 +54,21 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch.
+                    of milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
                 <li>
                     <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch.
+                    milliseconds elapsed since the UNIX epoch or a string
+                    containing a date and time which must be parsable according
+                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
                 </li>
             </ul>
         </dd>

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -372,7 +372,7 @@ SOFTWARE.
             {
                 value: "custom",
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                icon: "fa fa-wrench",
+                icon: "fa fa-user-o",
                 hasValue: true,
                 validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
             };

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -254,7 +254,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]+$/
                     };

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -685,7 +685,7 @@ module.exports = function(RED)
 
                     if (data.config.output.property.type === "jsonata")
                     {
-                        value = await getJSONataValue(data.expression, data.id, data.config.output.property.value);
+                        value = await getJSONataValue(data.expression, data.id, data.config.trigger, data.config.output.property.value);
                     }
                     else
                     {
@@ -704,7 +704,7 @@ module.exports = function(RED)
                     }
                     else if (data.config.output.property.type === "jsonata")
                     {
-                        let value = await getJSONataValue(data.expression, data.id, data.config.output.property.value);
+                        let value = await getJSONataValue(data.expression, data.id, data.config.trigger, data.config.output.property.value);
                         RED.util.setMessageProperty(msg, data.config.output.property.name, value, true);
                     }
                     else
@@ -720,7 +720,7 @@ module.exports = function(RED)
 
                     if (data.config.output.contentType === "jsonata")
                     {
-                        msg = await getJSONataValue(data.expression, data.id, data.config.output.value);
+                        msg = await getJSONataValue(data.expression, data.id, data.config.trigger, data.config.output.value);
                         if (typeof msg != "object")
                         {
                             const details = {event: data.id, expression: data.config.output.value, result: msg};
@@ -754,7 +754,7 @@ module.exports = function(RED)
             }
         }
 
-        async function getJSONataValue(expression, id, source)
+        async function getJSONataValue(expression, id, trigger, source)
         {
             try
             {
@@ -765,7 +765,11 @@ module.exports = function(RED)
                                                 config: {
                                                     name: node.config.name,
                                                     latitude: node.config.latitude,
-                                                    longitude: node.config.longitude}});
+                                                    longitude: node.config.longitude,
+                                                    timezone: node.config.timezone},
+                                                schedule: {
+                                                    id: id,
+                                                    trigger: trigger}});
             }
             catch (e)
             {

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -233,7 +233,7 @@ SOFTWARE.
                     {
                         value: "custom",
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-wrench",
+                        icon: "fa fa-user-o",
                         hasValue: true,
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.19.1",
+    "version": "1.20.0",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -23,21 +23,21 @@
     "bugs": "https://github.com/jensrossbach/node-red-contrib-chronos/issues",
     "dependencies": {
         "cronosjs": "^1.7.1",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.37",
+        "moment": "^2.30.1",
+        "moment-timezone": "^0.5.44",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^8.24.0",
-        "jsonata": "^1.8.6",
-        "mocha": "^10.0.0",
-        "node-red": "^3.0.2",
-        "node-red-node-test-helper": "^0.3.0",
+        "eslint": "^8.56.0",
+        "jsonata": "^2.0.3",
+        "mocha": "^10.2.0",
+        "node-red": "^3.1.3",
+        "node-red-node-test-helper": "^0.3.3",
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^14.0.0"
+        "sinon": "^17.0.1"
     },
     "main": "none",
     "scripts": {


### PR DESCRIPTION
### Added
- Added possibility to retrieve location coordinates (latitude and longitude) in configuration from environment variables.
- Added possibility to specify basetimes for time switch/filter nodes from context variables or message properties as datetime strings additionally to Unix epoch timestamps.
- Added dropdown menu to convert rule of time change node that allows to easily create ISO-8601 strings.
- Added more properties accessible to JSONata expressions of scheduler node output configurations.

### Changed
- Changed icons for custom / user defined data from wrench to user symbol.
- Updated versions of dependencies where possible.

### Fixed
- Fixed references to old default branch name.