### PR TITLE
Use Node-RED instead of OS locale if present

### DIFF
--- a/nodes/change.js
+++ b/nodes/change.js
@@ -31,7 +31,7 @@ module.exports = function(RED)
 
         node.chronos = require("./common/chronos.js");
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -43,7 +43,7 @@ module.exports = function(RED)
         RED.nodes.createNode(node, settings);
 
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         // backward compatibility to v1.17.x and earlier
         if (typeof settings.delayType == "undefined")

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -33,7 +33,7 @@ module.exports = function(RED)
 
         node.chronos = require("./common/chronos.js");
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -36,7 +36,7 @@ module.exports = function(RED)
         RED.nodes.createNode(node, settings);
 
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         // backward compatibility to v1.14.x and earlier
         if (typeof settings.mode == "undefined")

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -34,7 +34,7 @@ module.exports = function(RED)
 
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         node.initializing = true;
         node.eventTimesPending = false;

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -33,7 +33,7 @@ module.exports = function(RED)
 
         node.chronos = require("./common/chronos.js");
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = require("os-locale").sync();
+        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {


### PR DESCRIPTION
With this pull request, nodes now use the Node-RED locale if present in the settings instead of the OS locale. The latter is only used as fallback in case Node-RED does not have explicit locale configuration.