### PR TITLE
Add conversion to relative and calendar time to change node

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -235,29 +235,6 @@ SOFTWARE.
                         validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
                     };
 
-                    const customFormatInput =
-                    {
-                        value: "custom",
-                        label: node._("change.label.customFormat"),
-                        icon: "fa fa-user-o",
-                        hasValue: true,
-                        validate: /^.+$/
-                    };
-
-                    const iso8601FormatInput =
-                    {
-                        value: "iso8601",
-                        label: node._("change.label.iso8601Format"),
-                        hasValue: false
-                    };
-
-                    const iso8601UTCFormatInput =
-                    {
-                        value: "iso8601utc",
-                        label: node._("change.label.iso8601UTCFormat"),
-                        hasValue: false
-                    };
-
                     const partInput =
                     {
                         min: -270000,
@@ -364,9 +341,42 @@ SOFTWARE.
                                         .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
                                         .appendTo(startEndOfBox);
 
-                    const stringFormat = $("<input/>", {type: "text", class: "node-input-stringFormat", title: node._("change.label.format"), placeholder: node._("change.label.formatPlaceholder")})
-                                        .appendTo(toStringBox)
-                                        .typedInput({types: [customFormatInput, iso8601FormatInput, iso8601UTCFormatInput]});
+                    const stringFormat =
+                            $("<input/>", {
+                                type: "text",
+                                class: "node-input-stringFormat",
+                                title: node._("change.label.format"),
+                                placeholder: node._("change.label.formatPlaceholder")})
+                                    .appendTo(toStringBox)
+                                    .typedInput({
+                                        types: [
+                                            {
+                                                value: "custom",
+                                                label: node._("change.label.customFormat"),
+                                                icon: "fa fa-user-o",
+                                                hasValue: true,
+                                                validate: /^.+$/
+                                            },
+                                            {
+                                                value: "relative",
+                                                label: node._("change.label.relativeTime"),
+                                                hasValue: false
+                                            },
+                                            {
+                                                value: "calendar",
+                                                label: node._("change.label.calendarTime"),
+                                                hasValue: false
+                                            },
+                                            {
+                                                value: "iso8601",
+                                                label: node._("change.label.iso8601Format"),
+                                                hasValue: false
+                                            },
+                                            {
+                                                value: "iso8601utc",
+                                                label: node._("change.label.iso8601UTCFormat"),
+                                                hasValue: false
+                                            }]});
                     stringFormat.typedInput("width", "280px");
 
                     action.change(function()

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -256,6 +256,14 @@ module.exports = function(RED)
                                                 {
                                                     output = input.format(rule.format);
                                                 }
+                                                else if (rule.formatType == "calendar")
+                                                {
+                                                    output = input.calendar();
+                                                }
+                                                else if (rule.formatType == "relative")
+                                                {
+                                                    output = input.fromNow();
+                                                }
                                                 else if (rule.formatType == "iso8601")
                                                 {
                                                     output = input.toISOString(true);

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -148,14 +148,35 @@ SOFTWARE.
                     </li>
                     <li>
                         <i>Konvertieren</i>: Konvertiert den Zeitstempel des
-                        Ziels in eine Zeichenkettenrepräsentation. Wenn
-                        <i>Benutzerdef. Format</i> ausgewählt wurde, wird das
-                        Format der Zeichnkette über das Texteingabefeld
-                        angegeben und muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
-                        entsprechen. Es kann auch eine der beiden ISO-String
-                        Optionen ausgewählt werden um in einen ISO-8601
-                        String in lokaler (entsprechend der konfigurierten
-                        Zeitzone) oder UTC Zeit zu konvertieren.
+                        Ziels in eine von mehreren möglichen Zeichenkettenrepräsentationen:
+                        <ul>
+                            <li>
+                                <i>Benutzerdef. Format</i>: Die Zeichenkette kann
+                                über das Texteingabefeld beliebig angepasst werden.
+                                Das Format muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
+                                entsprechen.
+                            </li>
+                            <li>
+                                <i>Relative Zeit</i>: Zeichenkette, die die Zeit
+                                relativ zum jetzigen Zeitpunkt darstellt und
+                                undeutlicher wird, je weiter sie entfernt ist.
+                            </li>
+                            <li>
+                                <i>Kalendarzeit</i>: Zeichenkette, die die absolute
+                                Zeit (sofern nicht weiter entfernt als eine
+                                Woche) sowie das Datum relativ zum heutigen Tag
+                                (oder absolut, falls weiter entfernt als eine Woche)
+                                enthält.
+                            </li>
+                            <li>
+                                <i>ISO-8601</i>: ISO-8601 Zeichenkette in lokaler
+                                Zeit (entsprechend der konfigurierten Zeitzone).
+                            </li>
+                            <li>
+                                <i>ISO-8601 (UTC)</i>: ISO-8601 Zeichenkette in
+                                UTC-Zeit.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -10,8 +10,10 @@
             "date":               "Datum & Uhrzeit",
             "format":             "Format",
             "customFormat":       "Benutzerdef. Format",
-            "iso8601Format":      "ISO-8601 String",
-            "iso8601UTCFormat":   "ISO-8601 String (UTC)",
+            "relativeTime":       "Relative Zeit",
+            "calendarTime":       "Kalenderzeit",
+            "iso8601Format":      "ISO-8601",
+            "iso8601UTCFormat":   "ISO-8601 (UTC)",
             "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -143,13 +143,34 @@ SOFTWARE.
                         target timestamp to the end of a unit of time.
                     </li>
                     <li>
-                        <i>Convert</i>: Converts the target timestamp to a
-                        string representation. If <i>custom format</i> is
-                        selected, the format of the string is specified via the
-                        text box and must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
-                        It's also possible to select one of the ISO string
-                        options to convert into ISO-8601 strings either in local
-                        (according to the configured time zone) or UTC time.
+                        <i>Convert</i>: Converts the target timestamp to
+                        different kind of string representations:
+                        <ul>
+                            <li>
+                                <i>custom format</i>: String can be customized
+                                by specifying the format via the text box which
+                                must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                            </li>
+                            <li>
+                                <i>relative time</i>: String representing the time
+                                relative to the current time, being less precise
+                                the farer away it is.
+                            </li>
+                            <li>
+                                <i>calendar time</i>: String containing the absolute
+                                time (if not farer away than one week) and the date
+                                relative to today (or absolute if farer away than one
+                                week).
+                            </li>
+                            <li>
+                                <i>ISO-8601</i>: ISO-8601 string as local time
+                                (according to configured time zone).
+                            </li>
+                            <li>
+                                <i>ISO-8601 (UTC)</i>: ISO-8601 string as UTC
+                                time.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -10,8 +10,10 @@
             "date":               "date & time",
             "format":             "Format",
             "customFormat":       "custom format",
-            "iso8601Format":      "ISO-8601 string",
-            "iso8601UTCFormat":   "ISO-8601 string (UTC)",
+            "relativeTime":       "relative time",
+            "calendarTime":       "calendar time",
+            "iso8601Format":      "ISO-8601",
+            "iso8601UTCFormat":   "ISO-8601 (UTC)",
             "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":


### PR DESCRIPTION
This pull request add two more predefined string formats to the convert action of the time change node: relative time converts to a string representing the time relative to the current time, being less precise the farer away it is. Calendar time converts to a string containing the absolute time (if not farer away than one week) and the date relative to today (or absolute if farer away than one week).