### PR TITLE
Advanced time input for conditions

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -111,6 +111,12 @@ function getTimeFrom(node, source)
     if (!ret || !ret.isValid())  // fallback to number and ISO/RFC string parsing
     {
         ret = getMoment(node, source);
+
+        if ((typeof source == "number") && (source < 86400000))  // value is interpreted as number of milliseconds since midnight
+        {
+            const now = getMoment(node);
+            ret = ret.year(now.year()).month(now.month()).date(now.date());
+        }
     }
 
     ret.locale(node.locale);

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -306,6 +306,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -325,6 +326,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -344,6 +346,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -367,6 +370,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -390,6 +394,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -408,6 +413,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -426,6 +432,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -444,6 +451,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -462,6 +470,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -480,6 +489,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -498,6 +508,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -515,6 +526,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -534,6 +546,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -549,6 +562,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -564,6 +578,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                 return evalCondition(
                             RED,
                             node,
+                            msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
                                 RED,
@@ -602,13 +617,13 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
     }
     else
     {
-        result = evalCondition(RED, node, baseTime, cond, id);
+        result = evalCondition(RED, node, msg, baseTime, cond, id);
     }
 
     return result;
 }
 
-function evalCondition(RED, node, baseTime, cond, id)
+function evalCondition(RED, node, msg, baseTime, cond, id)
 {
     let result = false;
 
@@ -639,6 +654,7 @@ function evalCondition(RED, node, baseTime, cond, id)
         result = evalCondition(
                     RED,
                     node,
+                    msg,
                     baseTime,
                     convertCondition(
                         RED,
@@ -648,7 +664,7 @@ function evalCondition(RED, node, baseTime, cond, id)
     }
     else if ((cond.operator == "before") || (cond.operator == "after"))
     {
-        const targetTime = node.chronos.getTime(RED, node, baseTime.clone(), cond.operands.type, cond.operands.value);
+        const targetTime = getTime(RED, node, msg, baseTime.clone(), cond.operands.type, cond.operands.value);
 
         if (cond.operands.offset != 0)
         {
@@ -661,8 +677,8 @@ function evalCondition(RED, node, baseTime, cond, id)
     }
     else if ((cond.operator == "between") || (cond.operator == "outside"))
     {
-        const time1 = node.chronos.getTime(RED, node, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
-        const time2 = node.chronos.getTime(RED, node, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
+        const time1 = getTime(RED, node, msg, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
+        const time2 = getTime(RED, node, msg, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
 
         if (cond.operands[0].offset != 0)
         {
@@ -692,6 +708,51 @@ function evalCondition(RED, node, baseTime, cond, id)
     }
 
     return result;
+}
+
+function getTime(RED, node, msg, baseTime, type, value)
+{
+    let ret = undefined;
+
+    if ((type == "env") || (type == "global") || (type == "flow") || (type == "msg"))
+    {
+        let ctxValue = undefined;
+
+        if (type == "env")
+        {
+            ctxValue = RED.util.evaluateNodeProperty(value, type, node);
+        }
+        else if ((type == "global") || (type == "flow"))
+        {
+            const ctx = RED.util.parseContextStore(value);
+            ctxValue = node.context()[type].get(ctx.key, ctx.store);
+        }
+        else
+        {
+            ctxValue = RED.util.getMessageProperty(msg, value);
+        }
+
+        if (!ctxValue || ((typeof ctxValue != "number") && (typeof ctxValue != "string")))
+        {
+            throw new node.chronos.TimeError(
+                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"),
+                        {type: type, value: ctxValue});
+        }
+
+        ret = node.chronos.getTimeFrom(node, ctxValue);
+        if (!ret.isValid())
+        {
+            throw new node.chronos.TimeError(
+                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"),
+                        {type: type, value: ctxValue});
+        }
+    }
+    else
+    {
+        ret = node.chronos.getTime(RED, node, baseTime, type, value);
+    }
+
+    return ret;
 }
 
 function evaluateDateCondition(baseTime, cond)

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -368,7 +368,7 @@ SOFTWARE.
 
                     const time1 = $("<input/>", {type: "text", class: "node-input-time1"})
                                         .appendTo(time1Row1)
-                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput]});
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time1.typedInput("width", "280px");
                     time1._prevType = "time";
                     const extend1 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
@@ -377,7 +377,7 @@ SOFTWARE.
 
                     const time2 = $("<input/>", {type: "text", class: "node-input-time2"})
                                         .appendTo(time2Row1)
-                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput]});
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time2.typedInput("width", "280px");
                     time2._prevType = "time";
                     const extend2 = $("<a/>", {href: "#", style: "margin-left: 6px;"})

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -55,25 +55,13 @@ SOFTWARE.
                     Nachricht.
                 </li>
                 <li>
-                    <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
-                    eine Zeichenkette, die ein Datum und eine Zeit enthält
-                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
-                </li>
-                <li>
-                    <i>flow</i>: Zeitstempel aus einer Flow-Variable als
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeitstempel aus
+                    einer Kontextvariablen or einer Nachrichteneigenschaft als
                     Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    oder eine Zeichenkette, die ein Datum und eine Zeit
-                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
-                </li>
-                <li>
-                    <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
-                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
+                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
+                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
+                    eine Zeit nach RFC 2822 enthält.
                 </li>
             </ul>
         </dd>
@@ -153,7 +141,7 @@ SOFTWARE.
                 </li>
                 <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen
-                    Umgebungs- bzw. Kontextvariablen. Siehe Abschnitt <i>Eingabe</i>
+                    Umgebungs- bzw. Kontextvariable. Siehe Abschnitt <i>Eingabe</i>
                     weiter unten für eine Beschreibung der benötigten Struktur der
                     Variable.
                 </li>
@@ -176,6 +164,15 @@ SOFTWARE.
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte
                     Sonnenstände kann eingegeben werden.
+                </li>
+                <li>
+                    <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: Die Zeit
+                    wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
+                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
+                    eine Zeit nach RFC 2822 enthält, gelesen.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -57,25 +57,13 @@ SOFTWARE.
                     Nachricht.
                 </li>
                 <li>
-                    <i>global</i>: Zeitstempel aus einer globalen Variable als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung oder
-                    eine Zeichenkette, die ein Datum und eine Zeit enthält
-                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
-                </li>
-                <li>
-                    <i>flow</i>: Zeitstempel aus einer Flow-Variable als
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeitstempel aus
+                    einer Kontextvariablen or einer Nachrichteneigenschaft als
                     Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    oder eine Zeichenkette, die ein Datum und eine Zeit
-                    enthält und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
-                </li>
-                <li>
-                    <i>msg</i>: Zeitstempel aus einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    oder eine Zeichenkette, die ein Datum und eine Zeit enthält
-                    und nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                    geparst werden kann.
+                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
+                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
+                    eine Zeit nach RFC 2822 enthält.
                 </li>
             </ul>
         </dd>
@@ -132,7 +120,7 @@ SOFTWARE.
                 </li>
                 <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen
-                    Umgebungs- bzw. Kontextvariablen. Siehe Abschnitt <i>Eingabe</i>
+                    Umgebungs- bzw. Kontextvariable. Siehe Abschnitt <i>Eingabe</i>
                     weiter unten für eine Beschreibung der benötigten Struktur der
                     Variable.
                 </li>
@@ -155,6 +143,15 @@ SOFTWARE.
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte
                     Sonnenstände kann eingegeben werden.
+                </li>
+                <li>
+                    <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: Die Zeit
+                    wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
+                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
+                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
+                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
+                    eine Zeit nach RFC 2822 enthält, gelesen.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -53,22 +53,12 @@ SOFTWARE.
                     <i>message ingress</i>: Ingress time of the input message.
                 </li>
                 <li>
-                    <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-                </li>
-                <li>
-                    <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-                </li>
-                <li>
-                    <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Timestamp from
+                    a context variable or message property as number of
+                    milliseconds elapsed since the UNIX epoch (or number
+                    of milliseconds elapsed since midnight if smaller than
+                    86.400.000) or a string containing a time, an ISO 8601
+                    datetime or an RFC 2822 datetime.
                 </li>
             </ul>
         </dd>
@@ -166,6 +156,14 @@ SOFTWARE.
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names
                     can be entered.
+                </li>
+                <li>
+                    <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: The time is
+                    retrieved from an environment variable, a context variable or a
+                    message property with a timestamp as number of milliseconds elapsed
+                    since the UNIX epoch (or number of milliseconds elapsed since
+                    midnight if smaller than 86.400.000) or a string containing a
+                    time, an ISO 8601 datetime or an RFC 2822 datetime.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -53,22 +53,12 @@ SOFTWARE.
                     <i>message ingress</i>: Ingress time of the input message.
                 </li>
                 <li>
-                    <i>global</i>: Timestamp from a global variable as number
-                    of milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-                </li>
-                <li>
-                    <i>flow</i>: Timestamp from a flow variable as number of
-                    milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-                </li>
-                <li>
-                    <i>msg</i>: Timestamp from a message property as number of
-                    milliseconds elapsed since the UNIX epoch or a string
-                    containing a date and time which must be parsable according
-                    to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Timestamp from
+                    a context variable or message property as number of
+                    milliseconds elapsed since the UNIX epoch (or number
+                    of milliseconds elapsed since midnight if smaller than
+                    86.400.000) or a string containing a time, an ISO 8601
+                    datetime or an RFC 2822 datetime.
                 </li>
             </ul>
         </dd>
@@ -145,6 +135,14 @@ SOFTWARE.
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names
                     can be entered.
+                </li>
+                <li>
+                    <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: The time is
+                    retrieved from an environment variable, a context variable or a
+                    message property with a timestamp as number of milliseconds elapsed
+                    since the UNIX epoch (or number of milliseconds elapsed since
+                    midnight if smaller than 86.400.000) or a string containing a
+                    time, an ISO 8601 datetime or an RFC 2822 datetime.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -338,7 +338,7 @@ SOFTWARE.
 
                     const time1 = $("<input/>", {type: "text", class: "node-input-time1"})
                                         .appendTo(time1Row1)
-                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput]});
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time1.typedInput("width", "280px");
                     time1._prevType = "time";
                     const extend1 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
@@ -347,7 +347,7 @@ SOFTWARE.
 
                     const time2 = $("<input/>", {type: "text", class: "node-input-time2"})
                                         .appendTo(time2Row1)
-                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput]});
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time2.typedInput("width", "280px");
                     time2._prevType = "time";
                     const extend2 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
@@ -861,9 +861,41 @@ SOFTWARE.
                     {
                         data.label += " " + data.operands.value;
                     }
+                    else if (data.operands.type == "env")
+                    {
+                        if (data.operands.value.includes("${"))
+                        {
+                            data.label += " " + data.operands.value;
+                        }
+                        else
+                        {
+                            data.label += " " + "${" + data.operands.value + "}";
+                        }
+                    }
+                    else if ((data.operands.type == "global") || (data.operands.type == "flow"))
+                    {
+                        const ctx = RED.utils.parseContextKey(data.operands.value);
+                        data.label += " " + data.operands.type + "." + ctx.key + (ctx.store ? " (" + ctx.store + ")" : "");
+                    }
+                    else if (data.operands.type == "msg")
+                    {
+                        data.label += " msg." + data.operands.value;
+                    }
                     else
                     {
                         data.label += " " + node._("node-red-contrib-chronos/chronos-config:common.list." + data.operands.type + "." + data.operands.value);
+                    }
+
+                    if (data.operands.offset != 0)
+                    {
+                        data.label += ((data.operands.offset > 0) ? " + " : " - ");
+
+                        if (data.operands.random)
+                        {
+                            data.label += "~";
+                        }
+
+                        data.label += Math.abs(data.operands.offset) + " " + node._("node-red-contrib-chronos/chronos-config:common.label.min");
                     }
                 }
                 else if ((data.operator == "between") || (data.operator == "outside"))
@@ -883,18 +915,83 @@ SOFTWARE.
                     {
                         data.label += data.operands[0].value;
                     }
+                    else if (data.operands[0].type == "env")
+                    {
+                        if (data.operands[0].value.includes("${"))
+                        {
+                            data.label += " " + data.operands[0].value;
+                        }
+                        else
+                        {
+                            data.label += " " + "${" + data.operands[0].value + "}";
+                        }
+                    }
+                    else if ((data.operands[0].type == "global") || (data.operands[0].type == "flow"))
+                    {
+                        const ctx = RED.utils.parseContextKey(data.operands[0].value);
+                        data.label += " " + data.operands[0].type + "." + ctx.key + (ctx.store ? " (" + ctx.store + ")" : "");
+                    }
+                    else if (data.operands[0].type == "msg")
+                    {
+                        data.label += " msg." + data.operands[0].value;
+                    }
                     else
                     {
                         data.label += node._("node-red-contrib-chronos/chronos-config:common.list." + data.operands[0].type + "." + data.operands[0].value);
                     }
+
+                    if (data.operands[0].offset != 0)
+                    {
+                        data.label += ((data.operands[0].offset > 0) ? " + " : " - ");
+
+                        if (data.operands[0].random)
+                        {
+                            data.label += "~";
+                        }
+
+                        data.label += Math.abs(data.operands[0].offset) + " " + node._("node-red-contrib-chronos/chronos-config:common.label.min");
+                    }
+
                     data.label += " " + node._("switch.label.and") + " ";
                     if ((data.operands[1].type == "time") || (data.operands[1].type == "custom"))
                     {
                         data.label += data.operands[1].value;
                     }
+                    else if (data.operands[1].type == "env")
+                    {
+                        if (data.operands[1].value.includes("${"))
+                        {
+                            data.label += " " + data.operands[1].value;
+                        }
+                        else
+                        {
+                            data.label += " " + "${" + data.operands[1].value + "}";
+                        }
+                    }
+                    else if ((data.operands[1].type == "global") || (data.operands[1].type == "flow"))
+                    {
+                        const ctx = RED.utils.parseContextKey(data.operands[1].value);
+                        data.label += " " + data.operands[1].type + "." + ctx.key + (ctx.store ? " (" + ctx.store + ")" : "");
+                    }
+                    else if (data.operands[1].type == "msg")
+                    {
+                        data.label += " msg." + data.operands[1].value;
+                    }
                     else
                     {
                         data.label += node._("node-red-contrib-chronos/chronos-config:common.list." + data.operands[1].type + "." + data.operands[1].value);
+                    }
+
+                    if (data.operands[1].offset != 0)
+                    {
+                        data.label += ((data.operands[1].offset > 0) ? " + " : " - ");
+
+                        if (data.operands[1].random)
+                        {
+                            data.label += "~";
+                        }
+
+                        data.label += Math.abs(data.operands[1].offset) + " " + node._("node-red-contrib-chronos/chronos-config:common.label.min");
                     }
                 }
                 else if (data.operator == "days")


### PR DESCRIPTION
This pull request adds support for the time input of conditions in time switch and time filter nodes to retrieve the times from environment variables, context variables or message properties. The times can be specified either as number or as string. A numerical value is interpreted as number of milliseconds since the UNIX epoch or number of milliseconds since midnight if the value is less than 86.400.000. A string can be specified as a standalone time, as an ISO 8601 datetime or as an RFC 2822 datetime.