### PR TITLE
Advanced date and time string parsing

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -207,7 +207,7 @@ SOFTWARE.
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                         icon: "fa fa-clock-o",
                         hasValue: true,
-                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
                     };
 
                     const sunTimeInput =

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -32,7 +32,7 @@ function validateCondition(node, cond)
 
     if ((cond.operator == "before") || (cond.operator == "after"))
     {
-        if ((cond.operands.type == "time") && !node.chronos.isValidUserTime(cond.operands.value))
+        if ((cond.operands.type == "time") && !node.chronos.isValidUserTime(cond.operands.value, false))
         {
             return false;
         }
@@ -40,12 +40,12 @@ function validateCondition(node, cond)
 
     if ((cond.operator == "between") || (cond.operator == "outside"))
     {
-        if ((cond.operands[0].type == "time") && !node.chronos.isValidUserTime(cond.operands[0].value))
+        if ((cond.operands[0].type == "time") && !node.chronos.isValidUserTime(cond.operands[0].value, false))
         {
             return false;
         }
 
-        if ((cond.operands[1].type == "time") && !node.chronos.isValidUserTime(cond.operands[1].value))
+        if ((cond.operands[1].type == "time") && !node.chronos.isValidUserTime(cond.operands[1].value, false))
         {
             return false;
         }
@@ -262,7 +262,7 @@ function validateOperand(RED, node, operand, num)
     }
 
     if ((typeof operand.value != "string")
-        || ((operand.type == "time") && !node.chronos.isValidUserTime(operand.value))
+        || ((operand.type == "time") && !node.chronos.isValidUserTime(operand.value, false))
         || ((operand.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(operand.value))
         || ((operand.type == "moon") && !/^(rise|set)$/.test(operand.value)))
     {

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -393,7 +393,7 @@ SOFTWARE.
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                 icon: "fa fa-clock-o",
                 hasValue: true,
-                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
             };
 
             const sunTimeInput =

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -271,7 +271,7 @@ SOFTWARE.
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                         icon: "fa fa-clock-o",
                         hasValue: true,
-                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                        validate: function(v) { return v; }
                     };
 
                     const sunTimeInput =

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -59,9 +59,10 @@ SOFTWARE.
                     einer Kontextvariablen or einer Nachrichteneigenschaft als
                     Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
                     (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
-                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
-                    eine Zeit nach RFC 2822 enthält.
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
+                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
+                    Region-spezifischem Format oder ein Datum und eine Zeit
+                    nach ISO 8601 enthält.
                 </li>
             </ul>
         </dd>
@@ -152,6 +153,8 @@ SOFTWARE.
                 <li>
                     <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt in der
                     Form <code>hh:mm[:ss] [am|pm]</code> eingegeben werden.
+                    Optional ist die Eingabe eines Datums und einer Zeit in
+                    Region-spezifischem oder ISO 8601 Format möglich.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
@@ -170,9 +173,10 @@ SOFTWARE.
                     wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
                     als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
                     (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
-                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
-                    eine Zeit nach RFC 2822 enthält, gelesen.
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
+                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
+                    Region-spezifischem Format oder ein Datum und eine Zeit
+                    nach ISO 8601 enthält.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -61,9 +61,10 @@ SOFTWARE.
                     einer Kontextvariablen or einer Nachrichteneigenschaft als
                     Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
                     (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
-                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
-                    eine Zeit nach RFC 2822 enthält.
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
+                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
+                    Region-spezifischem Format oder ein Datum und eine Zeit
+                    nach ISO 8601 enthält.
                 </li>
             </ul>
         </dd>
@@ -131,6 +132,8 @@ SOFTWARE.
                 <li>
                     <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt in der
                     Form <code>hh:mm[:ss] [am|pm]</code> eingegeben werden.
+                    Optional ist die Eingabe eines Datums und einer Zeit in
+                    Region-spezifischem oder ISO 8601 Format möglich.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
@@ -149,9 +152,10 @@ SOFTWARE.
                     wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
                     als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
                     (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit,
-                    ein Datum und eine Zeit nach ISO 8601 oder ein Datum und
-                    eine Zeit nach RFC 2822 enthält, gelesen.
+                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
+                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
+                    Region-spezifischem Format oder ein Datum und eine Zeit
+                    nach ISO 8601 enthält.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -57,8 +57,9 @@ SOFTWARE.
                     a context variable or message property as number of
                     milliseconds elapsed since the UNIX epoch (or number
                     of milliseconds elapsed since midnight if smaller than
-                    86.400.000) or a string containing a time, an ISO 8601
-                    datetime or an RFC 2822 datetime.
+                    86.400.000) or a string containing a time in 12 or 24
+                    hour format, a region-specific datetime or an ISO 8601
+                    datetime.
                 </li>
             </ul>
         </dd>
@@ -143,7 +144,9 @@ SOFTWARE.
             <ul>
                 <li>
                     <i>time of day</i>: A specific time can be entered directly
-                    in the form <code>hh:mm[:ss] [am|pm]</code>.
+                    in the form <code>hh:mm[:ss] [am|pm]</code>. Optionally it
+                    is possible to specify a date and a time using regional or
+                    ISO 8601 format.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
@@ -163,7 +166,8 @@ SOFTWARE.
                     message property with a timestamp as number of milliseconds elapsed
                     since the UNIX epoch (or number of milliseconds elapsed since
                     midnight if smaller than 86.400.000) or a string containing a
-                    time, an ISO 8601 datetime or an RFC 2822 datetime.
+                    time in 12 or 24 hour format, a region-specific datetime or an
+                    ISO 8601 datetime.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -57,8 +57,9 @@ SOFTWARE.
                     a context variable or message property as number of
                     milliseconds elapsed since the UNIX epoch (or number
                     of milliseconds elapsed since midnight if smaller than
-                    86.400.000) or a string containing a time, an ISO 8601
-                    datetime or an RFC 2822 datetime.
+                    86.400.000) or a string containing a time in 12 or 24
+                    hour format, a region-specific datetime or an ISO 8601
+                    datetime.
                 </li>
             </ul>
         </dd>
@@ -122,7 +123,9 @@ SOFTWARE.
             <ul>
                 <li>
                     <i>time of day</i>: A specific time can be entered directly
-                    in the form <code>hh:mm[:ss] [am|pm]</code>.
+                    in the form <code>hh:mm[:ss] [am|pm]</code>. Optionally it
+                    is possible to specify a date and a time using regional or
+                    ISO 8601 format.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
@@ -142,7 +145,8 @@ SOFTWARE.
                     message property with a timestamp as number of milliseconds elapsed
                     since the UNIX epoch (or number of milliseconds elapsed since
                     midnight if smaller than 86.400.000) or a string containing a
-                    time, an ISO 8601 datetime or an RFC 2822 datetime.
+                    time in 12 or 24 hour format, a region-specific datetime or an
+                    ISO 8601 datetime.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -360,7 +360,7 @@ SOFTWARE.
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                 icon: "fa fa-clock-o",
                 hasValue: true,
-                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
             };
 
             const sunTimeInput =

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -241,7 +241,7 @@ SOFTWARE.
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                         icon: "fa fa-clock-o",
                         hasValue: true,
-                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
                     };
 
                     const sunTimeInput =

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -297,7 +297,7 @@ SOFTWARE.
                 label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                 icon: "fa fa-clock-o",
                 hasValue: true,
-                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
             };
 
             const sunTimeInput =

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -237,7 +237,7 @@ SOFTWARE.
                         label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
                         icon: "fa fa-clock-o",
                         hasValue: true,
-                        validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(am|AM|pm|PM)?$/
+                        validate: function(v) { return v; }
                     };
 
                     const sunTimeInput =


### PR DESCRIPTION
This pull request further improves the parsing of strings containing dates and times. This makes it even possible to provide dates along with the times in the _time of day_ input of time switch and time filter node conditions.

Strings can now be formatted in the following ways:
- specifying a time (without date) in 12 or 24 hour format (e.g., `3:20 pm`, `15:20`, ...)
- specifying a date and a time in region-specific format (e.g., `04/07/2024 3:20 pm`, `07.04.2024 15:20`, ...)
- specifying a date and a time in ISO 8601 format (e.g., `2024-04-07T15:20`, `2024-04-07 15:20`, ...)