### PR TITLE
Regional string convertions formats

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -351,31 +351,47 @@ SOFTWARE.
                                     .typedInput({
                                         types: [
                                             {
+                                                value: "predefined",
+                                                label: node._("change.label.predefinedFormat"),
+                                                icon: "fa fa-calendar",
+                                                options:
+                                                [
+                                                    {
+                                                        value: "regional",
+                                                        label: node._("change.list.convert.regionalDateTime")
+                                                    },
+                                                    {
+                                                        value: "regionalDate",
+                                                        label: node._("change.list.convert.regionalDate")
+                                                    },
+                                                    {
+                                                        value: "regionalTime",
+                                                        label: node._("change.list.convert.regionalTime")
+                                                    },
+                                                    {
+                                                        value: "relative",
+                                                        label: node._("change.list.convert.relativeTime")
+                                                    },
+                                                    {
+                                                        value: "calendar",
+                                                        label: node._("change.list.convert.calendar")
+                                                    },
+                                                    {
+                                                        value: "iso8601",
+                                                        label: node._("change.list.convert.iso8601Format")
+                                                    },
+                                                    {
+                                                        value: "iso8601utc",
+                                                        label: node._("change.list.convert.iso8601UTCFormat")
+                                                    }
+                                                ]
+                                            },
+                                            {
                                                 value: "custom",
                                                 label: node._("change.label.customFormat"),
                                                 icon: "fa fa-user-o",
                                                 hasValue: true,
                                                 validate: /^.+$/
-                                            },
-                                            {
-                                                value: "relative",
-                                                label: node._("change.label.relativeTime"),
-                                                hasValue: false
-                                            },
-                                            {
-                                                value: "calendar",
-                                                label: node._("change.label.calendarTime"),
-                                                hasValue: false
-                                            },
-                                            {
-                                                value: "iso8601",
-                                                label: node._("change.label.iso8601Format"),
-                                                hasValue: false
-                                            },
-                                            {
-                                                value: "iso8601utc",
-                                                label: node._("change.label.iso8601UTCFormat"),
-                                                hasValue: false
                                             }]});
                     stringFormat.typedInput("width", "280px");
 
@@ -570,11 +586,35 @@ SOFTWARE.
                         }
                         else if (data.type == "toString")
                         {
-                            if (data.formatType)
+                            // backward compatibility to v1.19.1 and below
+                            if (!data.formatType)
                             {
-                                stringFormat.typedInput("type", data.formatType);
+                                data.formatType = "custom";
                             }
 
+                            // backward compatibility to v1.21 and below
+                            if (data.formatType == "relative")
+                            {
+                                data.formatType = "predefined";
+                                data.format = "relative";
+                            }
+                            else if (data.formatType == "calendar")
+                            {
+                                data.formatType = "predefined";
+                                data.format = "calendar";
+                            }
+                            else if (data.formatType == "iso8601")
+                            {
+                                data.formatType = "predefined";
+                                data.format = "iso8601";
+                            }
+                            else if (data.formatType == "iso8601utc")
+                            {
+                                data.formatType = "predefined";
+                                data.format = "iso8601utc";
+                            }
+
+                            stringFormat.typedInput("type", data.formatType);
                             stringFormat.typedInput("value", data.format);
                         }
                         changeType.val(data.type);

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -65,6 +65,36 @@ module.exports = function(RED)
             {
                 let rule = node.rules[i];
 
+                // backward compatibility adaptations
+                if ((rule.action == "change") && (rule.type == "toString"))
+                {
+                    if (!rule.formatType)  // backward compatibility to v1.19.1 and below
+                    {
+                        rule.formatType = "custom";
+                    }
+                    // backward compatibility to v1.21 and below
+                    else if (rule.formatType == "relative")
+                    {
+                        rule.formatType = "predefined";
+                        rule.format = "relative";
+                    }
+                    else if (rule.formatType == "calendar")
+                    {
+                        rule.formatType = "predefined";
+                        rule.format = "calendar";
+                    }
+                    else if (rule.formatType == "iso8601")
+                    {
+                        rule.formatType = "predefined";
+                        rule.format = "iso8601";
+                    }
+                    else if (rule.formatType == "iso8601utc")
+                    {
+                        rule.formatType = "predefined";
+                        rule.format = "iso8601utc";
+                    }
+                }
+
                 if ((rule.action == "set") && (rule.type == "date"))
                 {
                     if (!node.chronos.isValidUserDate(rule.date))
@@ -81,7 +111,7 @@ module.exports = function(RED)
                 else if (
                     (rule.action == "change") &&
                     (rule.type == "toString") &&
-                    ((rule.formatType == "custom") || !rule.formatType) &&
+                    (rule.formatType == "custom") &&
                     !rule.format)
                 {
                     valid = false;
@@ -251,26 +281,40 @@ module.exports = function(RED)
                                             }
                                             case "toString":
                                             {
-                                                if ((rule.formatType == "custom") ||
-                                                    !rule.formatType)  // backward compatibility to v1.19.1 and below
+                                                if (rule.formatType == "custom")
                                                 {
                                                     output = input.format(rule.format);
                                                 }
-                                                else if (rule.formatType == "calendar")
+                                                else if (rule.formatType == "predefined")
                                                 {
-                                                    output = input.calendar();
-                                                }
-                                                else if (rule.formatType == "relative")
-                                                {
-                                                    output = input.fromNow();
-                                                }
-                                                else if (rule.formatType == "iso8601")
-                                                {
-                                                    output = input.toISOString(true);
-                                                }
-                                                else if (rule.formatType == "iso8601utc")
-                                                {
-                                                    output = input.toISOString();
+                                                    if (rule.format == "calendar")
+                                                    {
+                                                        output = input.calendar();
+                                                    }
+                                                    else if (rule.format == "relative")
+                                                    {
+                                                        output = input.fromNow();
+                                                    }
+                                                    else if (rule.format == "regional")
+                                                    {
+                                                        output = input.format("L LTS");
+                                                    }
+                                                    else if (rule.format == "regionalDate")
+                                                    {
+                                                        output = input.format("L");
+                                                    }
+                                                    else if (rule.format == "regionalTime")
+                                                    {
+                                                        output = input.format("LTS");
+                                                    }
+                                                    else if (rule.format == "iso8601")
+                                                    {
+                                                        output = input.toISOString(true);
+                                                    }
+                                                    else if (rule.format == "iso8601utc")
+                                                    {
+                                                        output = input.toISOString();
+                                                    }
                                                 }
 
                                                 break;

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -151,30 +151,52 @@ SOFTWARE.
                         Ziels in eine von mehreren möglichen Zeichenkettenrepräsentationen:
                         <ul>
                             <li>
-                                <i>Benutzerdef. Format</i>: Die Zeichenkette kann
-                                über das Texteingabefeld beliebig angepasst werden.
+                                <i>Vordefiniertes Format</i>: Das Format der
+                                Zeichenkette kann aus einer Liste vordefinierter
+                                Formate ausgewählt werden.
+                            </li>
+                            <ul>
+                                <li>
+                                    <i>Regional</i>: Zeichenkette, die das Datum
+                                    und die Uhrzeit in einem Region-spezifischen
+                                    Format enthält.
+                                </li>
+                                <li>
+                                    <i>Regional (nur Datum)</i>: Zeichenkette, die
+                                    das Datum in einem Region-spezifischen Format
+                                    enthält.
+                                </li>
+                                <li>
+                                    <i>Regional (nur Zeit)</i>: Zeichenkette, die
+                                    die Uhrzeit in einem Region-spezifischen Format
+                                    enthält.
+                                </li>
+                                <li>
+                                    <i>Relative Zeit</i>: Zeichenkette, die die Zeit
+                                    relativ zum jetzigen Zeitpunkt darstellt und
+                                    undeutlicher wird, je weiter sie entfernt ist.
+                                </li>
+                                <li>
+                                    <i>Kalender</i>: Zeichenkette, die die absolute
+                                    Zeit (sofern nicht weiter entfernt als eine
+                                    Woche) sowie das Datum relativ zum heutigen Tag
+                                    (oder absolut, falls weiter entfernt als eine Woche)
+                                    enthält.
+                                </li>
+                                <li>
+                                    <i>ISO-8601</i>: ISO-8601 Zeichenkette in lokaler
+                                    Zeit (entsprechend der konfigurierten Zeitzone).
+                                </li>
+                                <li>
+                                    <i>ISO-8601 (UTC)</i>: ISO-8601 Zeichenkette in
+                                    UTC-Zeit.
+                                </li>
+                            </ul>
+                            <li>
+                                <i>Benutzerdefiniertes Format</i>: Die Zeichenkette
+                                kann über das Texteingabefeld beliebig angepasst werden.
                                 Das Format muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
                                 entsprechen.
-                            </li>
-                            <li>
-                                <i>Relative Zeit</i>: Zeichenkette, die die Zeit
-                                relativ zum jetzigen Zeitpunkt darstellt und
-                                undeutlicher wird, je weiter sie entfernt ist.
-                            </li>
-                            <li>
-                                <i>Kalendarzeit</i>: Zeichenkette, die die absolute
-                                Zeit (sofern nicht weiter entfernt als eine
-                                Woche) sowie das Datum relativ zum heutigen Tag
-                                (oder absolut, falls weiter entfernt als eine Woche)
-                                enthält.
-                            </li>
-                            <li>
-                                <i>ISO-8601</i>: ISO-8601 Zeichenkette in lokaler
-                                Zeit (entsprechend der konfigurierten Zeitzone).
-                            </li>
-                            <li>
-                                <i>ISO-8601 (UTC)</i>: ISO-8601 Zeichenkette in
-                                UTC-Zeit.
                             </li>
                         </ul>
                     </li>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -9,11 +9,8 @@
             "now":                "Aktuelle Zeit",
             "date":               "Datum & Uhrzeit",
             "format":             "Format",
-            "customFormat":       "Benutzerdef. Format",
-            "relativeTime":       "Relative Zeit",
-            "calendarTime":       "Kalenderzeit",
-            "iso8601Format":      "ISO-8601",
-            "iso8601UTCFormat":   "ISO-8601 (UTC)",
+            "predefinedFormat":   "Vordefiniertes Format",
+            "customFormat":       "Benutzerdefiniertes Format",
             "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -31,6 +28,16 @@
                 "startOf":   "Anfang von",
                 "endOf":     "Ende von",
                 "toString":  "Konvertieren"
+            },
+            "convert":
+            {
+                "regionalDateTime":   "Regional",
+                "regionalDate":       "Regional (nur Datum)",
+                "regionalTime":       "Regional (nur Zeit)",
+                "relativeTime":       "Relative Zeit",
+                "calendar":           "Kalender",
+                "iso8601Format":      "ISO-8601",
+                "iso8601UTCFormat":   "ISO-8601 (UTC)"
             }
         },
         "status":

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -147,28 +147,46 @@ SOFTWARE.
                         different kind of string representations:
                         <ul>
                             <li>
+                                <i>predefined format</i>: String format can be
+                                chosen from a list of predefined formats.
+                            </li>
+                            <ul>
+                                <li>
+                                    <i>regional</i>: String containing the date
+                                    and the time in a region-specific format.
+                                </li>
+                                <li>
+                                    <i>regional (date only)</i>: String containing
+                                    the date in a region-specific format.
+                                </li>
+                                <li>
+                                    <i>regional (time only)</i>: String containing
+                                    the time in a region-specific format.
+                                </li>
+                                <li>
+                                    <i>relative time</i>: String representing the time
+                                    relative to the current time, being less precise
+                                    the farer away it is.
+                                </li>
+                                <li>
+                                    <i>calendar</i>: String containing the absolute
+                                    time (if not farer away than one week) and the
+                                    date relative to today (or absolute if farer away
+                                    than one week).
+                                </li>
+                                <li>
+                                    <i>ISO-8601</i>: ISO-8601 string as local time
+                                    (according to configured time zone).
+                                </li>
+                                <li>
+                                    <i>ISO-8601 (UTC)</i>: ISO-8601 string as UTC
+                                    time.
+                                </li>
+                            </ul>
+                            <li>
                                 <i>custom format</i>: String can be customized
                                 by specifying the format via the text box which
                                 must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
-                            </li>
-                            <li>
-                                <i>relative time</i>: String representing the time
-                                relative to the current time, being less precise
-                                the farer away it is.
-                            </li>
-                            <li>
-                                <i>calendar time</i>: String containing the absolute
-                                time (if not farer away than one week) and the date
-                                relative to today (or absolute if farer away than one
-                                week).
-                            </li>
-                            <li>
-                                <i>ISO-8601</i>: ISO-8601 string as local time
-                                (according to configured time zone).
-                            </li>
-                            <li>
-                                <i>ISO-8601 (UTC)</i>: ISO-8601 string as UTC
-                                time.
                             </li>
                         </ul>
                     </li>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -9,11 +9,8 @@
             "now":                "current time",
             "date":               "date & time",
             "format":             "Format",
+            "predefinedFormat":   "predefined format",
             "customFormat":       "custom format",
-            "relativeTime":       "relative time",
-            "calendarTime":       "calendar time",
-            "iso8601Format":      "ISO-8601",
-            "iso8601UTCFormat":   "ISO-8601 (UTC)",
             "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -31,6 +28,16 @@
                 "startOf":   "Start of",
                 "endOf":     "End of",
                 "toString":  "Convert"
+            },
+            "convert":
+            {
+                "regionalDateTime":   "regional",
+                "regionalDate":       "regional (date only)",
+                "regionalTime":       "regional (time only)",
+                "relativeTime":       "relative time",
+                "calendar":           "calendar",
+                "iso8601Format":      "ISO-8601",
+                "iso8601UTCFormat":   "ISO-8601 (UTC)"
             }
         },
         "status":


### PR DESCRIPTION
This pull requests adds 3 additional predefined convertion formats for converting timestamps into strings:

- regional: String containing the date and the time in a region-specific format
- regional (date only): String containing the date in a region-specific format
- regional (time only): String containing the time in a region-specific format

Additionally, the predefined formats are no longer on the first selection level parallel to the custom format but grouped under a new first level type "predefined formats".