### PR TITLE
Add possibility to supply sun and moon times via string

### DIFF
--- a/nodes/config.js
+++ b/nodes/config.js
@@ -78,8 +78,8 @@ module.exports = function(RED)
             if (data && (data.length > 0))
             {
                 const EXP = /^[0-9a-zA-Z_]+$/;
+                const names = [];
                 let valid = true;
-                let names = [];
 
                 // check for invalid names
                 for (let i=0; i<data.length; ++i)
@@ -103,7 +103,7 @@ module.exports = function(RED)
             }
             else
             {
-                return true;
+                return false;
             }
 
             function hasDuplicates(arr)

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -681,8 +681,8 @@ module.exports = function(RED)
 
             if (((typeof data.value != "string") && (typeof data.value != "number")) ||
                 ((data.type == "time") && !chronos.isValidUserTime(data.value)) ||
-                ((data.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(data.value)) ||
-                ((data.type == "moon") && !/^(rise|set)$/.test(data.value)))
+                ((data.type == "sun") && !chronos.PATTERN_SUNTIME.test(data.value)) ||
+                ((data.type == "moon") && !chronos.PATTERN_MOONTIME.test(data.value)))
             {
                 return false;
             }

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -55,14 +55,35 @@ SOFTWARE.
                     Nachricht.
                 </li>
                 <li>
-                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeitstempel aus
-                    einer Kontextvariablen or einer Nachrichteneigenschaft als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
-                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
-                    Region-spezifischem Format oder ein Datum und eine Zeit
-                    nach ISO 8601 enthält.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeit aus einer
+                    Kontextvariablen or einer Nachrichteneigenschaft. Die
+                    Variablen/Eigenschaften können folgendes Format haben:
+                    <ul>
+                        <li>
+                            Zahl (Zeitstempel)
+                            <ul>
+                                <li>
+                                    Anzahl Millisekunden seit Beginn der
+                                    UNIX-Zeitzählung
+                                </li>
+                                <li>
+                                    Anzahl Millisekunden seit Mitternacht,
+                                    wenn Wert kleiner als 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            Zeichenkette
+                            <ul>
+                                <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                                <li>
+                                    Datum und Uhrzeit in Region-spezifischem
+                                    Format
+                                </li>
+                                <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
         </dd>
@@ -151,10 +172,10 @@ SOFTWARE.
             gibt es folgende Möglichkeiten:
             <ul>
                 <li>
-                    <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt in der
-                    Form <code>hh:mm[:ss] [am|pm]</code> eingegeben werden.
-                    Optional ist die Eingabe eines Datums und einer Zeit in
-                    Region-spezifischem oder ISO 8601 Format möglich.
+                    <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12-
+                    oder 24-Stunden-Format eingegeben werden. Optional ist die
+                    Eingabe eines Datums und einer Zeit in Region-spezifischem
+                    oder ISO 8601 Format möglich.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
@@ -170,13 +191,44 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: Die Zeit
-                    wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
-                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
-                    Region-spezifischem Format oder ein Datum und eine Zeit
-                    nach ISO 8601 enthält.
+                    wird aus einer Umgebungs- oder Kontextvariablen oder einer
+                    Nachrichteneigenschaft gelesen. Die Variablen/Eigenschaften
+                    können folgendes Format haben:
+                    <ul>
+                        <li>
+                            Zahl (Zeitstempel)
+                            <ul>
+                                <li>
+                                    Anzahl Millisekunden seit Beginn der
+                                    UNIX-Zeitzählung
+                                </li>
+                                <li>
+                                    Anzahl Millisekunden seit Mitternacht,
+                                    wenn Wert kleiner als 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            Zeichenkette
+                            <ul>
+                                <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                                <li>Sonnenstand</li>
+                                <li>Mondstand</li>
+                                <li>Benutzerdefinierter Sonnenstand</li>
+                                <li>
+                                    Datum und Uhrzeit in Region-spezifischem
+                                    Format
+                                </li>
+                                <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                                <li>Datum und Sonnenstand</li>
+                                <li>Datum und Mondstand</li>
+                                <li>
+                                    Datum und benutzerdefinierter
+                                    Sonnenstand
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -57,14 +57,35 @@ SOFTWARE.
                     Nachricht.
                 </li>
                 <li>
-                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeitstempel aus
-                    einer Kontextvariablen or einer Nachrichteneigenschaft als
-                    Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
-                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
-                    Region-spezifischem Format oder ein Datum und eine Zeit
-                    nach ISO 8601 enthält.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Zeit aus einer
+                    Kontextvariablen or einer Nachrichteneigenschaft. Die
+                    Variablen/Eigenschaften können folgendes Format haben:
+                    <ul>
+                        <li>
+                            Zahl (Zeitstempel)
+                            <ul>
+                                <li>
+                                    Anzahl Millisekunden seit Beginn der
+                                    UNIX-Zeitzählung
+                                </li>
+                                <li>
+                                    Anzahl Millisekunden seit Mitternacht,
+                                    wenn Wert kleiner als 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            Zeichenkette
+                            <ul>
+                                <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                                <li>
+                                    Datum und Uhrzeit in Region-spezifischem
+                                    Format
+                                </li>
+                                <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
         </dd>
@@ -130,10 +151,10 @@ SOFTWARE.
             gibt es folgende Möglichkeiten:
             <ul>
                 <li>
-                    <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt in der
-                    Form <code>hh:mm[:ss] [am|pm]</code> eingegeben werden.
-                    Optional ist die Eingabe eines Datums und einer Zeit in
-                    Region-spezifischem oder ISO 8601 Format möglich.
+                    <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12-
+                    oder 24-Stunden-Format eingegeben werden. Optional ist die
+                    Eingabe eines Datums und einer Zeit in Region-spezifischem
+                    oder ISO 8601 Format möglich.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
@@ -149,13 +170,44 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: Die Zeit
-                    wird aus einer Kontextvariablen or einer Nachrichteneigenschaft
-                    als Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
-                    (oder Anzahl Millisekunden seit Mitternacht, wenn kleiner
-                    als 86.400.000) oder eine Zeichenkette, die eine Zeit im
-                    12- oder 24-Stunden-Format, ein Datum und eine Zeit in
-                    Region-spezifischem Format oder ein Datum und eine Zeit
-                    nach ISO 8601 enthält.
+                    wird aus einer Umgebungs- oder Kontextvariablen oder einer
+                    Nachrichteneigenschaft gelesen. Die Variablen/Eigenschaften
+                    können folgendes Format haben:
+                    <ul>
+                        <li>
+                            Zahl (Zeitstempel)
+                            <ul>
+                                <li>
+                                    Anzahl Millisekunden seit Beginn der
+                                    UNIX-Zeitzählung
+                                </li>
+                                <li>
+                                    Anzahl Millisekunden seit Mitternacht,
+                                    wenn Wert kleiner als 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            Zeichenkette
+                            <ul>
+                                <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                                <li>Sonnenstand</li>
+                                <li>Mondstand</li>
+                                <li>Benutzerdefinierter Sonnenstand</li>
+                                <li>
+                                    Datum und Uhrzeit in Region-spezifischem
+                                    Format
+                                </li>
+                                <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                                <li>Datum und Sonnenstand</li>
+                                <li>Datum und Mondstand</li>
+                                <li>
+                                    Datum und benutzerdefinierter
+                                    Sonnenstand
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -53,13 +53,32 @@ SOFTWARE.
                     <i>message ingress</i>: Ingress time of the input message.
                 </li>
                 <li>
-                    <i>global</i>, <i>flow</i>, <i>msg</i>: Timestamp from
-                    a context variable or message property as number of
-                    milliseconds elapsed since the UNIX epoch (or number
-                    of milliseconds elapsed since midnight if smaller than
-                    86.400.000) or a string containing a time in 12 or 24
-                    hour format, a region-specific datetime or an ISO 8601
-                    datetime.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Time from a context
+                    variable or message property. The variables/properties can
+                    have the following format:
+                    <ul>
+                        <li>
+                            Number (timestamp)
+                            <ul>
+                                <li>
+                                    Number of milliseconds elapsed since the UNIX
+                                    epoch
+                                </li>
+                                <li>
+                                    Number of milliseconds elapsed since midnight
+                                    if value is smaller than 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            String
+                            <ul>
+                                <li>Time in 12 or 24 hour format</li>
+                                <li>Date and time in region-specific format</li>
+                                <li>Date and time in ISO 8601 format</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
         </dd>
@@ -144,9 +163,8 @@ SOFTWARE.
             <ul>
                 <li>
                     <i>time of day</i>: A specific time can be entered directly
-                    in the form <code>hh:mm[:ss] [am|pm]</code>. Optionally it
-                    is possible to specify a date and a time using regional or
-                    ISO 8601 format.
+                    in 12 or 24 hour format. Optionally it is possible to specify
+                    a date and a time using regional or ISO 8601 format.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
@@ -163,11 +181,37 @@ SOFTWARE.
                 <li>
                     <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: The time is
                     retrieved from an environment variable, a context variable or a
-                    message property with a timestamp as number of milliseconds elapsed
-                    since the UNIX epoch (or number of milliseconds elapsed since
-                    midnight if smaller than 86.400.000) or a string containing a
-                    time in 12 or 24 hour format, a region-specific datetime or an
-                    ISO 8601 datetime.
+                    message property. The variables/properties can have the following
+                    format:
+                    <ul>
+                        <li>
+                            Number (timestamp)
+                            <ul>
+                                <li>
+                                    Number of milliseconds elapsed since the UNIX
+                                    epoch
+                                </li>
+                                <li>
+                                    Number of milliseconds elapsed since midnight
+                                    if value is smaller than 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            String
+                            <ul>
+                                <li>Time in 12 or 24 hour format</li>
+                                <li>Sun time</li>
+                                <li>Moon time</li>
+                                <li>Custom sun time</li>
+                                <li>Date and time in region-specific format</li>
+                                <li>Date and time in ISO 8601 format</li>
+                                <li>Date and sun time</li>
+                                <li>Date and moon time</li>
+                                <li>Date and custom sun time</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -53,13 +53,32 @@ SOFTWARE.
                     <i>message ingress</i>: Ingress time of the input message.
                 </li>
                 <li>
-                    <i>global</i>, <i>flow</i>, <i>msg</i>: Timestamp from
-                    a context variable or message property as number of
-                    milliseconds elapsed since the UNIX epoch (or number
-                    of milliseconds elapsed since midnight if smaller than
-                    86.400.000) or a string containing a time in 12 or 24
-                    hour format, a region-specific datetime or an ISO 8601
-                    datetime.
+                    <i>global</i>, <i>flow</i>, <i>msg</i>: Time from a context
+                    variable or message property. The variables/properties can
+                    have the following format:
+                    <ul>
+                        <li>
+                            Number (timestamp)
+                            <ul>
+                                <li>
+                                    Number of milliseconds elapsed since the UNIX
+                                    epoch
+                                </li>
+                                <li>
+                                    Number of milliseconds elapsed since midnight
+                                    if value is smaller than 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            String
+                            <ul>
+                                <li>Time in 12 or 24 hour format</li>
+                                <li>Date and time in region-specific format</li>
+                                <li>Date and time in ISO 8601 format</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
         </dd>
@@ -123,9 +142,8 @@ SOFTWARE.
             <ul>
                 <li>
                     <i>time of day</i>: A specific time can be entered directly
-                    in the form <code>hh:mm[:ss] [am|pm]</code>. Optionally it
-                    is possible to specify a date and a time using regional or
-                    ISO 8601 format.
+                    in 12 or 24 hour format. Optionally it is possible to specify
+                    a date and a time using regional or ISO 8601 format.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
@@ -142,11 +160,37 @@ SOFTWARE.
                 <li>
                     <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: The time is
                     retrieved from an environment variable, a context variable or a
-                    message property with a timestamp as number of milliseconds elapsed
-                    since the UNIX epoch (or number of milliseconds elapsed since
-                    midnight if smaller than 86.400.000) or a string containing a
-                    time in 12 or 24 hour format, a region-specific datetime or an
-                    ISO 8601 datetime.
+                    message property. The variables/properties can have the following
+                    format:
+                    <ul>
+                        <li>
+                            Number (timestamp)
+                            <ul>
+                                <li>
+                                    Number of milliseconds elapsed since the UNIX
+                                    epoch
+                                </li>
+                                <li>
+                                    Number of milliseconds elapsed since midnight
+                                    if value is smaller than 86.400.000
+                                </li>
+                            </ul>
+                        </li>
+                        <li>
+                            String
+                            <ul>
+                                <li>Time in 12 or 24 hour format</li>
+                                <li>Sun time</li>
+                                <li>Moon time</li>
+                                <li>Custom sun time</li>
+                                <li>Date and time in region-specific format</li>
+                                <li>Date and time in ISO 8601 format</li>
+                                <li>Date and sun time</li>
+                                <li>Date and moon time</li>
+                                <li>Date and custom sun time</li>
+                            </ul>
+                        </li>
+                    </ul>
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -750,8 +750,8 @@ module.exports = function(RED)
 
                 if (((typeof data.value != "string") && (typeof data.value != "number")) ||
                     ((data.type == "time") && !chronos.isValidUserTime(data.value)) ||
-                    ((data.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(data.value)) ||
-                    ((data.type == "moon") && !/^(rise|set)$/.test(data.value)))
+                    ((data.type == "sun") && !chronos.PATTERN_SUNTIME.test(data.value)) ||
+                    ((data.type == "moon") && !chronos.PATTERN_MOONTIME.test(data.value)))
                 {
                     return false;
                 }

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -848,8 +848,8 @@ module.exports = function(RED)
 
             if (((typeof data.value != "string") && (typeof data.value != "number")) ||
                 ((data.type == "time") && !chronos.isValidUserTime(data.value)) ||
-                ((data.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(data.value)) ||
-                ((data.type == "moon") && !/^(rise|set)$/.test(data.value)) ||
+                ((data.type == "sun") && !chronos.PATTERN_SUNTIME.test(data.value)) ||
+                ((data.type == "moon") && !chronos.PATTERN_MOONTIME.test(data.value)) ||
                 ((data.type == "crontab") && !cronosjs.validate(data.value, {strict: true})))
             {
                 return false;

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -844,8 +844,8 @@ module.exports = function(RED)
 
             if (((typeof data.value != "string") && (typeof data.value != "number")) ||
                 ((data.type == "time") && !chronos.isValidUserTime(data.value)) ||
-                ((data.type == "sun") && !/^(sunrise|sunriseEnd|sunsetStart|sunset|goldenHour|goldenHourEnd|night|nightEnd|dawn|nauticalDawn|dusk|nauticalDusk|solarNoon|nadir)$/.test(data.value)) ||
-                ((data.type == "moon") && !/^(rise|set)$/.test(data.value)))
+                ((data.type == "sun") && !chronos.PATTERN_SUNTIME.test(data.value)) ||
+                ((data.type == "moon") && !chronos.PATTERN_MOONTIME.test(data.value)))
             {
                 return false;
             }


### PR DESCRIPTION
This pull request extends the possibilities for providing date and time via a string from message properties, environment variables or context variables. With this change, it is additionally possible to supply a sun time, moon time or custom sun time in the input string.

Additionally, there are some improvements for the calculation of the _between_ and _outside_ operators, especially when dates are supplied and some other minor code improvements/refactorings.