### PR TITLE
More intuitive expand/collapse buttons for time switch/filter node

### DIFF
--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -23,6 +23,12 @@ SOFTWARE.
 -->
 
 <script type="text/html" data-template-name="chronos-filter">
+    <style>
+        a:focus:not(:focus-visible)
+        {
+            outline: none;
+        }
+    </style>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.name">
@@ -371,8 +377,8 @@ SOFTWARE.
                                         .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time1.typedInput("width", "280px");
                     time1._prevType = "time";
-                    const extend1 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
-                                        .html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>")
+                    const extend1 = $("<a/>", {href: "#", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.expand"), style: "margin-left: 6px;"})
+                                        .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time1Row1);
 
                     const time2 = $("<input/>", {type: "text", class: "node-input-time2"})
@@ -380,8 +386,8 @@ SOFTWARE.
                                         .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time2.typedInput("width", "280px");
                     time2._prevType = "time";
-                    const extend2 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
-                                        .html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>")
+                    const extend2 = $("<a/>", {href: "#", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.expand"), style: "margin-left: 6px;"})
+                                        .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time2Row1);
 
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
@@ -572,13 +578,13 @@ SOFTWARE.
                     function showExtensionRow1()
                     {
                         time1Row2.show();
-                        extend1.html("<i class='fa fa-angle-double-up' aria-hidden='true'></i>");
+                        extend1.html("<i class='fa fa-angle-down' aria-hidden='true'></i>");
                     }
 
                     function hideExtensionRow1()
                     {
                         time1Row2.hide();
-                        extend1.html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>");
+                        extend1.html("<i class='fa fa-angle-right' aria-hidden='true'></i>");
 
                         offset1.spinner("value", 0);
                         random1.prop("checked", false);
@@ -587,13 +593,13 @@ SOFTWARE.
                     function showExtensionRow2()
                     {
                         time2Row2.show();
-                        extend2.html("<i class='fa fa-angle-double-up' aria-hidden='true'></i>");
+                        extend2.html("<i class='fa fa-angle-down' aria-hidden='true'></i>");
                     }
 
                     function hideExtensionRow2()
                     {
                         time2Row2.hide();
-                        extend2.html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>");
+                        extend2.html("<i class='fa fa-angle-right' aria-hidden='true'></i>");
 
                         offset2.spinner("value", 0);
                         random2.prop("checked", false);

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -25,7 +25,8 @@
         },
         "tooltip":
         {
-            "offset":  "Versatz (in Minuten)"
+            "offset":  "Versatz (in Minuten)",
+            "expand":  "Aus-/Einklappen"
         },
         "list":
         {

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -232,8 +232,9 @@ SOFTWARE.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines
-            (wahlweise zufälligen) Versatzes verschoben werden. Das ist über
-            den Doppelpfeil auf der rechten Seite erreichbar.
+            (wahlweise zufälligen) Versatzes verschoben werden. Die
+            entsprechenden Eingabefelder können über den Pfeil-Knopf auf
+            der rechten Seite ausgeklappt werden.
         </dd>
         <dt>Alle Bedingungen müssen zutreffen</dt>
         <dd>

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -211,8 +211,9 @@ SOFTWARE.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines
-            (wahlweise zufälligen) Versatzes verschoben werden. Das ist über
-            den Doppelpfeil auf der rechten Seite erreichbar.
+            (wahlweise zufälligen) Versatzes verschoben werden. Die
+            entsprechenden Eingabefelder können über den Pfeil-Knopf auf
+            der rechten Seite ausgeklappt werden.
         </dd>
         <dt>Bei erster Übereinstimmung aufhören</dt>
         <dd>

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -25,7 +25,8 @@
         },
         "tooltip":
         {
-            "offset":  "Offset (in minutes)"
+            "offset":  "Offset (in minutes)",
+            "expand":  "expand/collapse"
         },
         "list":
         {

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -215,8 +215,8 @@ SOFTWARE.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally
-            randomized) offset, accessible through the double down arrow on the
-            right side.
+            randomized) offset, accessible through the expand/collapse arrow on
+            the right side.
         </dd>
     </dl>
     <h3>Input</h3>

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -194,8 +194,8 @@ SOFTWARE.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally
-            randomized) offset, accessible through the double down arrow on the
-            right side.
+            randomized) offset, accessible through the expand/collapse arrow on
+            the right side.
         </dd>
         <dt>Stop on first match</dt>
         <dd>

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -23,6 +23,12 @@ SOFTWARE.
 -->
 
 <script type="text/html" data-template-name="chronos-switch">
+    <style>
+        a:focus:not(:focus-visible)
+        {
+            outline: none;
+        }
+    </style>
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.name"></span></label>
         <input type="text" id="node-input-name" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.name">
@@ -341,8 +347,8 @@ SOFTWARE.
                                         .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time1.typedInput("width", "280px");
                     time1._prevType = "time";
-                    const extend1 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
-                                        .html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>")
+                    const extend1 = $("<a/>", {href: "#", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.expand"), style: "margin-left: 6px;"})
+                                        .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time1Row1);
 
                     const time2 = $("<input/>", {type: "text", class: "node-input-time2"})
@@ -350,8 +356,8 @@ SOFTWARE.
                                         .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg"]});
                     time2.typedInput("width", "280px");
                     time2._prevType = "time";
-                    const extend2 = $("<a/>", {href: "#", style: "margin-left: 6px;"})
-                                        .html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>")
+                    const extend2 = $("<a/>", {href: "#", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.expand"), style: "margin-left: 6px;"})
+                                        .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time2Row1);
 
                     $("<label/>", {style: "width: auto; margin-right: 6px;"})
@@ -542,13 +548,13 @@ SOFTWARE.
                     function showExtensionRow1()
                     {
                         time1Row2.show();
-                        extend1.html("<i class='fa fa-angle-double-up' aria-hidden='true'></i>");
+                        extend1.html("<i class='fa fa-angle-down' aria-hidden='true'></i>");
                     }
 
                     function hideExtensionRow1()
                     {
                         time1Row2.hide();
-                        extend1.html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>");
+                        extend1.html("<i class='fa fa-angle-right' aria-hidden='true'></i>");
 
                         offset1.spinner("value", 0);
                         random1.prop("checked", false);
@@ -557,13 +563,13 @@ SOFTWARE.
                     function showExtensionRow2()
                     {
                         time2Row2.show();
-                        extend2.html("<i class='fa fa-angle-double-up' aria-hidden='true'></i>");
+                        extend2.html("<i class='fa fa-angle-down' aria-hidden='true'></i>");
                     }
 
                     function hideExtensionRow2()
                     {
                         time2Row2.hide();
-                        extend2.html("<i class='fa fa-angle-double-down' aria-hidden='true'></i>");
+                        extend2.html("<i class='fa fa-angle-right' aria-hidden='true'></i>");
 
                         offset2.spinner("value", 0);
                         random2.prop("checked", false);


### PR DESCRIPTION
This pull request makes the expand/collapse buttons for the _before_, _after_, _between_ and _outside_ operators of time switch and time filter nodes more intuitive by using other symbols and adding tooltips. Additionally, the focus outline is only shown when using keyboard navigation and not when clicking on them with the mouse.