### PR TITLE
Add config variable to all JSONata expressions

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -362,6 +362,14 @@ function getJSONataExpression(RED, node, expr)
 {
     const expression = RED.util.prepareJSONataExpression(expr, node);
 
+    expression.assign(
+        "config", {
+            name: node.config.name,
+            latitude: node.config.latitude,
+            longitude: node.config.longitude,
+            timezone: node.config.timezone,
+            locale: node.locale});
+
     expression.registerFunction("millisecond", ts => { return getMoment(node, ts).millisecond(); }, "<(sn):n>");
     expression.registerFunction("second", ts => { return getMoment(node, ts).second(); }, "<(sn):n>");
     expression.registerFunction("minute", ts => { return getMoment(node, ts).minute(); }, "<(sn):n>");

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -29,7 +29,7 @@ module.exports = function(RED)
         const chronos = require("./common/chronos.js");
         const cronosjs = require("cronosjs");
 
-        let node = this;
+        const node = this;
         RED.nodes.createNode(node, settings);
 
         node.name = settings.name;
@@ -793,18 +793,12 @@ module.exports = function(RED)
         {
             try
             {
-                return await chronos.evaluateJSONataExpression(
-                                            RED,
-                                            expression, {
-                                                name: node.name,
-                                                config: {
-                                                    name: node.config.name,
-                                                    latitude: node.config.latitude,
-                                                    longitude: node.config.longitude,
-                                                    timezone: node.config.timezone},
-                                                schedule: {
-                                                    id: id,
-                                                    trigger: trigger}});
+                expression.assign(
+                            "schedule", {
+                                id: id,
+                                trigger: trigger});
+
+                return await chronos.evaluateJSONataExpression(RED, expression, {});
             }
             catch (e)
             {

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -808,21 +808,15 @@ module.exports = function(RED)
         {
             try
             {
-                return await chronos.evaluateJSONataExpression(
-                                RED,
-                                node.outputValue, {
-                                    name: node.name,
-                                    config: {
-                                        name: node.config.name,
-                                        latitude: node.config.latitude,
-                                        longitude: node.config.longitude,
-                                        timezone: node.config.timezone},
-                                    state: {
+                node.outputValue.assign(
+                                    "state", {
                                         id: node.currentState.data.id,
                                         trigger: node.currentState.data.trigger,
                                         value: (node.currentState.data.state.type === "date") ? Date.now() : node.currentState.data.state.value,
                                         since: node.currentState.since.valueOf(),
-                                        until: node.currentState.until ? node.currentState.until.valueOf() : null}});
+                                        until: node.currentState.until ? node.currentState.until.valueOf() : null});
+
+                return await chronos.evaluateJSONataExpression(RED, node.outputValue, {});
             }
             catch (e)
             {


### PR DESCRIPTION
This pull request adds the expression variable `$config` to all JSONata expressions of all nodes. The variable is an object containing information about the assoctiated configuration node.

### ‼️ Breaking Changes ‼️
- Property `config` in JSONata expressions of Scheduler and State node has been turned into an expression variable and must therefore be accessed as `$config` now.
- Property `schedule` in JSONata expressions of Scheduler node has been turned into an expression variable and must therefore be accessed as `$schedule` now.
- Property `state` in JSONata expressions of State node has been turned into an expression variable and must therefore be accessed as `$state` now.
- Property `name` has been removed from JSONata expressions of Scheduler and State node.