### PR TITLE
Support for passive trigger mode in state node

### DIFF
--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -103,9 +103,10 @@ SOFTWARE.
                         </li>
                         <li>
                             <i>Manueller Auslöser</i>: Zustand wird nicht
-                            automatisch ausgelöst, sondern kann nur manuell
-                            über eine Eingangsnachricht ausgelöst werden.
-                            Siehe Abschnitt <i>Eingabe</i> für weitere Informationen.
+                            automatisch aktiviert, sondern kann nur manuell
+                            über eine Eingabenachricht aktiviert werden.
+                            Siehe Kommando <code>set</code> im Abschnitt
+                            <i>Eingabe</i> für weitere Informationen.
                         </li>
                     </ul>
                 </li>
@@ -178,6 +179,15 @@ SOFTWARE.
             Optional kann eine Verzögerung angegeben werden, nach der die Ausgabe
             erfolgt (standardmäßig nach 0,1 Sekunden).
         </dd>
+        <dt>Passiver Auslösemodus</dt>
+        <dd>
+            Wenn aktiviert, wird der Knoten beim Erreichen der Auslösezeitpunkte
+            die Zustände nicht selbstständig ändern. Stattdessen müssen
+            Zustandsänderungen von einem externen Zeitgeber (beispielsweise
+            einem Scheduler-Knoten) über eine Eingabenachricht ausgelöst werden.
+            Siehe Kommando <code>trigger</code> weiter unten im Abschnitt
+            <i>Eingabe</i> für weitere Informationen.
+        </dd>
     </dl>
     <h3>Eingabe</h3>
     <dt>Zustands-Knoten steuern</dt>
@@ -187,9 +197,9 @@ SOFTWARE.
     </dd>
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
-        <dd>Steuert den Knoten abhängig von den angegebenen Kommandos</dd>
+        <dd>Steuert den Knoten abhängig von den angegebenen Kommandos; entweder "trigger", "get", "set", "reset" oder "reload"</dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
-        <dd>Kennzeichnung des zu aktivierenden Zustands</dd>
+        <dd>Kennzeichnung des auszulösenden oder zu aktivierenden Zustands</dd>
         <dt class="optional">timeout<span class="property-type">number | object</span></dt>
         <dd>Zeit bis der ursprüngliche Zustands wiederhergestellt wird</dd>
     </dl>
@@ -202,26 +212,37 @@ SOFTWARE.
         Folgende Kommandos werden zurzeit unterstützt:
         <ul>
             <li>
-                <code>get</code>: Löst die Ausgabe des aktuellen Zustandswertes
-                aus.
+                <code>trigger</code>: Nur möglich im passiven Auslösemodus.
+                Wenn <code>msg.payload</code> eine gültige Kennzeichnung
+                eines konfigurierten Zustands enthält, wird dieser Zustand
+                aktiviert, sofern die konfigurierten Bedingungen zutreffen.
+                Wenn <code>msg.payload</code> nicht gesetzt ist, wird geprüft,
+                ob der Auslösezeitpunkt eines Zustands erreicht wurde und
+                in diesem Fall, unter der Voraussetzung dass die Bedingungen
+                erfüllt sind, der Zustand aktiviert. Wenn sich der Zustand
+                durch die Aktion ändert, wird der aktuelle Wert des Zustands
+                ausgegeben.
             </li>
             <li>
-                <code>set</code>: Setzt den aktuellen Zustand auf den konfigurierten
-                Zustand mit der Kennzeichnung in <code>msg.payload</code>. Die
-                zugehörigen Kennzeichnungen werden in der Zustandsliste neben
-                den Einträgen angezeigt. Wenn sich der Zustand durch die Aktion
-                ändert, wird auch die Ausgabe des Zustands ausgelöst. Optional
-                kann eine Zeit in <code>msg.timeout</code> angegeben werden,
-                nach deren Ablauf der Zustand wie beim Kommando <code>reset</code>
-                zurückgesetzt wird. Die Zeit kann entweder als Zahl in Minuten
-                oder als Objekt mit den Eigenschaften <code>seconds</code>,
-                <code>minutes</code> und/oder <code>hours</code> angegeben werden.
+                <code>get</code>: Gibt den aktuellen Zustandswert aus.
+            </li>
+            <li>
+                <code>set</code>: Setzt den aktuellen Zustand bedingungslos
+                auf den konfigurierten Zustand mit der Kennzeichnung in
+                <code>msg.payload</code>. Wenn sich der Zustand durch die
+                Aktion ändert, wird der aktuelle Wert des Zustands ausgegeben.
+                Optional kann eine Zeit in <code>msg.timeout</code> angegeben
+                werden, nach deren Ablauf der Zustand wie beim Kommando
+                <code>reset</code> zurückgesetzt wird. Die Zeit kann entweder
+                als Zahl in Minuten oder als Objekt mit den Eigenschaften
+                <code>seconds</code>, <code>minutes</code> und/oder
+                <code>hours</code> angegeben werden.
             </li>
             <li>
                 <code>reset</code>: Setzt den aktuellen Zustand auf seinen
                 ursprünglichen Wert anhand des konfigurierten Auslösezeitpunkts
                 und der Bedingungen zurück. Wenn sich der Zustand durch die Aktion
-                ändert, wird auch die Ausgabe des Zustands ausgelöst.
+                ändert, wird der aktuelle Wert des Zustands ausgegeben.
             </li>
             <li>
                 <code>reload</code>: Führt zu einer Neuberechnung der Zeitereignisse
@@ -238,7 +259,7 @@ SOFTWARE.
     </dd>
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
-        <dd>Kontrolkommando; must auf "configure" gesetzt werden</dd>
+        <dd>Kontrolkommando; muss auf "configure" gesetzt werden</dd>
         <dt>payload<span class="property-type">object</span></dt>
         <dd>Überschreibt Zustände und/oder Bedingungen</dd>
     </dl>

--- a/nodes/locales/de/state.json
+++ b/nodes/locales/de/state.json
@@ -10,7 +10,8 @@
             "states":         "Zustände",
             "value":          "Wert",
             "manualTrigger":  "Manueller Auslöser",
-            "outputOnStart":  "Beim Start aktuellen Zustand ausgeben nach"
+            "outputOnStart":  "Beim Start aktuellen Zustand ausgeben nach",
+            "passiveMode":    "Passiver Auslösemodus"
         },
         "status":
         {
@@ -22,7 +23,8 @@
         "error":
         {
             "noStates":           "Keine Zustände konfiguriert",
-            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__"
+            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__",
+            "commandNotAllowed":  "Kommando nur im passiven Auslösemodus erlaubt"
         }
     }
 }

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -96,10 +96,10 @@ SOFTWARE.
                             <i>Input</i> below for details.
                         </li>
                         <li>
-                            <i>manual trigger</i>: State will not be triggered
-                            automatically but can only be triggered manually
-                            via an input message. See section <i>Input</i>
-                            below for details.
+                            <i>manual trigger</i>: State will not be activated
+                            automatically but can only be activated manually
+                            via an input message. See <code>set</code> command
+                            in section <i>Input</i> below for details.
                         </li>
                     </ul>
                 </li>
@@ -169,6 +169,14 @@ SOFTWARE.
             choose a delay after which the output is produced (defaults to 0.1
             seconds).
         </dd>
+        <dt>Passive trigger mode</dt>
+        <dd>
+            If selected, the state node will not actively change states upon
+            reaching their trigger times. Instead, state changes must be
+            triggered by an external timer source (such as a scheduler node)
+            via input message. See <code>trigger</code> command in section
+            <i>Input</i> below for further information.
+        </dd>
     </dl>
     <h3>Input</h3>
     <dt>Control state node</dt>
@@ -178,9 +186,9 @@ SOFTWARE.
     </dd>
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
-        <dd>Control command to be executed</dd>
+        <dd>Control command to be executed; one of "trigger", "get", "set", "reset" or "reload"</dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
-        <dd>Identifier of the state to activate</dd>
+        <dd>Identifier of the state to trigger or activate</dd>
         <dt class="optional">timeout<span class="property-type">number | object</span></dt>
         <dd>Timeout after which the original state is restored</dd>
     </dl>
@@ -193,26 +201,36 @@ SOFTWARE.
         The following commands are currently supported:
         <ul>
             <li>
-                <code>get</code>: Explicitly triggers the output of the current
-                state.
+                <code>trigger</code>: Only allowed in passive trigger mode. If
+                <code>msg.payload</code> contains a valid identifier of a
+                configured state, that state will be activated provided that
+                the configured conditions are met. If <code>msg.payload</code>
+                is not set, checks if the trigger time of a configured state
+                is reached and in this case activates the state provided
+                that the conditions are met. If the state actually changed
+                by this action, the current value of the state will be sent
+                or stored.
             </li>
             <li>
-                <code>set</code>: Sets the current state to the configured state
-                with the identifier in <code>msg.payload</code>. The assigned
-                identifiers are displayed in the state list next to each entry.
-                If the state actually changed by this action, the output of the
-                new state is triggered. Optionally, a timeout can be specified
-                in <code>msg.timeout</code>. After the timeout has elapsed, the
-                state is restored in the same way as the <code>reset</code> command
-                does. The timeout can be specified as number of minutes or as an
-                object containing the properties <code>seconds</code>, <code>minutes</code>
-                and/or <code>hours</code>.
+                <code>get</code>: Explicitly sends or stores the current state
+                value.
+            </li>
+            <li>
+                <code>set</code>: Sets the current state unconditionally to the
+                configured state with the identifier in <code>msg.payload</code>.
+                If the state actually changed by this action, the current value
+                of the state will be sent or stored. Optionally, a timeout can
+                be specified in <code>msg.timeout</code>. After the timeout has
+                elapsed, the state is restored in the same way as the <code>reset</code>
+                command does. The timeout can be specified as number of minutes
+                or as an object containing the properties <code>seconds</code>,
+                <code>minutes</code> and/or <code>hours</code>.
             </li>
             <li>
                 <code>reset</code>: Sets the state back to its original value
                 according to the configured trigger time and conditions. If the
-                state actually changed by this action, the output of the restored
-                state is triggered.
+                state actually changed by this action, the current value of the
+                state will be sent or stored.
             </li>
             <li>
                 <code>reload</code>: Forces state triggers to be recalculated

--- a/nodes/locales/en-US/state.json
+++ b/nodes/locales/en-US/state.json
@@ -10,7 +10,8 @@
             "value":          "Value",
             "states":         "States",
             "manualTrigger":  "manual trigger",
-            "outputOnStart":  "Output current state on start after"
+            "outputOnStart":  "Output current state on start after",
+            "passiveMode":    "Passive trigger mode"
         },
         "status":
         {
@@ -22,7 +23,8 @@
         "error":
         {
             "noStates":           "No states configured",
-            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__"
+            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__",
+            "commandNotAllowed":  "Command only allowed in passive trigger mode"
         }
     }
 }

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -66,6 +66,10 @@ SOFTWARE.
         <input id="node-input-outputOnStartDelay" type="text" placeholder="0.1" style="width: 45px; height: 28px;">&nbsp;
         <span data-i18n="node-red-contrib-chronos/chronos-config:common.list.unit.seconds"></span>
     </div>
+    <div class="form-row">
+        <input id="node-input-passiveMode" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+        <label for="node-input-passiveMode" style="margin-bottom: 0px; width: auto;" data-i18n="state.label.passiveMode"></label>
+    </div>
 </script>
 
 <script type="text/javascript">
@@ -186,6 +190,10 @@ SOFTWARE.
             {
                 value:    0.1,
                 validate: RED.validators.number(true)
+            },
+            passiveMode:
+            {
+                value: false
             }
         },
         oneditprepare: function()


### PR DESCRIPTION
This pull request adds the passive trigger mode to the state node.

In this mode, the state node will not actively change states upon reaching their trigger times. Instead, state changes must be triggered by an external trigger source via input message. This allows for instance to operate a state node and a scheduler node in tandem processing having the scheduler node acting as external timer for the state node. The state node will note schedule any own timers in this (except timers for a specified timeout in the "set" command of an input message).

The new mode also introduces the new command "trigger" for input messages which must be used by external trigger sources.