### PR TITLE
Rename JSONata variable $schedule to $event and reintroduce node name

### DIFF
--- a/nodes/change.js
+++ b/nodes/change.js
@@ -30,6 +30,7 @@ module.exports = function(RED)
         RED.nodes.createNode(this, settings);
 
         node.chronos = require("./common/chronos.js");
+        node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 

--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -362,6 +362,7 @@ function getJSONataExpression(RED, node, expr)
 {
     const expression = RED.util.prepareJSONataExpression(expr, node);
 
+    expression.assign("node", node.name || "");
     expression.assign(
         "config", {
             name: node.config.name,

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -42,6 +42,7 @@ module.exports = function(RED)
         let node = this;
         RED.nodes.createNode(node, settings);
 
+        node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -32,6 +32,7 @@ module.exports = function(RED)
         RED.nodes.createNode(this, settings);
 
         node.chronos = require("./common/chronos.js");
+        node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -32,9 +32,10 @@ module.exports = function(RED)
         const chronos = require("./common/chronos.js");
         const cronosjs = require("cronosjs");
 
-        let node = this;
+        const node = this;
         RED.nodes.createNode(node, settings);
 
+        node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -794,7 +794,7 @@ module.exports = function(RED)
             try
             {
                 expression.assign(
-                            "schedule", {
+                            "event", {
                                 id: id,
                                 trigger: trigger});
 

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -32,6 +32,7 @@ module.exports = function(RED)
         RED.nodes.createNode(this, settings);
 
         node.chronos = require("./common/chronos.js");
+        node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 


### PR DESCRIPTION
This pull request introduces the JSONata expression variable `$node` containing a node's name to all JSONata expressions (this expression variable replaces the property `name` which was removed by pull request #155 from scheduler and state node expressions). It also renames expression variable `$schedule` to `$event` in order to use the name `$schedule` for the whole schedule in future.

### ‼️ Breaking Changes (Update) ‼️
- JSONata expression variable `$schedule` has been renamed to `$event`.
