### PR TITLE
Fix crash when no state is active and other improvements

### DIFF
--- a/nodes/state.js
+++ b/nodes/state.js
@@ -535,6 +535,7 @@ module.exports = function(RED)
         function resetCurrentState()
         {
             cancelTimer();
+            node.currentState = {};
 
             restoreCurrentState(true, false).then(() =>
             {
@@ -670,7 +671,7 @@ module.exports = function(RED)
                                 now, false, false);
             }
 
-            return nextState.triggerTime;
+            return nextState ? nextState.triggerTime : undefined;
         }
 
         function getNextState()
@@ -984,7 +985,7 @@ module.exports = function(RED)
                     stateValue = node.currentState.data.state.value;
                 }
 
-                let when = (node.currentState.until) ? node.currentState.until.calendar() : undefined;
+                let when = node.currentState.until ? node.currentState.until.calendar() : undefined;
 
                 if (when)
                 {
@@ -997,7 +998,7 @@ module.exports = function(RED)
             }
             else
             {
-                node.status({fill: "yellow", shape: "dot", text: "state.status.noState"});
+                node.status({fill: "grey", shape: "dot", text: "state.status.noState"});
             }
         }
     }


### PR DESCRIPTION
This pull request fixes a crash in state node that occurs when the node is stateless (e.g., there are only states with manual triggers configured) and a state is activated.

Additionally, when a state is activated via input message with timeout and all states are manually triggered ones, the node now falls back into stateless state after the state timed out.

Finally, the color of the stateless state has been changed from yellow to grey in the Node-RED editor.