### PR TITLE
Add input message command "getid" to state node

### DIFF
--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -197,7 +197,10 @@ SOFTWARE.
     </dd>
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
-        <dd>Steuert den Knoten abhängig von den angegebenen Kommandos; entweder "trigger", "get", "set", "reset" oder "reload"</dd>
+        <dd>
+            Steuert den Knoten abhängig von den angegebenen Kommandos;
+            entweder "trigger", "get", "getid", "set", "reset" oder "reload"
+        </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Kennzeichnung des auszulösenden oder zu aktivierenden Zustands</dd>
         <dt class="optional">timeout<span class="property-type">number | object</span></dt>
@@ -225,6 +228,14 @@ SOFTWARE.
             </li>
             <li>
                 <code>get</code>: Gibt den aktuellen Zustandswert aus.
+            </li>
+            <li>
+                <code>getid</code>: Schickt eine Nachricht mit der Kennzeichnung
+                des aktuellen Zustands in <code>msg.payload</code> an den
+                Ausgabe-Port. Die Nachricht enthält die ursprüngliche
+                <code>msg.topic</code> Eigenschaft mit "getid", um diese
+                von normalen Zustandsänderungsnachrichten unterscheiden
+                zu können.
             </li>
             <li>
                 <code>set</code>: Setzt den aktuellen Zustand bedingungslos
@@ -362,7 +373,8 @@ SOFTWARE.
     <h3>Ausgabe</h3>
     <p>
         Immer wenn sich der Zustand ändert und die Ausgabe als Ausgangsnachricht
-        konfiguriert ist, wird eine Nachricht an den Ausgabe-Port des Knotens
-        gesendet.
+        konfiguriert ist, wird eine Nachricht mit dem Zustandswert an den
+        Ausgabe-Port des Knotens gesendet. Zusätzlich kann eine Antwortnachricht
+        auf das "getid" Kommando an den Ausgabe-Port gesendet werden.
     </p>
 </script>

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -186,7 +186,10 @@ SOFTWARE.
     </dd>
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
-        <dd>Control command to be executed; one of "trigger", "get", "set", "reset" or "reload"</dd>
+        <dd>
+            Control command to be executed;
+            one of "trigger", "get", "getid", "set", "reset" or "reload"
+        </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Identifier of the state to trigger or activate</dd>
         <dt class="optional">timeout<span class="property-type">number | object</span></dt>
@@ -214,6 +217,13 @@ SOFTWARE.
             <li>
                 <code>get</code>: Explicitly sends or stores the current state
                 value.
+            </li>
+            <li>
+                <code>getid</code>: Sends a message with the identifier of the
+                currently active state in <code>msg.payload</code> to the output
+                port. The message contains the original <code>msg.topic</code>
+                property with "getid" in order to distinguish it from normal
+                state change output messages.
             </li>
             <li>
                 <code>set</code>: Sets the current state unconditionally to the
@@ -347,7 +357,8 @@ SOFTWARE.
     <h3>Output</h3>
     <p>
         Whenever the state changes and the output is configured to be a message
-        property or a full message, a message is sent to the output port of this
-        node.
+        property or a full message, a message containing the state value is
+        sent to the output port of this node. Additionally, a response to the
+        "getid" command may be sent to the output port.
     </p>
 </script>

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -219,7 +219,7 @@ module.exports = function(RED)
                             return;
                         }
 
-                        if (msg.topic == "trigger")
+                        if (msg.topic === "trigger")
                         {
                             if (node.passiveMode)
                             {
@@ -267,6 +267,16 @@ module.exports = function(RED)
                         else if (msg.topic === "get")
                         {
                             outputCurrentState();
+                            done();
+                        }
+                        else if (msg.topic === "getid")
+                        {
+                            if (node.currentState.data)
+                            {
+                                msg.payload = node.currentState.data.id;
+                                send(msg);
+                            }
+
                             done();
                         }
                         else if (msg.topic === "set")


### PR DESCRIPTION
This pull request adds a new command for input messages to state nodes. The command "getid" can be used to query the identifier of the currently active state.

In order to be able to distinguish the response message from normal state change output messages, the response message to the "getid" command contains the original `msg.topic` property with "getid".