### PR TITLE
Add new commands "pause" and "resume" to state node

### DIFF
--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -199,7 +199,8 @@ SOFTWARE.
         <dt>topic<span class="property-type">string</span></dt>
         <dd>
             Steuert den Knoten abhängig von den angegebenen Kommandos;
-            entweder "trigger", "get", "getid", "set", "reset" oder "reload"
+            entweder "trigger", "get", "getid", "set", "reset", "reload",
+            "pause" oder "resume"
         </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Kennzeichnung des auszulösenden oder zu aktivierenden Zustands</dd>
@@ -259,6 +260,20 @@ SOFTWARE.
                 <code>reload</code>: Führt zu einer Neuberechnung der Zeitereignisse
                 (programmierte Daten aus Umgebungs- und Kontextvariablen werden
                 ebenfalls erneut geladen).
+            </li>
+            <li>
+                <code>pause</code>: Unterdrückt automatische Zustandsänderungen
+                wenn Auslösezeiten erreicht werden. Hat keine Wirkung, wenn der
+                passive Auslösemodus aktiviert ist.
+            </li>
+            <li>
+                <code>resume</code>: Setzt automatische Zustandsänderungen
+                wieder in Gang. Hat keine Wirkung, wenn der passive Auslösemodus
+                aktiviert ist. Bitte beachten, dass dieses Kommando den
+                aktuellen Zustand nicht auf denjenigen Zustand zurücksetzt,
+                der normalerweise während der pausierten Zeitspanne ausgelöst
+                worden wäre. Um den Zustand zurückzusetzen, muss zusätzlich
+                das Kommando <code>reset</code> geschickt werden.
             </li>
         </ul>
     </dd>

--- a/nodes/locales/de/state.json
+++ b/nodes/locales/de/state.json
@@ -15,16 +15,15 @@
         },
         "status":
         {
-            "noStates":          "Keine Zustände",
-            "noState":           "Kein aktueller Zustand",
-            "currentState":      "Aktueller Zustand",
-            "until":             "bis"
+            "noStates":      "Keine Zustände",
+            "noState":       "Kein aktueller Zustand",
+            "currentState":  "Aktueller Zustand",
+            "until":         "bis"
         },
         "error":
         {
             "noStates":           "Keine Zustände konfiguriert",
-            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__",
-            "commandNotAllowed":  "Kommando nur im passiven Auslösemodus erlaubt"
+            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__"
         }
     }
 }

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -187,8 +187,8 @@ SOFTWARE.
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
         <dd>
-            Control command to be executed;
-            one of "trigger", "get", "getid", "set", "reset" or "reload"
+            Control command to be executed; one of "trigger", "get", "getid",
+            "set", "reset", "reload", "pause" or "resume"
         </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Identifier of the state to trigger or activate</dd>
@@ -204,8 +204,8 @@ SOFTWARE.
         The following commands are currently supported:
         <ul>
             <li>
-                <code>trigger</code>: Only allowed in passive trigger mode. If
-                <code>msg.payload</code> contains a valid identifier of a
+                <code>trigger</code>: Only supported in passive trigger mode.
+                If <code>msg.payload</code> contains a valid identifier of a
                 configured state, that state will be activated provided that
                 the configured conditions are met. If <code>msg.payload</code>
                 is not set, checks if the trigger time of a configured state
@@ -246,6 +246,19 @@ SOFTWARE.
                 <code>reload</code>: Forces state triggers to be recalculated
                 (also reloads programmed data from environment and context
                 variables).
+            </li>
+            <li>
+                <code>pause</code>: Suppresses automatic state changes when
+                trigger times have been reached. Does nothing if passive trigger
+                mode is enabled.
+            </li>
+            <li>
+                <code>resume</code>: Resumes automatic state changes. Does
+                nothing if passive trigger mode is enabled. Note that this
+                command does not reset the current state to the state that
+                would have normally been activated during paused period.
+                Additionally use the <code>reset</code> command to also have
+                the state reset.
             </li>
         </ul>
     </dd>

--- a/nodes/locales/en-US/state.json
+++ b/nodes/locales/en-US/state.json
@@ -15,16 +15,15 @@
         },
         "status":
         {
-            "noStates":          "no states",
-            "noState":           "no current state",
-            "currentState":      "current state",
-            "until":             "until"
+            "noStates":      "no states",
+            "noState":       "no current state",
+            "currentState":  "current state",
+            "until":         "until"
         },
         "error":
         {
             "noStates":           "No states configured",
-            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__",
-            "commandNotAllowed":  "Command only allowed in passive trigger mode"
+            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__"
         }
     }
 }


### PR DESCRIPTION
This pull request adds the new commands "pause" and "resume" to the state node. With these commands, automatic state changes can be suspended in order to keep specific states active for longer time. This is especially useful in combination with manual states.