### PR TITLE
Optimize scheduler resource usage

### DIFF
--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -8,9 +8,11 @@
             "outputPort":     "Geplante Nachricht",
             "eventTimes":     "Ereigniszeiten",
             "schedule":       "Zeitplan",
+            "options":        "Optionen",
             "crontab":        "Cron-Tabelle",
             "multiPort":      "Separate Ausgabe-Ports für Zeitereignisse",
             "nextEventPort":  "Ausgabe-Port für Ereigniszeiten",
+            "delayOnStart":   "Beim Starten Nachrichten verzögern um",
             "disabled":       "Mit inaktivem Zeitplan starten"
         },
         "status":
@@ -18,7 +20,7 @@
             "noSchedule":        "Kein Zeitplan",
             "noTime":            "Kein Zeitpunkt",
             "disabledSchedule":  "Zeitplan inaktiv",
-            "nextEvent":         "Nächstes Ereignis:"
+            "nextEvent":         "Nächstes Ereignis"
         },
         "error":
         {

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -8,9 +8,11 @@
             "outputPort":     "scheduled message",
             "eventTimes":     "event times",
             "schedule":       "Schedule",
+            "options":        "Options",
             "crontab":        "cron table",
             "multiPort":      "Dedicated output ports for schedule events",
             "nextEventPort":  "Output port for event times",
+            "delayOnStart":   "Delay messages on start by",
             "disabled":       "Start with disabled schedule"
         },
         "status":
@@ -18,7 +20,7 @@
             "noSchedule":        "no schedule",
             "noTime":            "no time",
             "disabledSchedule":  "disabled",
-            "nextEvent":         "next event at"
+            "nextEvent":         "next event"
         },
         "error":
         {

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -31,23 +31,37 @@ SOFTWARE.
         <label for="node-input-config"><i class="fa fa-cog"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.config"></span></label>
         <input type="text" id="node-input-config" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.config">
     </div>
-    <div class="form-row node-input-scheduleList-row" style="padding-top: 10px">
-        <label for="node-input-scheduleList"><i class="fa fa-calendar-o"></i> <span data-i18n="scheduler.label.schedule"></span></label>
-        <div class="form-row">
-            <ol id="node-input-scheduleList"></ol>
+    <div class="form-row" style="margin-bottom: 0px;">
+        <ul style="min-width: 600px; margin-bottom: 20px;" id="tab-row"></ul>
+    </div>
+    <div id="tabs-content">
+        <div id="tab-schedule" style="display: none;">
+            <div class="form-row list-row">
+                <div class="form-row">
+                    <ol id="node-input-scheduleList"></ol>
+                </div>
+            </div>
         </div>
-    </div>
-    <div class="form-row">
-        <input id="node-input-multiPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
-    </div>
-    <div class="form-row">
-        <input id="node-input-nextEventPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-nextEventPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.nextEventPort"></label>
-    </div>
-    <div class="form-row">
-        <input id="node-input-disabled" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-disabled" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.disabled"></label>
+        <div id="tab-options" style="display: none;">
+            <div class="form-row">
+                <input id="node-input-disabled" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-disabled" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.disabled"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-multiPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-nextEventPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-nextEventPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.nextEventPort"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-delayOnStart" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-delayOnStart" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.delayOnStart"></label>
+                <input id="node-input-onStartDelay" type="text" placeholder="0.1" style="width: 45px; height: 28px;">&nbsp;
+                <span data-i18n="node-red-contrib-chronos/chronos-config:common.list.unit.seconds"></span>
+            </div>
+        </div>
     </div>
 </script>
 
@@ -136,6 +150,10 @@ SOFTWARE.
                     return v.length > 0;
                 }
             },
+            disabled:
+            {
+                value: false
+            },
             multiPort:
             {
                 value: false
@@ -144,9 +162,14 @@ SOFTWARE.
             {
                 value: false
             },
-            disabled:
+            delayOnStart:
             {
-                value: false
+                value: true
+            },
+            onStartDelay:
+            {
+                value:    0.1,
+                validate: RED.validators.number(true)
             },
             outputs:
             {
@@ -156,6 +179,21 @@ SOFTWARE.
         oneditprepare: function()
         {
             const node = this;
+
+            const tabs = RED.tabs.create(
+            {
+                id: "tab-row",
+                onchange: function(tab)
+                {
+                    $("#tabs-content").children().hide();
+                    $("#" + tab.id).show();
+                    RED.tray.resize();
+                }
+            });
+
+            tabs.addTab({id: "tab-schedule", iconClass: "fa fa-calendar", label: node._("scheduler.label.schedule")});
+            tabs.addTab({id: "tab-options", iconClass: "fa fa-cogs", label: node._("scheduler.label.options")});
+            tabs.activateTab("tab-schedule");
 
             const scheduleList = $("#node-input-scheduleList").css("min-width", "500px").css("min-height", "150px").editableList(
             {
@@ -442,6 +480,17 @@ SOFTWARE.
                 }
             });
 
+            // backward compatibility to v1.23.x and earlier
+            if (typeof node.delayOnStart == "undefined")
+            {
+                $("#node-input-delayOnStart").prop("checked", true);
+            }
+
+            $("#node-input-delayOnStart").on("change", function()
+            {
+                $("#node-input-onStartDelay").attr("disabled", !$("#node-input-delayOnStart").prop("checked"));
+            });
+
             node.schedule.forEach(data =>
             {
                 scheduleList.editableList("addItem", data);
@@ -552,19 +601,26 @@ SOFTWARE.
         },
         oneditresize: function(size)
         {
-            const scheduleListRow = $("#dialog-form>div.node-input-scheduleList-row");
-            const otherRows = $("#dialog-form>div:not(.node-input-scheduleList-row)");
+            const listRow = $("#dialog-form div.list-row");
+            const otherRows = $("#dialog-form>div");
             let height = size.height;
 
             for (let i=0; i<otherRows.length; ++i)
             {
-                height -= $(otherRows[i]).outerHeight(true);
+                let row = $(otherRows[i]);
+
+                if (row.is(":visible") && (row.attr("id") != "tabs-content"))
+                {
+                    height -= row.outerHeight(true);
+                }
             }
 
-            height -= (parseInt(scheduleListRow.css("marginTop")) + parseInt(scheduleListRow.css("marginBottom")));
-            height -= $("#dialog-form>div.node-input-scheduleList-row>label").outerHeight(true);
+            height -= (parseInt(listRow.css("marginTop")) + parseInt(listRow.css("marginBottom")));
 
-            $("#node-input-scheduleList").editableList("height", height);
+            if ($("#tab-schedule").is(":visible"))
+            {
+                $("#node-input-scheduleList").editableList("height", height);
+            }
         }
     });
 </script>

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -897,9 +897,9 @@ SOFTWARE.
         },
         oneditresize: function(size)
         {
+            const listRow = $("#dialog-form div.list-row");
+            const otherRows = $("#dialog-form>div");
             let height = size.height;
-            let listRow = $("#dialog-form div.list-row");
-            let otherRows = $("#dialog-form>div");
 
             for (let i=0; i<otherRows.length; ++i)
             {

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -327,7 +327,7 @@ module.exports = function(RED)
 
                                             node.debug("[State:" + node.currentState.data.id + "] Starting timer for timeout of " + timeout + " milliseconds");
                                             node.currentState.timer = setTimeout(resetCurrentState, timeout);
-                                            node.trace("[State:" + node.currentState.data.id + "] Successfully started timer with ID " + node.currentState.timer);
+                                            node.debug("[State:" + node.currentState.data.id + "] Successfully started timer with ID " + node.currentState.timer);
 
                                             node.currentState.until = node.currentState.since.clone();
                                             node.currentState.until.add(timeout, "milliseconds");
@@ -834,7 +834,7 @@ module.exports = function(RED)
                     node.debug("[State:" + state.data.id + "] Starting timer for trigger at " + state.triggerTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
                     node.currentState.timer = setTimeout(async() =>
                     {
-                        node.debug("[State:" + state.data.id + "] Timer expired");
+                        node.trace("[State:" + state.data.id + "] Timer with ID " + node.currentState.timer + " expired");
                         delete node.currentState.timer;
 
                         if (await evalConditions(state.triggerTime))
@@ -854,7 +854,7 @@ module.exports = function(RED)
                         updateStatus();
                     }, state.triggerTime.diff(chronos.getCurrentTime(node)));
 
-                    node.trace("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer);
+                    node.debug("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer);
                 }
             }
         }
@@ -863,7 +863,7 @@ module.exports = function(RED)
         {
             if (node.currentState.timer)
             {
-                node.trace("Cancelling active timer with ID " + node.currentState.timer);
+                node.debug("Cancelling active timer with ID " + node.currentState.timer);
 
                 clearTimeout(node.currentState.timer);
                 delete node.currentState.timer;


### PR DESCRIPTION
This pull request optimizes the resource usage of the scheduler node by reducing the number of scheduled timers. Instead of one timer per enabled event, only a single timer for the next upcoming enabled event is started. Additionally the usage of the Node-RED event `flows:started` for delaying next event messages after node start until flows have been set up has been replaced by a fixed delay that is customizable and by default 0.1 seconds. Reason is that this event is an undocumented internal Node-RED event that shouldn't be used by nodes as it can be removed/changed at any time and also has some restrictions related to maximum number of allowed events. The fixed delay is optional and is used for any message being sent directly after start of the node.