### PR TITLE
Support for changing time zone / UTC offset for convert rule

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -294,7 +294,9 @@ SOFTWARE.
                     const setPartBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const addsubBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const startEndOfBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
-                    const toStringBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
+                    const convertBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
+                    const convertRow1 = $("<div/>").appendTo(convertBox);
+                    const convertRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(convertBox);
 
                     const setPartType = $("<select/>", {class: "node-input-setPartType", style: "width: auto;"})
                                         .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
@@ -347,7 +349,7 @@ SOFTWARE.
                                 class: "node-input-stringFormat",
                                 title: node._("change.label.format"),
                                 placeholder: node._("change.label.formatPlaceholder")})
-                                    .appendTo(toStringBox)
+                                    .appendTo(convertRow1)
                                     .typedInput({
                                         types: [
                                             {
@@ -395,6 +397,35 @@ SOFTWARE.
                                             }]});
                     stringFormat.typedInput("width", "280px");
 
+                    const timeZone =
+                            $("<input/>", {
+                                type: "text",
+                                class: "node-input-timeZone",
+                                title: node._("change.label.format")})
+                                    .appendTo(convertRow2)
+                                    .typedInput({
+                                        types: [
+                                            {
+                                                value: "current",
+                                                label: node._("change.label.currentTZ"),
+                                                hasValue: false
+                                            },
+                                            {
+                                                value: "timeZone",
+                                                label: node._("change.label.timeZone"),
+                                                icon: "fa fa-globe",
+                                                hasValue: true,
+                                                validate: /^.+$/
+                                            },
+                                            {
+                                                value: "utcOffset",
+                                                label: node._("change.label.utcOffset"),
+                                                icon: "fa fa-expand",
+                                                hasValue: true,
+                                                validate: /^(?:Z|[+-]\d\d:\d\d|-?\d+)$/
+                                            }]});
+                    timeZone.typedInput("width", "280px");
+
                     action.change(function()
                     {
                         setBox.hide();
@@ -421,7 +452,7 @@ SOFTWARE.
                         setPartBox.hide();
                         addsubBox.hide();
                         startEndOfBox.hide();
-                        toStringBox.hide();
+                        convertBox.hide();
 
                         const value = $(this).val();
                         switch (value)
@@ -445,7 +476,7 @@ SOFTWARE.
                             }
                             case "toString":
                             {
-                                toStringBox.show();
+                                convertBox.show();
                                 break;
                             }
                         }
@@ -614,8 +645,17 @@ SOFTWARE.
                                 data.format = "iso8601utc";
                             }
 
+                            if (typeof data.tzType == "undefined")
+                            {
+                                data.tzType = "current";
+                                data.tzValue = "";
+                            }
+
                             stringFormat.typedInput("type", data.formatType);
                             stringFormat.typedInput("value", data.format);
+
+                            timeZone.typedInput("type", data.tzType);
+                            timeZone.typedInput("value", data.tzValue);
                         }
                         changeType.val(data.type);
                     }
@@ -648,6 +688,7 @@ SOFTWARE.
                 const date = $(this).find(".node-input-date");
                 const time = $(this).find(".node-input-time");
                 const stringFormat = $(this).find(".node-input-stringFormat");
+                const timeZone = $(this).find(".node-input-timeZone");
 
                 data.action = $(this).find(".node-input-action").val();
                 data.target = {};
@@ -690,6 +731,8 @@ SOFTWARE.
                     {
                         data.formatType = stringFormat.typedInput("type");
                         data.format = stringFormat.typedInput("value");
+                        data.tzType = timeZone.typedInput("type");
+                        data.tzValue = timeZone.typedInput("value");
                     }
                 }
 

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -285,6 +285,21 @@ module.exports = function(RED)
                                             }
                                             case "toString":
                                             {
+                                                if (rule.tzType == "timeZone")
+                                                {
+                                                    input.tz(rule.tzValue);
+                                                }
+                                                else if (rule.tzType == "utcOffset")
+                                                {
+                                                    // if it's a number, convert it to a number
+                                                    if (+rule.tzValue === +rule.tzValue)
+                                                    {
+                                                        rule.tzValue = +rule.tzValue;
+                                                    }
+
+                                                    input.utcOffset(rule.tzValue);
+                                                }
+
                                                 if (rule.formatType == "custom")
                                                 {
                                                     output = input.format(rule.format);

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -199,6 +199,29 @@ SOFTWARE.
                                 entsprechen.
                             </li>
                         </ul>
+                        In der zweiten Zeile kann die lokale Zeit des Eingangszeitstempels
+                        geändert werden:
+                        <ul>
+                            <li>
+                                <i>Aktuelle Zeitzone</i>: Die ursprüngliche Zeitzone
+                                (die Zeitzone, die im verwendeten Konfigurationsknoten
+                                eingestellt wurde) wird beibehalten.
+                            </li>
+                            <li>
+                                <i>Zeitzone</i>: Ein <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">gültiger Zeitzonenname</a>
+                                kann angegeben werden und die Zeit wird in die ensprechende
+                                Zeitzone konvertiert.
+                            </li>
+                            <li>
+                                <i>UTC-Versatz</i>: Ein Versatz in Minuten und/oder
+                                Stunden kann angegeben werden. Eine Zahl zwischen
+                                -16 und 16 wird als Stunden interpretiert, alle Zahlen
+                                außerhalb dieses Bereichs als Minuten. Zusätzlich ist
+                                es möglich, Stunden und Minuten in der Form <code>+/-HH:MM</code>
+                                anzugeben. Der Wert wird als Versatz zur UTC-Zeit
+                                angewendet.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -11,6 +11,9 @@
             "format":             "Format",
             "predefinedFormat":   "Vordefiniertes Format",
             "customFormat":       "Benutzerdefiniertes Format",
+            "currentTZ":          "Aktuelle Zeitzone",
+            "timeZone":           "Zeitzone",
+            "utcOffset":          "UTC-Versatz",
             "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -27,6 +30,7 @@
                 "subtract":  "Abziehen",
                 "startOf":   "Anfang von",
                 "endOf":     "Ende von",
+                "timeZone":  "Zeitzone",
                 "toString":  "Konvertieren"
             },
             "convert":

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -189,6 +189,28 @@ SOFTWARE.
                                 must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
                             </li>
                         </ul>
+                        In the second row, it is possible to change the local time
+                        of the input timestamp:
+                        <ul>
+                            <li>
+                                <i>current time zone</i>: The original time zone (the
+                                time zone configured in the associated configuration
+                                node) is kept unmodified.
+                            </li>
+                            <li>
+                                <i>time zone</i>: The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>
+                                can be specified and the time is converted to that
+                                time zone.
+                            </li>
+                            <li>
+                                <i>UTC offset</i>: An offset in minutes and/or hours
+                                can be specified. A number between -16 and 16 is
+                                interpreted as hours, a number outside of that range
+                                as minutes. Additionally, it is possible to specify
+                                hours and minutes in the form <code>+/-HH:MM</code>.
+                                The value is applied as offset to the UTC time.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -11,6 +11,9 @@
             "format":             "Format",
             "predefinedFormat":   "predefined format",
             "customFormat":       "custom format",
+            "currentTZ":          "current time zone",
+            "timeZone":           "time zone",
+            "utcOffset":          "UTC offset",
             "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -27,6 +30,7 @@
                 "subtract":  "Subtract",
                 "startOf":   "Start of",
                 "endOf":     "End of",
+                "timeZone":  "Time zone",
                 "toString":  "Convert"
             },
             "convert":


### PR DESCRIPTION
This pull request extends the convert rule of the time change node by adding the possibility to set a named time zone or a numerical UTC offset. Thereby the target's local time can be converted to a different time zone than the one configured in the associated config node.