### PR TITLE
Support for basic and extended input format for more nodes

### DIFF
--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -734,6 +734,10 @@ function getTime(RED, node, msg, baseTime, type, value)
         if (type == "env")
         {
             ctxValue = RED.util.evaluateNodeProperty(value, type, node);
+            if (!ctxValue)
+            {
+                ctxValue = value;
+            }
         }
         else if ((type == "global") || (type == "flow"))
         {

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -760,9 +760,7 @@ function getTime(RED, node, msg, baseTime, type, value)
                             RED,
                             node,
                             baseTime,
-                            (typeof ctxValue == "string")
-                                ? "auto"
-                                : "time",
+                            "auto",
                             ctxValue);
 
         if (!ret.isValid())

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -64,11 +64,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -200,11 +201,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -263,11 +263,12 @@ SOFTWARE.
                 <ul>
                     <li>
                         Anzahl Millisekunden seit Beginn der
-                        UNIX-Zeitzählung
+                        UNIX-Zeitzählung (Weltzeit)
                     </li>
                     <li>
                         Anzahl Millisekunden seit Mitternacht,
-                        wenn Wert kleiner als 86.400.000
+                        (lokaler Zeit) wenn Wert kleiner als
+                        86.400.000
                     </li>
                 </ul>
             </li>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -119,26 +119,23 @@ SOFTWARE.
                 <li>
                     <i>Umgebungsvariable</i>: Die Ende-Bedingung wird aus der
                     angegebenen Umgebungsvariablen geladen, siehe Abschnitt
-                    <i>Eingabe</i> (Eigenschaft <code>until</code>) für eine
-                    Beschreibung des Variablenformats.
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
                 <li>
                     <i>global</i>: Die Ende-Bedingung wird aus der angegebenen
-                    globalen Kontextvariablen geladen, siehe Abschnitt <i>Eingabe</i>
-                    (Eigenschaft <code>until</code>) für eine Beschreibung des
-                    Variablenformats.
+                    globalen Kontextvariablen geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
                 <li>
                     <i>flow</i>: Die Ende-Bedingung wird aus der angegebenen
-                    Flow-Kontextvariablen geladen, siehe Abschnitt <i>Eingabe</i>
-                    (Eigenschaft <code>until</code>) für eine Beschreibung des
-                    Variablenformats.
+                    Flow-Kontextvariablen geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
             </ul>
         </dd>
         <dt>Datum</dt>
         <dd>
-            Ein Datum für den Endezeitpunkt kann in der Form <code>JJJJ-MM-TT</code>
+            Ein Datum für den Endzeitpunkt kann in der Form <code>JJJJ-MM-TT</code>
             angegeben werden. Falls nicht angegeben, wird das Datum des Eintreffens
             der Nachricht verwendet.
         </dd>
@@ -244,16 +241,58 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
-        <dd>Art des Endezeitpunkts; entweder "time", "sun", "moon" oder "custom"</dd>
+        <dd>Art des Endzeitpunkts; entweder "time", "sun", "moon" oder "custom"</dd>
         <dt>value<span class="property-type">string | number</span></dt>
-        <dd>Endezeitpunkt; der Inhalt ist abhängig von der Art des Endezeitpunkts</dd>
+        <dd>Endzeitpunkt; der Inhalt ist abhängig von der Art des Endzeitpunkts</dd>
         <dt class="optional">date<span class="property-type">string</span></dt>
-        <dd>Datum des Endezeitpunkts in der Form <code>JJJJ-MM-TT</code></dd>
+        <dd>Datum des Endzeitpunkts in der Form <code>JJJJ-MM-TT</code></dd>
         <dt class="optional">offset<span class="property-type">number</span></dt>
-        <dd>Zeitlicher Versatz zum Endezeitpunkt</dd>
+        <dd>Zeitlicher Versatz zum Endzeitpunkt</dd>
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
     </dl>
+    <p>
+        Umgebungs- und Kontextvariablen für den Endzeitpunkt der periodischen
+        Nachrichtenwiederholung können als Zahlen, Zeichenketten oder Objekte
+        spezifiziert werden. Bei letzterem muss die Objektstruktur die gleiche
+        sein wie bei der Nachrichteneigenschaft <code>until</code> (siehe oben).
+        Zahlen und Zeichenketten können folgendes Format haben:
+        <ul>
+            <li>
+                Zahl (Zeitstempel)
+                <ul>
+                    <li>
+                        Anzahl Millisekunden seit Beginn der
+                        UNIX-Zeitzählung
+                    </li>
+                    <li>
+                        Anzahl Millisekunden seit Mitternacht,
+                        wenn Wert kleiner als 86.400.000
+                    </li>
+                </ul>
+            </li>
+            <li>
+                Zeichenkette
+                <ul>
+                    <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                    <li>Sonnenstand</li>
+                    <li>Mondstand</li>
+                    <li>Benutzerdefinierter Sonnenstand</li>
+                    <li>
+                        Datum und Uhrzeit in Region-spezifischem
+                        Format
+                    </li>
+                    <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                    <li>Datum und Sonnenstand</li>
+                    <li>Datum und Mondstand</li>
+                    <li>
+                        Datum und benutzerdefinierter
+                        Sonnenstand
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </p>
     <h3>Ausgaben</h3>
     <p>
         Nachrichten werden beim Eintreffen zum Ausgabe-Port weitergeleitet und

--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -218,8 +218,8 @@ SOFTWARE.
         <dd>Überschreibt ein einzelnes oder mehrere Zeitereignisse</dd>
     </dl>
     <dd>
-        Die Umgebungs-/Kontextvariablen und die Elemente des <code>msg.payload</code>
-        Arrays müssen Objekte sein und die folgenden Eigenschaften enthalten:
+        Die Elemente des <code>msg.payload</code> Arrays müssen Objekte sein und
+        die folgenden Eigenschaften enthalten:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -261,6 +261,15 @@ SOFTWARE.
         gesteuert und wieder andere überschrieben werden. Weiterhin ist es
         möglich, einzelne Array-Elemente auf <code>null</code> zu setzen, um
         die dazugehörigen Zeitereignis zu ignorieren.
+    </dd>
+    <dd>
+        Umgebungs- und Kontextvariablen können als Zahlen, Zeichenketten oder
+        Objekte spezifiziert werden. Bei letzterem muss die Objektstruktur die
+        gleiche sein wie bei den Nachrichteneigenschaften (siehe oben). Zahlen
+        müssen als Millisekunden seit Mitternacht angegeben werden und
+        Zeichenketten müssen entweder eine Uhrzeit im 12- oder 24-Stunden-Format,
+        einen Sonnenstand, einen Mondstand oder einen benutzerdefinierten
+        Sonnenstand enthalten.
     </dd>
     <h3>Ausgaben</h3>
     <p>

--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -25,8 +25,8 @@
         "error":
         {
             "noSchedule":       "Kein Zeitplan konfiguriert",
-            "invalidCtxEvent":  "Ungültiges Zeitereignis aus Kontextvariable: __event__",
-            "invalidMsgEvent":  "Ungültiges Zeitereignis aus Nachrichteneigenschaft: __event__"
+            "invalidCtxEvent":  "Ungültiges Zeitereignis aus Kontextvariable",
+            "invalidMsgEvent":  "Ungültiges Zeitereignis aus Nachrichteneigenschaft"
         }
     }
 }

--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -311,9 +311,7 @@ SOFTWARE.
         <dd>Wert des Zustands</dd>
     </dl>
     <dd>
-        Die Eigenschaft <code>trigger</code> hat den folgenden Aufbau (der gleiche
-        Aufbau wird auch beim Laden des Auslösers aus einer Umgebungs- oder
-        Kontextvariablen verwenden):
+        Die Eigenschaft <code>trigger</code> hat den folgenden Aufbau:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -325,6 +323,15 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
     </dl>
+    <dd>
+        Umgebungs- und Kontextvariablen können als Zahlen, Zeichenketten oder
+        Objekte spezifiziert werden. Bei letzterem muss die Objektstruktur die
+        gleiche sein wie bei der Nachrichteneigenschaft <code>trigger</code>
+        (siehe oben). Zahlen müssen als Millisekunden seit Mitternacht angegeben
+        werden und Zeichenketten müssen entweder eine Uhrzeit im 12- oder
+        24-Stunden-Format, einen Sonnenstand, einen Mondstand oder einen
+        benutzerdefinierten Sonnenstand enthalten.
+    </dd>
     <dd>
         Die Eigenschaft <code>state</code> hat folgenden Aufbau:
     </dd>
@@ -349,10 +356,10 @@ SOFTWARE.
         <dt>operands<span class="property-type">object | array</span></dt>
         <dd>Operanden für den Vergleich; der Inhalt ist abhängig vom Operator</dd>
     </dl>
-    <p>
+    <dd>
         Wenn <code>operator</code> "days" enthält, muss <code>operands</code> ein
         Objekt sein und folgende Eigenschaften enthalten:
-    </p>
+    </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
         <dd>
@@ -369,22 +376,22 @@ SOFTWARE.
         <dt>exclude<span class="property-type">boolean</span></dt>
         <dd>Negiertes Ergebnis</dd>
     </dl>
-    <p>
+    <dd>
         Wenn <code>operator</code> "weekdays" enthält, muss <code>operands</code>
         ein Objekt sein. Dieses kann boolesche Eigenschaften enthalten, deren
         Namen einem englischen Wochentag ("monday", "tuesday", ...) entsprechen.
         Wenn der Wert wahr ist, ist die Bedingung für Auslösezeitpunkte an dem
         entsprechenden Tag erfüllt oder sie ist nicht erfüllt, wenn der Wert der
         Eigenschaft falsch ist oder die Eigenschaft fehlt.
-    </p>
-    <p>
+    </dd>
+    <dd>
         Wenn <code>operator</code> "months" enthält, muss <code>operands</code>
         ein Objekt sein. Dieses kann boolesche Eigenschaften enthalten, deren
         Namen einem englischen Monat ("january", "february", ...) des Jahres
         entsprechen. Wenn der Wert wahr ist, ist die Bedingung für Auslösezeitpunkte
         in dem entsprechenden Monat erfüllt oder sie ist nicht erfüllt, wenn der
         Wert der Eigenschaft falsch ist oder die Eigenschaft fehlt.
-    </p>
+    </dd>
     <h3>Ausgabe</h3>
     <p>
         Immer wenn sich der Zustand ändert und die Ausgabe als Ausgangsnachricht

--- a/nodes/locales/de/state.json
+++ b/nodes/locales/de/state.json
@@ -23,7 +23,7 @@
         "error":
         {
             "noStates":           "Keine Zustände konfiguriert",
-            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__"
+            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable"
         }
     }
 }

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -66,11 +66,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -179,11 +180,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -62,11 +62,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -189,11 +189,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -113,18 +113,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>env variable</i>: Ending condition will be loaded from the specified
-                    environment variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    environment variable, see section <i>Input</i> below for details.
                 </li>
                 <li>
                     <i>global</i>: Ending condition will be loaded from the specified global
-                    context variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    context variable, see section <i>Input</i> below for details.
                 </li>
                 <li>
                     <i>flow</i>: Ending condition will be loaded from the specified flow
-                    context variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    context variable, see section <i>Input</i> below for details.
                 </li>
             </ul>
         </dd>
@@ -240,6 +237,41 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
     </dl>
+    <p>
+        Environment and context variables for the repetition ending time can be
+        specified as numbers, strings or objects. For the latter, the object
+        structure must be the same as for message property <code>until</code>,
+        see above. Numbers and strings can have the following format:
+        <ul>
+            <li>
+                Number (timestamp)
+                <ul>
+                    <li>
+                        Number of milliseconds elapsed since the UNIX
+                        epoch
+                    </li>
+                    <li>
+                        Number of milliseconds elapsed since midnight
+                        if value is smaller than 86.400.000
+                    </li>
+                </ul>
+            </li>
+            <li>
+                String
+                <ul>
+                    <li>Time in 12 or 24 hour format</li>
+                    <li>Sun time</li>
+                    <li>Moon time</li>
+                    <li>Custom sun time</li>
+                    <li>Date and time in region-specific format</li>
+                    <li>Date and time in ISO 8601 format</li>
+                    <li>Date and sun time</li>
+                    <li>Date and moon time</li>
+                    <li>Date and custom sun time</li>
+                </ul>
+            </li>
+        </ul>
+    </p>
     <h3>Outputs</h3>
     <p>
         Messages are sent to the output upon reception and periodically until

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -248,11 +248,11 @@ SOFTWARE.
                 <ul>
                     <li>
                         Number of milliseconds elapsed since the UNIX
-                        epoch
+                        epoch (universal time)
                     </li>
                     <li>
                         Number of milliseconds elapsed since midnight
-                        if value is smaller than 86.400.000
+                        (local time) if value is smaller than 86.400.000
                     </li>
                 </ul>
             </li>

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -205,8 +205,8 @@ SOFTWARE.
         <dd>Overrides a single or multiple schedule events</dd>
     </dl>
     <dd>
-        The environment/context variables and the elements of the <code>msg.payload</code>
-        array must be objects containing the following properties:
+        The elements of the <code>msg.payload</code> array must be objects
+        containing the following properties:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -245,6 +245,13 @@ SOFTWARE.
         certain events with a single input message. It is also possible to set
         specific elements in the array to <code>null</code> in order to ignore
         the corresponding events.
+    </dd>
+    <dd>
+        Environment and context variables can be specified as numbers, strings or
+        objects. For the latter, the object structure must be the same as for
+        message properties, see above. Numbers must be provided as milliseconds
+        elapsed since midnight and strings must contain either a time in 12 or 24
+        hour format, a sun time, a moon time or a custom sun time.
     </dd>
     <h3>Outputs</h3>
     <p>

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -25,8 +25,8 @@
         "error":
         {
             "noSchedule":       "No schedule configured",
-            "invalidCtxEvent":  "Invalid schedule event from context variable: __event__",
-            "invalidMsgEvent":  "Invalid schedule event from message property: __event__"
+            "invalidCtxEvent":  "Invalid schedule event from context variable",
+            "invalidMsgEvent":  "Invalid schedule event from message property"
         }
     }
 }

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -296,9 +296,7 @@ SOFTWARE.
         <dd>Value of the state</dd>
     </dl>
     <dd>
-        The <code>trigger</code> property has the following structure (the same
-        structure is used when loading triggers from environment or context
-        variables):
+        The <code>trigger</code> property has the following structure:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -310,6 +308,13 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
     </dl>
+    <dd>
+        Environment and context variables can be specified as numbers, strings or
+        objects. For the latter, the object structure must be the same as for
+        message property <code>trigger</code>, see above. Numbers must be provided
+        as milliseconds elapsed since midnight and strings must contain either a
+        time in 12 or 24 hour format, a sun time, a moon time or a custom sun time.
+    </dd>
     <dd>
         The <code>state</code> property has the following structure:
     </dd>
@@ -333,10 +338,10 @@ SOFTWARE.
         <dt>operands<span class="property-type">object | array</span></dt>
         <dd>Operands for comparison; content is depending on operator</dd>
     </dl>
-    <p>
+    <dd>
         If <code>operator</code> is "days", <code>operands</code> must be
         an object containing the following properties:
-    </p>
+    </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
         <dd>
@@ -353,20 +358,20 @@ SOFTWARE.
         <dt>exclude<span class="property-type">boolean</span></dt>
         <dd>Negated result</dd>
     </dl>
-    <p>
+    <dd>
         If <code>operator</code> is "weekdays", <code>operands</code>
         must be an object. It may contain boolean properties with names of
         days of the week. If <code>true</code>, the condition is fullfilled
         for trigger times on that day or not fulfilled if the property is
         <code>false</code> or not present.
-    </p>
-    <p>
+    </dd>
+    <dd>
         If <code>operator</code> is "months", <code>operands</code>
         must be an object. It may contain boolean properties with names of
         months of the year. If <code>true</code>, the condition is fullfilled
         for trigger times in that month or not fulfilled if the property is
         <code>false</code> or not present.
-    </p>
+    </dd>
     <h3>Output</h3>
     <p>
         Whenever the state changes and the output is configured to be a message

--- a/nodes/locales/en-US/state.json
+++ b/nodes/locales/en-US/state.json
@@ -23,7 +23,7 @@
         "error":
         {
             "noStates":           "No states configured",
-            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__"
+            "invalidCtxTrigger":  "Invalid state trigger from context variable"
         }
     }
 }

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -62,11 +62,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -168,11 +168,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -393,8 +393,7 @@ SOFTWARE.
                     triggerType.on("change", function()
                     {
                         const type = triggerType.typedInput("type");
-                        if ((type === "crontab") || (type === "env") ||
-                            (type === "global") || (type === "flow"))
+                        if (type === "crontab")
                         {
                             offsetBox.hide();
                         }
@@ -448,13 +447,18 @@ SOFTWARE.
                     triggerType._prevType = data.trigger.type;
                     triggerType.typedInput("type", data.trigger.type);
 
-                    if ((data.trigger.type != "crontab") &&
-                        (data.trigger.type != "env") &&
-                        (data.trigger.type != "global") &&
-                        (data.trigger.type != "flow"))
+                    if (data.trigger.type != "crontab")
                     {
-                        triggerOffset.spinner("value", data.trigger.offset);
-                        triggerRandom.prop("checked", data.trigger.random);
+                        triggerOffset.spinner(
+                                        "value",
+                                        (typeof data.trigger.offset != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.offset
+                                            : 0);
+                        triggerRandom.prop(
+                                        "checked",
+                                        (typeof data.trigger.random != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.random
+                                            : false);
                     }
                     else
                     {
@@ -519,8 +523,7 @@ SOFTWARE.
                 data.trigger.type = triggerType.typedInput("type");
                 data.trigger.value = triggerType.typedInput("value");
 
-                if ((data.trigger.type != "crontab") && (data.trigger.type != "env") &&
-                    (data.trigger.type != "global") && (data.trigger.type != "flow"))
+                if (data.trigger.type != "crontab")
                 {
                     data.trigger.offset = triggerOffset.spinner("value");
                     data.trigger.random = triggerRandom.prop("checked");

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -462,10 +462,7 @@ SOFTWARE.
                     trigger.on("change", function()
                     {
                         let type = trigger.typedInput("type");
-                        if ((type === "env") ||
-                            (type === "global") ||
-                            (type === "flow") ||
-                            (type === "manual"))
+                        if (type === "manual")
                         {
                             offsetBox.hide();
                         }
@@ -498,13 +495,18 @@ SOFTWARE.
                     trigger._prevType = data.trigger.type;
                     trigger.typedInput("type", data.trigger.type);
 
-                    if ((data.trigger.type != "env") &&
-                        (data.trigger.type != "global") &&
-                        (data.trigger.type != "flow") &&
-                        (data.trigger.type != "manual"))
+                    if (data.trigger.type != "manual")
                     {
-                        triggerOffset.spinner("value", data.trigger.offset);
-                        triggerRandom.prop("checked", data.trigger.random);
+                        triggerOffset.spinner(
+                                        "value",
+                                        (typeof data.trigger.offset != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.offset
+                                            : 0);
+                        triggerRandom.prop(
+                                        "checked",
+                                        (typeof data.trigger.random != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.random
+                                            : false);
                     }
                     else
                     {
@@ -836,10 +838,7 @@ SOFTWARE.
                     data.trigger.value = trigger.typedInput("value");
                 }
 
-                if ((data.trigger.type != "env") &&
-                    (data.trigger.type != "global") &&
-                    (data.trigger.type != "flow") &&
-                    (data.trigger.type != "manual"))
+                if (data.trigger.type != "manual")
                 {
                     data.trigger.offset = $(this).find(".node-input-triggerOffset").spinner("value");
                     data.trigger.random = $(this).find(".node-input-triggerRandom").prop("checked");


### PR DESCRIPTION
This pull request adds support for the basic and extended external input formats to scheduler, state and repeat node. Scheduler and state node support a time-only subset of these formats and repeat node supports the formats for the until time.