### PR TITLE
Support for arbitrary message property input in repeat and delay nodes

### DIFF
--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -539,7 +539,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-customDelayType")});
 
             $("#node-input-delayType").change(function()

--- a/nodes/locales/de/delay.html
+++ b/nodes/locales/de/delay.html
@@ -129,13 +129,13 @@ SOFTWARE.
             kann eine Zahl sein, die entweder die Zeitspanne in Millisekunden
             enthält oder die Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
             als absoluten Zeitpunkt zu dem die Verzögerung endet. Letzteres
-            kann auch als Zeichenkette mit Datum und Uhrzeit, die nach den Regeln
-            von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-            geparst werden kann, zurückgegeben werden. Im Fall von <i>Umgebungsvariable</i>,
-            <i>global</i> oder <i>flow</i> wird die Verzögerung aus der angegebenen
-            Umgebungs- bzw. Kontextvariablen geladen. Siehe Abschnitt <i>Input</i>
-            weiter unten für eine Beschreibung des Variablenformats (Eigenschaften
-            <code>fixedDuration</code>, <code>randomDuration</code> und <code>when</code>).
+            kann auch als Zeichenkette mit Datum und Uhrzeit zurückgegeben werden.
+            Im Fall von <i>Umgebungsvariable</i>, <i>global</i>, <i>flow</i>
+            oder <i>msg</i> wird die Verzögerung aus der angegebenen
+            Umgebungs-/Kontextvariablen bzw. Nachrichteneigenschaft geladen.
+            Siehe Abschnitt <i>Input</i> weiter unten für eine Beschreibung
+            des Variablenformats (Eigenschaften <code>fixedDuration</code>,
+            <code>randomDuration</code> und <code>when</code>).
         </dd>
         <dt>Steuereigenschaften in Nachrichten beibehalten</dt>
         <dd>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -131,6 +131,11 @@ SOFTWARE.
                     Flow-Kontextvariablen geladen, siehe Abschnitt
                     <i>Eingabe</i> für weitere Informationen.
                 </li>
+                <li>
+                    <i>msg</i>: Die Ende-Bedingung wird aus der angegebenen
+                    Nachrichteneigenschaft geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
+                </li>
             </ul>
         </dd>
         <dt>Datum</dt>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -74,12 +74,11 @@ SOFTWARE.
             UNIX-Zeitzählung als absoluten Zeitpunkt der nächsten Wiederholung
             enthält. Oder es handelt sich um eine Zeichenkette mit einem Datum
             und einer Uhrzeit, die den absoluten Zeitpunkt der nächsten Wiederholung
-            darstellt. Die Zeichenkette muss nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-            geparst werden können. Im Fall von <i>Umgebungsvariable</i>, <i>global</i>
-            oder <i>flow</i> wird die Wiederholung aus der angegebenen Umgebungs-
-            bzw. Kontextvariablen geladen. Siehe Abschnitt <i>Input</i> weiter
-            unten für eine Beschreibung des Variablenformats (Eigenschaften
-            <code>interval</code> und <code>crontab</code>).
+            darstellt. Im Fall von <i>Umgebungsvariable</i>, <i>global</i>,
+            <i>flow</i> oder <i>msg</i> wird die Wiederholung aus der angegebenen
+            Umgebungs-/Kontextvariablen bzw. Nachrichteneigenschaft geladen. Siehe
+            Abschnitt <i>Input</i> weiter unten für eine Beschreibung des
+            Variablenformats (Eigenschaften <code>interval</code> und <code>crontab</code>).
         </dd>
         <dt>Bis</dt>
         <dd>

--- a/nodes/locales/en-US/delay.html
+++ b/nodes/locales/en-US/delay.html
@@ -125,10 +125,9 @@ SOFTWARE.
             can be a number either containing the duration in milliseconds or
             the amount of milliseconds elapsed since the UNIX epoch representing
             the point in time when the delay ends. The latter can also be
-            expressed as a datetime string which must be parseable according
-            to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-            When selecting <i>env variable</i>, <i>global</i> or <i>flow</i>,
-            the delay is taken from the specified environment or context variable.
+            expressed as a datetime string. When selecting <i>env variable</i>,
+            <i>global</i>, <i>flow</i> or <i>msg</i>, the delay is taken from
+            the specified environment/context variable or message property.
             See section <i>Input</i> below for a description of the format
             (properties <code>fixedDuration</code>, <code>randomDuration</code>
             and <code>when</code>).

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -123,6 +123,10 @@ SOFTWARE.
                     <i>flow</i>: Ending condition will be loaded from the specified flow
                     context variable, see section <i>Input</i> below for details.
                 </li>
+                <li>
+                    <i>msg</i>: Ending condition will be loaded from the specified message
+                    property, see section <i>Input</i> below for details.
+                </li>
             </ul>
         </dd>
         <dt>Date</dt>

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -70,12 +70,11 @@ SOFTWARE.
             number containing the amount of milliseconds until the next trigger or
             the amount of milliseconds elapsed since the UNIX epoch representing
             the absolute time of the next trigger. Or it is a valid datetime string
-            representing the absolute time of the next trigger. The string must be
-            parseable according to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-            When selecting <i>env variable</i>, <i>global</i> or <i>flow</i>, the
-            repetition is taken from the specified environment or context variable.
-            See section <i>Input</i> below for a description of the format (properties
-            <code>interval</code> and <code>crontab</code>).
+            representing the absolute time of the next trigger. When selecting
+            <i>env variable</i>, <i>global</i>, <i>flow</i> or <i>msg</i>, the
+            repetition is taken from the specified environment/context variable or
+            message property. See section <i>Input</i> below for a description of
+            the format (properties <code>interval</code> and <code>crontab</code>).
         </dd>
         <dt>Until</dt>
         <dd>

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -447,7 +447,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-untilType")});
             const untilOffset =
                     $("#node-input-untilOffset")

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -425,7 +425,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-customRepetitionType")});
             const untilDate =
                     $("#node-input-untilDate")

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -383,7 +383,7 @@ module.exports = function(RED)
         {
             let ret = {};
 
-            if ((type == "env") || (type == "global") || (type == "flow"))
+            if ((type == "env") || (type == "global") || (type == "flow") || (type == "msg"))
             {
                 let ctxData = undefined;
 
@@ -405,10 +405,14 @@ module.exports = function(RED)
                         ctxData = value;
                     }
                 }
-                else
+                else if ((type == "global") || (type == "flow"))
                 {
                     const ctx = RED.util.parseContextStore(value);
                     ctxData = node.context()[type].get(ctx.key, ctx.store);
+                }
+                else
+                {
+                    ctxData = RED.util.getMessageProperty(node.message, value);
                 }
 
                 if (isValidFlatUntilTime(ctxData))


### PR DESCRIPTION
With this pull request, repeat node supports loading the custom repetition data as well as the until time from an arbitrary property of the input message. Delay node supports the same for the custom delay data.