### PR TITLE
Release 1.24

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports =
     },
     "parserOptions":
     {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2020
     },
     "rules":
     {

--- a/examples/state/Advanced output and conditions.json
+++ b/examples/state/Advanced output and conditions.json
@@ -1,0 +1,174 @@
+[
+    {
+        "id": "671609705841dfab",
+        "type": "tab",
+        "label": "Advanced output and conditions",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "04b2823017743f50",
+        "type": "comment",
+        "z": "671609705841dfab",
+        "name": "",
+        "info": "# Advanced output and conditions\nState node that is configured with three states, full message output and advanced conditions.\n1. First state with string value \"on\" is activated at 08:00.\n2. Second state with string value \"auto\" is activated at 10:00.\n3. Third state with string value \"off\" is activated at 18:00.\n4. State changes happen from April to September on work days and from October to March on weekends.\n5. Full message with state identifier, value, start date/time and end date/time is sent on state change.\n6. Initial state output is sent when node starts.",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "c2900ff315be9284",
+        "type": "chronos-state",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "outputValue": "{\t    \"id\": $state.id,\t    \"payload\": $state.value,\t    \"since\": $moment($state.since, $config.timezone).calendar(),\t    \"until\": $moment($state.until, $config.timezone).calendar()\t}",
+        "outputType": "fullMsg",
+        "states": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "8:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "on"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "10:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "auto"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "18:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "off"
+                }
+            }
+        ],
+        "conditions": [
+            {
+                "operator": "months",
+                "operands": [
+                    false,
+                    false,
+                    false,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    false,
+                    false,
+                    false
+                ]
+            },
+            {
+                "operator": "weekdays",
+                "operands": [
+                    false,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    false
+                ]
+            },
+            {
+                "operator": "months",
+                "operands": [
+                    true,
+                    true,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    true,
+                    true,
+                    true
+                ]
+            },
+            {
+                "operator": "weekdays",
+                "operands": [
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    true
+                ]
+            }
+        ],
+        "evaluation": "($condition[0] and $condition[1]) or ($condition[2] and $condition[3])",
+        "evaluationType": "jsonata",
+        "outputOnStart": true,
+        "outputOnStartDelay": 0.1,
+        "passiveMode": false,
+        "x": 170,
+        "y": 140,
+        "wires": [
+            [
+                "ff49410550fef9fa"
+            ]
+        ]
+    },
+    {
+        "id": "ff49410550fef9fa",
+        "type": "debug",
+        "z": "671609705841dfab",
+        "name": "state value",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "true",
+        "targetType": "full",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 340,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "timezone": "",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/state/Five states.json
+++ b/examples/state/Five states.json
@@ -1,0 +1,139 @@
+[
+    {
+        "id": "671609705841dfab",
+        "type": "tab",
+        "label": "Five states",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "04b2823017743f50",
+        "type": "comment",
+        "z": "671609705841dfab",
+        "name": "",
+        "info": "# Five states\nState node that is configured with five states and no conditions.\n1. First state with string value \"MORNING\" is activated at 08:00.\n2. Second state with string value \"NOON\" is activated at 12:00.\n3. Third state with string value \"AFTERNOON\" is activated at 13:00.\n4. Fourth state with string value \"EVENING\" is activated at 18:00.\n5. Fifth state with string value \"NIGHT\" is activated at 23:00.\n6. Initial state value is sent to the output port when node starts.",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "c2900ff315be9284",
+        "type": "chronos-state",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "outputValue": "payload",
+        "outputType": "msg",
+        "states": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "8:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "MORNING"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "12:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "NOON"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "13:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "AFTERNOON"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "18:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "EVENING"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "23:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "str",
+                    "value": "NIGHT"
+                }
+            }
+        ],
+        "conditions": [],
+        "evaluation": "",
+        "evaluationType": "and",
+        "outputOnStart": true,
+        "outputOnStartDelay": 0.1,
+        "passiveMode": false,
+        "x": 170,
+        "y": 140,
+        "wires": [
+            [
+                "ff49410550fef9fa"
+            ]
+        ]
+    },
+    {
+        "id": "ff49410550fef9fa",
+        "type": "debug",
+        "z": "671609705841dfab",
+        "name": "state value",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 340,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "timezone": "",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/state/Passive trigger mode.json
+++ b/examples/state/Passive trigger mode.json
@@ -1,0 +1,146 @@
+[
+    {
+        "id": "671609705841dfab",
+        "type": "tab",
+        "label": "Passive trigger mode",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "04b2823017743f50",
+        "type": "comment",
+        "z": "671609705841dfab",
+        "name": "",
+        "info": "# Passive trigger mode\nState node that is configured with two states, one condition and passive trigger mode.\n1. First state with boolean value \"true\" is activated at sunrise.\n2. Second state with boolean value \"false\" is activated at sunset.\n3. State changes happen only on even days.\n5. State node is in passive trigger mode, i.e., it doesn't trigger on its own but is triggered by the external scheduler node.",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "a5513d31a0934bb6",
+        "type": "chronos-scheduler",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "schedule": [
+            {
+                "trigger": {
+                    "type": "crontab",
+                    "value": "* * * * *"
+                },
+                "output": {
+                    "type": "msg",
+                    "property": {
+                        "name": "topic",
+                        "type": "str",
+                        "value": "trigger"
+                    }
+                }
+            }
+        ],
+        "multiPort": false,
+        "nextEventPort": false,
+        "disabled": false,
+        "outputs": 1,
+        "x": 160,
+        "y": 140,
+        "wires": [
+            [
+                "c2900ff315be9284"
+            ]
+        ]
+    },
+    {
+        "id": "c2900ff315be9284",
+        "type": "chronos-state",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "outputValue": "payload",
+        "outputType": "msg",
+        "states": [
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunrise",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "bool",
+                    "value": "true"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunset",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "bool",
+                    "value": "false"
+                }
+            }
+        ],
+        "conditions": [
+            {
+                "operator": "days",
+                "operands": {
+                    "type": "even",
+                    "day": "monday",
+                    "exclude": false
+                }
+            }
+        ],
+        "evaluation": "",
+        "evaluationType": "and",
+        "outputOnStart": false,
+        "outputOnStartDelay": 0.1,
+        "passiveMode": true,
+        "x": 320,
+        "y": 140,
+        "wires": [
+            [
+                "ff49410550fef9fa"
+            ]
+        ]
+    },
+    {
+        "id": "ff49410550fef9fa",
+        "type": "debug",
+        "z": "671609705841dfab",
+        "name": "state value",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 490,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "timezone": "",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/examples/state/Two states.json
+++ b/examples/state/Two states.json
@@ -1,0 +1,116 @@
+[
+    {
+        "id": "671609705841dfab",
+        "type": "tab",
+        "label": "Two states",
+        "disabled": false,
+        "info": "",
+        "env": []
+    },
+    {
+        "id": "04b2823017743f50",
+        "type": "comment",
+        "z": "671609705841dfab",
+        "name": "",
+        "info": "# Two states\nState node that is configured with two states and one condition.\n1. First state with boolean value \"true\" is activated at 10:00 in the morning.\n2. Second state with boolean value \"false\" is activated at sunset in the evening.\n3. State changes happen only during work week (Monday to Friday).\n4. Initial state value is sent to the output port when node starts.",
+        "x": 120,
+        "y": 60,
+        "wires": []
+    },
+    {
+        "id": "c2900ff315be9284",
+        "type": "chronos-state",
+        "z": "671609705841dfab",
+        "name": "",
+        "config": "5e581578.25c88c",
+        "outputValue": "payload",
+        "outputType": "msg",
+        "states": [
+            {
+                "trigger": {
+                    "type": "time",
+                    "value": "10:00",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "bool",
+                    "value": "true"
+                }
+            },
+            {
+                "trigger": {
+                    "type": "sun",
+                    "value": "sunsetStart",
+                    "offset": 0,
+                    "random": false
+                },
+                "state": {
+                    "type": "bool",
+                    "value": "false"
+                }
+            }
+        ],
+        "conditions": [
+            {
+                "operator": "weekdays",
+                "operands": [
+                    false,
+                    true,
+                    true,
+                    true,
+                    true,
+                    true,
+                    false
+                ]
+            }
+        ],
+        "evaluation": "",
+        "evaluationType": "and",
+        "outputOnStart": true,
+        "outputOnStartDelay": 0.1,
+        "passiveMode": false,
+        "x": 170,
+        "y": 140,
+        "wires": [
+            [
+                "ff49410550fef9fa"
+            ]
+        ]
+    },
+    {
+        "id": "ff49410550fef9fa",
+        "type": "debug",
+        "z": "671609705841dfab",
+        "name": "state value",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": false,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "",
+        "statusType": "auto",
+        "x": 340,
+        "y": 140,
+        "wires": []
+    },
+    {
+        "id": "5e581578.25c88c",
+        "type": "chronos-config",
+        "name": "Berlin",
+        "timezone": "",
+        "sunPositions": [
+            {
+                "angle": -4,
+                "riseName": "blueHourDawn",
+                "setName": "blueHourDusk"
+            },
+            {
+                "angle": -8,
+                "riseName": "blueHourDawnBegin",
+                "setName": "blueHourDuskEnd"
+            }
+        ]
+    }
+]

--- a/nodes/change.html
+++ b/nodes/change.html
@@ -294,7 +294,9 @@ SOFTWARE.
                     const setPartBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const addsubBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const startEndOfBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
-                    const toStringBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
+                    const convertBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
+                    const convertRow1 = $("<div/>").appendTo(convertBox);
+                    const convertRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(convertBox);
 
                     const setPartType = $("<select/>", {class: "node-input-setPartType", style: "width: auto;"})
                                         .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
@@ -347,7 +349,7 @@ SOFTWARE.
                                 class: "node-input-stringFormat",
                                 title: node._("change.label.format"),
                                 placeholder: node._("change.label.formatPlaceholder")})
-                                    .appendTo(toStringBox)
+                                    .appendTo(convertRow1)
                                     .typedInput({
                                         types: [
                                             {
@@ -395,6 +397,35 @@ SOFTWARE.
                                             }]});
                     stringFormat.typedInput("width", "280px");
 
+                    const timeZone =
+                            $("<input/>", {
+                                type: "text",
+                                class: "node-input-timeZone",
+                                title: node._("change.label.format")})
+                                    .appendTo(convertRow2)
+                                    .typedInput({
+                                        types: [
+                                            {
+                                                value: "current",
+                                                label: node._("change.label.currentTZ"),
+                                                hasValue: false
+                                            },
+                                            {
+                                                value: "timeZone",
+                                                label: node._("change.label.timeZone"),
+                                                icon: "fa fa-globe",
+                                                hasValue: true,
+                                                validate: /^.+$/
+                                            },
+                                            {
+                                                value: "utcOffset",
+                                                label: node._("change.label.utcOffset"),
+                                                icon: "fa fa-expand",
+                                                hasValue: true,
+                                                validate: /^(?:Z|[+-]\d\d:\d\d|-?\d+)$/
+                                            }]});
+                    timeZone.typedInput("width", "280px");
+
                     action.change(function()
                     {
                         setBox.hide();
@@ -421,7 +452,7 @@ SOFTWARE.
                         setPartBox.hide();
                         addsubBox.hide();
                         startEndOfBox.hide();
-                        toStringBox.hide();
+                        convertBox.hide();
 
                         const value = $(this).val();
                         switch (value)
@@ -445,7 +476,7 @@ SOFTWARE.
                             }
                             case "toString":
                             {
-                                toStringBox.show();
+                                convertBox.show();
                                 break;
                             }
                         }
@@ -614,8 +645,17 @@ SOFTWARE.
                                 data.format = "iso8601utc";
                             }
 
+                            if (typeof data.tzType == "undefined")
+                            {
+                                data.tzType = "current";
+                                data.tzValue = "";
+                            }
+
                             stringFormat.typedInput("type", data.formatType);
                             stringFormat.typedInput("value", data.format);
+
+                            timeZone.typedInput("type", data.tzType);
+                            timeZone.typedInput("value", data.tzValue);
                         }
                         changeType.val(data.type);
                     }
@@ -648,6 +688,7 @@ SOFTWARE.
                 const date = $(this).find(".node-input-date");
                 const time = $(this).find(".node-input-time");
                 const stringFormat = $(this).find(".node-input-stringFormat");
+                const timeZone = $(this).find(".node-input-timeZone");
 
                 data.action = $(this).find(".node-input-action").val();
                 data.target = {};
@@ -690,6 +731,8 @@ SOFTWARE.
                     {
                         data.formatType = stringFormat.typedInput("type");
                         data.format = stringFormat.typedInput("value");
+                        data.tzType = timeZone.typedInput("type");
+                        data.tzValue = timeZone.typedInput("value");
                     }
                 }
 

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -285,6 +285,21 @@ module.exports = function(RED)
                                             }
                                             case "toString":
                                             {
+                                                if (rule.tzType == "timeZone")
+                                                {
+                                                    input.tz(rule.tzValue);
+                                                }
+                                                else if (rule.tzType == "utcOffset")
+                                                {
+                                                    // if it's a number, convert it to a number
+                                                    if (+rule.tzValue === +rule.tzValue)
+                                                    {
+                                                        rule.tzValue = +rule.tzValue;
+                                                    }
+
+                                                    input.utcOffset(rule.tzValue);
+                                                }
+
                                                 if (rule.formatType == "custom")
                                                 {
                                                     output = input.format(rule.format);

--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -45,6 +45,7 @@ class TimeError extends Error
 const moment = require("moment-timezone");
 const sunCalc = require("suncalc");
 
+require("./moment_locales.js");
 
 function getMoment()
 {

--- a/nodes/common/moment_locales.js
+++ b/nodes/common/moment_locales.js
@@ -1,0 +1,39 @@
+
+/*
+ * Copyright (c) 2024 Jens-Uwe Rossbach
+ *
+ * This code is licensed under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+module.exports = Promise.all([
+    import("moment/locale/en-au.js"),
+    import("moment/locale/en-ca.js"),
+    import("moment/locale/en-gb.js"),
+    import("moment/locale/en-ie.js"),
+    import("moment/locale/en-il.js"),
+    import("moment/locale/en-in.js"),
+    import("moment/locale/en-nz.js"),
+    import("moment/locale/en-sg.js"),
+    import("moment/locale/de.js"),
+    import("moment/locale/de-at.js"),
+    import("moment/locale/de-ch.js")
+]);

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -734,6 +734,10 @@ function getTime(RED, node, msg, baseTime, type, value)
         if (type == "env")
         {
             ctxValue = RED.util.evaluateNodeProperty(value, type, node);
+            if (!ctxValue)
+            {
+                ctxValue = value;
+            }
         }
         else if ((type == "global") || (type == "flow"))
         {

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -760,9 +760,7 @@ function getTime(RED, node, msg, baseTime, type, value)
                             RED,
                             node,
                             baseTime,
-                            (typeof ctxValue == "string")
-                                ? "auto"
-                                : "time",
+                            "auto",
                             ctxValue);
 
         if (!ret.isValid())

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -539,7 +539,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-customDelayType")});
 
             $("#node-input-delayType").change(function()

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -199,6 +199,29 @@ SOFTWARE.
                                 entsprechen.
                             </li>
                         </ul>
+                        In der zweiten Zeile kann die lokale Zeit des Eingangszeitstempels
+                        geändert werden:
+                        <ul>
+                            <li>
+                                <i>Aktuelle Zeitzone</i>: Die ursprüngliche Zeitzone
+                                (die Zeitzone, die im verwendeten Konfigurationsknoten
+                                eingestellt wurde) wird beibehalten.
+                            </li>
+                            <li>
+                                <i>Zeitzone</i>: Ein <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">gültiger Zeitzonenname</a>
+                                kann angegeben werden und die Zeit wird in die ensprechende
+                                Zeitzone konvertiert.
+                            </li>
+                            <li>
+                                <i>UTC-Versatz</i>: Ein Versatz in Minuten und/oder
+                                Stunden kann angegeben werden. Eine Zahl zwischen
+                                -16 und 16 wird als Stunden interpretiert, alle Zahlen
+                                außerhalb dieses Bereichs als Minuten. Zusätzlich ist
+                                es möglich, Stunden und Minuten in der Form <code>+/-HH:MM</code>
+                                anzugeben. Der Wert wird als Versatz zur UTC-Zeit
+                                angewendet.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -11,6 +11,9 @@
             "format":             "Format",
             "predefinedFormat":   "Vordefiniertes Format",
             "customFormat":       "Benutzerdefiniertes Format",
+            "currentTZ":          "Aktuelle Zeitzone",
+            "timeZone":           "Zeitzone",
+            "utcOffset":          "UTC-Versatz",
             "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -27,6 +30,7 @@
                 "subtract":  "Abziehen",
                 "startOf":   "Anfang von",
                 "endOf":     "Ende von",
+                "timeZone":  "Zeitzone",
                 "toString":  "Konvertieren"
             },
             "convert":

--- a/nodes/locales/de/delay.html
+++ b/nodes/locales/de/delay.html
@@ -129,13 +129,13 @@ SOFTWARE.
             kann eine Zahl sein, die entweder die Zeitspanne in Millisekunden
             enthält oder die Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung
             als absoluten Zeitpunkt zu dem die Verzögerung endet. Letzteres
-            kann auch als Zeichenkette mit Datum und Uhrzeit, die nach den Regeln
-            von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-            geparst werden kann, zurückgegeben werden. Im Fall von <i>Umgebungsvariable</i>,
-            <i>global</i> oder <i>flow</i> wird die Verzögerung aus der angegebenen
-            Umgebungs- bzw. Kontextvariablen geladen. Siehe Abschnitt <i>Input</i>
-            weiter unten für eine Beschreibung des Variablenformats (Eigenschaften
-            <code>fixedDuration</code>, <code>randomDuration</code> und <code>when</code>).
+            kann auch als Zeichenkette mit Datum und Uhrzeit zurückgegeben werden.
+            Im Fall von <i>Umgebungsvariable</i>, <i>global</i>, <i>flow</i>
+            oder <i>msg</i> wird die Verzögerung aus der angegebenen
+            Umgebungs-/Kontextvariablen bzw. Nachrichteneigenschaft geladen.
+            Siehe Abschnitt <i>Input</i> weiter unten für eine Beschreibung
+            des Variablenformats (Eigenschaften <code>fixedDuration</code>,
+            <code>randomDuration</code> und <code>when</code>).
         </dd>
         <dt>Steuereigenschaften in Nachrichten beibehalten</dt>
         <dd>

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -64,11 +64,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -200,11 +201,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -131,6 +131,11 @@ SOFTWARE.
                     Flow-Kontextvariablen geladen, siehe Abschnitt
                     <i>Eingabe</i> für weitere Informationen.
                 </li>
+                <li>
+                    <i>msg</i>: Die Ende-Bedingung wird aus der angegebenen
+                    Nachrichteneigenschaft geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
+                </li>
             </ul>
         </dd>
         <dt>Datum</dt>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -263,11 +263,12 @@ SOFTWARE.
                 <ul>
                     <li>
                         Anzahl Millisekunden seit Beginn der
-                        UNIX-Zeitzählung
+                        UNIX-Zeitzählung (Weltzeit)
                     </li>
                     <li>
                         Anzahl Millisekunden seit Mitternacht,
-                        wenn Wert kleiner als 86.400.000
+                        (lokaler Zeit) wenn Wert kleiner als
+                        86.400.000
                     </li>
                 </ul>
             </li>

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -119,26 +119,23 @@ SOFTWARE.
                 <li>
                     <i>Umgebungsvariable</i>: Die Ende-Bedingung wird aus der
                     angegebenen Umgebungsvariablen geladen, siehe Abschnitt
-                    <i>Eingabe</i> (Eigenschaft <code>until</code>) für eine
-                    Beschreibung des Variablenformats.
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
                 <li>
                     <i>global</i>: Die Ende-Bedingung wird aus der angegebenen
-                    globalen Kontextvariablen geladen, siehe Abschnitt <i>Eingabe</i>
-                    (Eigenschaft <code>until</code>) für eine Beschreibung des
-                    Variablenformats.
+                    globalen Kontextvariablen geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
                 <li>
                     <i>flow</i>: Die Ende-Bedingung wird aus der angegebenen
-                    Flow-Kontextvariablen geladen, siehe Abschnitt <i>Eingabe</i>
-                    (Eigenschaft <code>until</code>) für eine Beschreibung des
-                    Variablenformats.
+                    Flow-Kontextvariablen geladen, siehe Abschnitt
+                    <i>Eingabe</i> für weitere Informationen.
                 </li>
             </ul>
         </dd>
         <dt>Datum</dt>
         <dd>
-            Ein Datum für den Endezeitpunkt kann in der Form <code>JJJJ-MM-TT</code>
+            Ein Datum für den Endzeitpunkt kann in der Form <code>JJJJ-MM-TT</code>
             angegeben werden. Falls nicht angegeben, wird das Datum des Eintreffens
             der Nachricht verwendet.
         </dd>
@@ -244,16 +241,58 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
-        <dd>Art des Endezeitpunkts; entweder "time", "sun", "moon" oder "custom"</dd>
+        <dd>Art des Endzeitpunkts; entweder "time", "sun", "moon" oder "custom"</dd>
         <dt>value<span class="property-type">string | number</span></dt>
-        <dd>Endezeitpunkt; der Inhalt ist abhängig von der Art des Endezeitpunkts</dd>
+        <dd>Endzeitpunkt; der Inhalt ist abhängig von der Art des Endzeitpunkts</dd>
         <dt class="optional">date<span class="property-type">string</span></dt>
-        <dd>Datum des Endezeitpunkts in der Form <code>JJJJ-MM-TT</code></dd>
+        <dd>Datum des Endzeitpunkts in der Form <code>JJJJ-MM-TT</code></dd>
         <dt class="optional">offset<span class="property-type">number</span></dt>
-        <dd>Zeitlicher Versatz zum Endezeitpunkt</dd>
+        <dd>Zeitlicher Versatz zum Endzeitpunkt</dd>
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
     </dl>
+    <p>
+        Umgebungs- und Kontextvariablen für den Endzeitpunkt der periodischen
+        Nachrichtenwiederholung können als Zahlen, Zeichenketten oder Objekte
+        spezifiziert werden. Bei letzterem muss die Objektstruktur die gleiche
+        sein wie bei der Nachrichteneigenschaft <code>until</code> (siehe oben).
+        Zahlen und Zeichenketten können folgendes Format haben:
+        <ul>
+            <li>
+                Zahl (Zeitstempel)
+                <ul>
+                    <li>
+                        Anzahl Millisekunden seit Beginn der
+                        UNIX-Zeitzählung
+                    </li>
+                    <li>
+                        Anzahl Millisekunden seit Mitternacht,
+                        wenn Wert kleiner als 86.400.000
+                    </li>
+                </ul>
+            </li>
+            <li>
+                Zeichenkette
+                <ul>
+                    <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                    <li>Sonnenstand</li>
+                    <li>Mondstand</li>
+                    <li>Benutzerdefinierter Sonnenstand</li>
+                    <li>
+                        Datum und Uhrzeit in Region-spezifischem
+                        Format
+                    </li>
+                    <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                    <li>Datum und Sonnenstand</li>
+                    <li>Datum und Mondstand</li>
+                    <li>
+                        Datum und benutzerdefinierter
+                        Sonnenstand
+                    </li>
+                </ul>
+            </li>
+        </ul>
+    </p>
     <h3>Ausgaben</h3>
     <p>
         Nachrichten werden beim Eintreffen zum Ausgabe-Port weitergeleitet und

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -74,12 +74,11 @@ SOFTWARE.
             UNIX-Zeitzählung als absoluten Zeitpunkt der nächsten Wiederholung
             enthält. Oder es handelt sich um eine Zeichenkette mit einem Datum
             und einer Uhrzeit, die den absoluten Zeitpunkt der nächsten Wiederholung
-            darstellt. Die Zeichenkette muss nach den Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-            geparst werden können. Im Fall von <i>Umgebungsvariable</i>, <i>global</i>
-            oder <i>flow</i> wird die Wiederholung aus der angegebenen Umgebungs-
-            bzw. Kontextvariablen geladen. Siehe Abschnitt <i>Input</i> weiter
-            unten für eine Beschreibung des Variablenformats (Eigenschaften
-            <code>interval</code> und <code>crontab</code>).
+            darstellt. Im Fall von <i>Umgebungsvariable</i>, <i>global</i>,
+            <i>flow</i> oder <i>msg</i> wird die Wiederholung aus der angegebenen
+            Umgebungs-/Kontextvariablen bzw. Nachrichteneigenschaft geladen. Siehe
+            Abschnitt <i>Input</i> weiter unten für eine Beschreibung des
+            Variablenformats (Eigenschaften <code>interval</code> und <code>crontab</code>).
         </dd>
         <dt>Bis</dt>
         <dd>

--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -218,8 +218,8 @@ SOFTWARE.
         <dd>Überschreibt ein einzelnes oder mehrere Zeitereignisse</dd>
     </dl>
     <dd>
-        Die Umgebungs-/Kontextvariablen und die Elemente des <code>msg.payload</code>
-        Arrays müssen Objekte sein und die folgenden Eigenschaften enthalten:
+        Die Elemente des <code>msg.payload</code> Arrays müssen Objekte sein und
+        die folgenden Eigenschaften enthalten:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -261,6 +261,15 @@ SOFTWARE.
         gesteuert und wieder andere überschrieben werden. Weiterhin ist es
         möglich, einzelne Array-Elemente auf <code>null</code> zu setzen, um
         die dazugehörigen Zeitereignis zu ignorieren.
+    </dd>
+    <dd>
+        Umgebungs- und Kontextvariablen können als Zahlen, Zeichenketten oder
+        Objekte spezifiziert werden. Bei letzterem muss die Objektstruktur die
+        gleiche sein wie bei den Nachrichteneigenschaften (siehe oben). Zahlen
+        müssen als Millisekunden seit Mitternacht angegeben werden und
+        Zeichenketten müssen entweder eine Uhrzeit im 12- oder 24-Stunden-Format,
+        einen Sonnenstand, einen Mondstand oder einen benutzerdefinierten
+        Sonnenstand enthalten.
     </dd>
     <h3>Ausgaben</h3>
     <p>

--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -25,8 +25,8 @@
         "error":
         {
             "noSchedule":       "Kein Zeitplan konfiguriert",
-            "invalidCtxEvent":  "Ungültiges Zeitereignis aus Kontextvariable: __event__",
-            "invalidMsgEvent":  "Ungültiges Zeitereignis aus Nachrichteneigenschaft: __event__"
+            "invalidCtxEvent":  "Ungültiges Zeitereignis aus Kontextvariable",
+            "invalidMsgEvent":  "Ungültiges Zeitereignis aus Nachrichteneigenschaft"
         }
     }
 }

--- a/nodes/locales/de/scheduler.json
+++ b/nodes/locales/de/scheduler.json
@@ -8,9 +8,11 @@
             "outputPort":     "Geplante Nachricht",
             "eventTimes":     "Ereigniszeiten",
             "schedule":       "Zeitplan",
+            "options":        "Optionen",
             "crontab":        "Cron-Tabelle",
             "multiPort":      "Separate Ausgabe-Ports für Zeitereignisse",
             "nextEventPort":  "Ausgabe-Port für Ereigniszeiten",
+            "delayOnStart":   "Beim Starten Nachrichten verzögern um",
             "disabled":       "Mit inaktivem Zeitplan starten"
         },
         "status":
@@ -18,7 +20,7 @@
             "noSchedule":        "Kein Zeitplan",
             "noTime":            "Kein Zeitpunkt",
             "disabledSchedule":  "Zeitplan inaktiv",
-            "nextEvent":         "Nächstes Ereignis:"
+            "nextEvent":         "Nächstes Ereignis"
         },
         "error":
         {

--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -311,9 +311,7 @@ SOFTWARE.
         <dd>Wert des Zustands</dd>
     </dl>
     <dd>
-        Die Eigenschaft <code>trigger</code> hat den folgenden Aufbau (der gleiche
-        Aufbau wird auch beim Laden des Auslösers aus einer Umgebungs- oder
-        Kontextvariablen verwenden):
+        Die Eigenschaft <code>trigger</code> hat den folgenden Aufbau:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -325,6 +323,15 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
     </dl>
+    <dd>
+        Umgebungs- und Kontextvariablen können als Zahlen, Zeichenketten oder
+        Objekte spezifiziert werden. Bei letzterem muss die Objektstruktur die
+        gleiche sein wie bei der Nachrichteneigenschaft <code>trigger</code>
+        (siehe oben). Zahlen müssen als Millisekunden seit Mitternacht angegeben
+        werden und Zeichenketten müssen entweder eine Uhrzeit im 12- oder
+        24-Stunden-Format, einen Sonnenstand, einen Mondstand oder einen
+        benutzerdefinierten Sonnenstand enthalten.
+    </dd>
     <dd>
         Die Eigenschaft <code>state</code> hat folgenden Aufbau:
     </dd>
@@ -349,10 +356,10 @@ SOFTWARE.
         <dt>operands<span class="property-type">object | array</span></dt>
         <dd>Operanden für den Vergleich; der Inhalt ist abhängig vom Operator</dd>
     </dl>
-    <p>
+    <dd>
         Wenn <code>operator</code> "days" enthält, muss <code>operands</code> ein
         Objekt sein und folgende Eigenschaften enthalten:
-    </p>
+    </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
         <dd>
@@ -369,22 +376,22 @@ SOFTWARE.
         <dt>exclude<span class="property-type">boolean</span></dt>
         <dd>Negiertes Ergebnis</dd>
     </dl>
-    <p>
+    <dd>
         Wenn <code>operator</code> "weekdays" enthält, muss <code>operands</code>
         ein Objekt sein. Dieses kann boolesche Eigenschaften enthalten, deren
         Namen einem englischen Wochentag ("monday", "tuesday", ...) entsprechen.
         Wenn der Wert wahr ist, ist die Bedingung für Auslösezeitpunkte an dem
         entsprechenden Tag erfüllt oder sie ist nicht erfüllt, wenn der Wert der
         Eigenschaft falsch ist oder die Eigenschaft fehlt.
-    </p>
-    <p>
+    </dd>
+    <dd>
         Wenn <code>operator</code> "months" enthält, muss <code>operands</code>
         ein Objekt sein. Dieses kann boolesche Eigenschaften enthalten, deren
         Namen einem englischen Monat ("january", "february", ...) des Jahres
         entsprechen. Wenn der Wert wahr ist, ist die Bedingung für Auslösezeitpunkte
         in dem entsprechenden Monat erfüllt oder sie ist nicht erfüllt, wenn der
         Wert der Eigenschaft falsch ist oder die Eigenschaft fehlt.
-    </p>
+    </dd>
     <h3>Ausgabe</h3>
     <p>
         Immer wenn sich der Zustand ändert und die Ausgabe als Ausgangsnachricht

--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -199,7 +199,8 @@ SOFTWARE.
         <dt>topic<span class="property-type">string</span></dt>
         <dd>
             Steuert den Knoten abhängig von den angegebenen Kommandos;
-            entweder "trigger", "get", "getid", "set", "reset" oder "reload"
+            entweder "trigger", "get", "getid", "set", "reset", "reload",
+            "pause" oder "resume"
         </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Kennzeichnung des auszulösenden oder zu aktivierenden Zustands</dd>
@@ -259,6 +260,20 @@ SOFTWARE.
                 <code>reload</code>: Führt zu einer Neuberechnung der Zeitereignisse
                 (programmierte Daten aus Umgebungs- und Kontextvariablen werden
                 ebenfalls erneut geladen).
+            </li>
+            <li>
+                <code>pause</code>: Unterdrückt automatische Zustandsänderungen
+                wenn Auslösezeiten erreicht werden. Hat keine Wirkung, wenn der
+                passive Auslösemodus aktiviert ist.
+            </li>
+            <li>
+                <code>resume</code>: Setzt automatische Zustandsänderungen
+                wieder in Gang. Hat keine Wirkung, wenn der passive Auslösemodus
+                aktiviert ist. Bitte beachten, dass dieses Kommando den
+                aktuellen Zustand nicht auf denjenigen Zustand zurücksetzt,
+                der normalerweise während der pausierten Zeitspanne ausgelöst
+                worden wäre. Um den Zustand zurückzusetzen, muss zusätzlich
+                das Kommando <code>reset</code> geschickt werden.
             </li>
         </ul>
     </dd>

--- a/nodes/locales/de/state.json
+++ b/nodes/locales/de/state.json
@@ -23,7 +23,7 @@
         "error":
         {
             "noStates":           "Keine Zustände konfiguriert",
-            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__"
+            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable"
         }
     }
 }

--- a/nodes/locales/de/state.json
+++ b/nodes/locales/de/state.json
@@ -15,16 +15,15 @@
         },
         "status":
         {
-            "noStates":          "Keine Zustände",
-            "noState":           "Kein aktueller Zustand",
-            "currentState":      "Aktueller Zustand",
-            "until":             "bis"
+            "noStates":      "Keine Zustände",
+            "noState":       "Kein aktueller Zustand",
+            "currentState":  "Aktueller Zustand",
+            "until":         "bis"
         },
         "error":
         {
             "noStates":           "Keine Zustände konfiguriert",
-            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__",
-            "commandNotAllowed":  "Kommando nur im passiven Auslösemodus erlaubt"
+            "invalidCtxTrigger":  "Ungültiger Zustandsauslöser aus Kontextvariable: __trigger__"
         }
     }
 }

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -66,11 +66,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -179,11 +180,12 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Anzahl Millisekunden seit Beginn der
-                                    UNIX-Zeitzählung
+                                    UNIX-Zeitzählung (Weltzeit)
                                 </li>
                                 <li>
                                     Anzahl Millisekunden seit Mitternacht,
-                                    wenn Wert kleiner als 86.400.000
+                                    (lokaler Zeit) wenn Wert kleiner als
+                                    86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -189,6 +189,28 @@ SOFTWARE.
                                 must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
                             </li>
                         </ul>
+                        In the second row, it is possible to change the local time
+                        of the input timestamp:
+                        <ul>
+                            <li>
+                                <i>current time zone</i>: The original time zone (the
+                                time zone configured in the associated configuration
+                                node) is kept unmodified.
+                            </li>
+                            <li>
+                                <i>time zone</i>: The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>
+                                can be specified and the time is converted to that
+                                time zone.
+                            </li>
+                            <li>
+                                <i>UTC offset</i>: An offset in minutes and/or hours
+                                can be specified. A number between -16 and 16 is
+                                interpreted as hours, a number outside of that range
+                                as minutes. Additionally, it is possible to specify
+                                hours and minutes in the form <code>+/-HH:MM</code>.
+                                The value is applied as offset to the UTC time.
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -11,6 +11,9 @@
             "format":             "Format",
             "predefinedFormat":   "predefined format",
             "customFormat":       "custom format",
+            "currentTZ":          "current time zone",
+            "timeZone":           "time zone",
+            "utcOffset":          "UTC offset",
             "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
         },
         "list":
@@ -27,6 +30,7 @@
                 "subtract":  "Subtract",
                 "startOf":   "Start of",
                 "endOf":     "End of",
+                "timeZone":  "Time zone",
                 "toString":  "Convert"
             },
             "convert":

--- a/nodes/locales/en-US/delay.html
+++ b/nodes/locales/en-US/delay.html
@@ -125,10 +125,9 @@ SOFTWARE.
             can be a number either containing the duration in milliseconds or
             the amount of milliseconds elapsed since the UNIX epoch representing
             the point in time when the delay ends. The latter can also be
-            expressed as a datetime string which must be parseable according
-            to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-            When selecting <i>env variable</i>, <i>global</i> or <i>flow</i>,
-            the delay is taken from the specified environment or context variable.
+            expressed as a datetime string. When selecting <i>env variable</i>,
+            <i>global</i>, <i>flow</i> or <i>msg</i>, the delay is taken from
+            the specified environment/context variable or message property.
             See section <i>Input</i> below for a description of the format
             (properties <code>fixedDuration</code>, <code>randomDuration</code>
             and <code>when</code>).

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -62,11 +62,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -189,11 +189,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -113,18 +113,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>env variable</i>: Ending condition will be loaded from the specified
-                    environment variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    environment variable, see section <i>Input</i> below for details.
                 </li>
                 <li>
                     <i>global</i>: Ending condition will be loaded from the specified global
-                    context variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    context variable, see section <i>Input</i> below for details.
                 </li>
                 <li>
                     <i>flow</i>: Ending condition will be loaded from the specified flow
-                    context variable, see section <i>Input</i> (property <code>until</code>)
-                    below for a description of the format.
+                    context variable, see section <i>Input</i> below for details.
                 </li>
             </ul>
         </dd>
@@ -240,6 +237,41 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
     </dl>
+    <p>
+        Environment and context variables for the repetition ending time can be
+        specified as numbers, strings or objects. For the latter, the object
+        structure must be the same as for message property <code>until</code>,
+        see above. Numbers and strings can have the following format:
+        <ul>
+            <li>
+                Number (timestamp)
+                <ul>
+                    <li>
+                        Number of milliseconds elapsed since the UNIX
+                        epoch
+                    </li>
+                    <li>
+                        Number of milliseconds elapsed since midnight
+                        if value is smaller than 86.400.000
+                    </li>
+                </ul>
+            </li>
+            <li>
+                String
+                <ul>
+                    <li>Time in 12 or 24 hour format</li>
+                    <li>Sun time</li>
+                    <li>Moon time</li>
+                    <li>Custom sun time</li>
+                    <li>Date and time in region-specific format</li>
+                    <li>Date and time in ISO 8601 format</li>
+                    <li>Date and sun time</li>
+                    <li>Date and moon time</li>
+                    <li>Date and custom sun time</li>
+                </ul>
+            </li>
+        </ul>
+    </p>
     <h3>Outputs</h3>
     <p>
         Messages are sent to the output upon reception and periodically until

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -123,6 +123,10 @@ SOFTWARE.
                     <i>flow</i>: Ending condition will be loaded from the specified flow
                     context variable, see section <i>Input</i> below for details.
                 </li>
+                <li>
+                    <i>msg</i>: Ending condition will be loaded from the specified message
+                    property, see section <i>Input</i> below for details.
+                </li>
             </ul>
         </dd>
         <dt>Date</dt>

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -248,11 +248,11 @@ SOFTWARE.
                 <ul>
                     <li>
                         Number of milliseconds elapsed since the UNIX
-                        epoch
+                        epoch (universal time)
                     </li>
                     <li>
                         Number of milliseconds elapsed since midnight
-                        if value is smaller than 86.400.000
+                        (local time) if value is smaller than 86.400.000
                     </li>
                 </ul>
             </li>

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -70,12 +70,11 @@ SOFTWARE.
             number containing the amount of milliseconds until the next trigger or
             the amount of milliseconds elapsed since the UNIX epoch representing
             the absolute time of the next trigger. Or it is a valid datetime string
-            representing the absolute time of the next trigger. The string must be
-            parseable according to <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
-            When selecting <i>env variable</i>, <i>global</i> or <i>flow</i>, the
-            repetition is taken from the specified environment or context variable.
-            See section <i>Input</i> below for a description of the format (properties
-            <code>interval</code> and <code>crontab</code>).
+            representing the absolute time of the next trigger. When selecting
+            <i>env variable</i>, <i>global</i>, <i>flow</i> or <i>msg</i>, the
+            repetition is taken from the specified environment/context variable or
+            message property. See section <i>Input</i> below for a description of
+            the format (properties <code>interval</code> and <code>crontab</code>).
         </dd>
         <dt>Until</dt>
         <dd>

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -205,8 +205,8 @@ SOFTWARE.
         <dd>Overrides a single or multiple schedule events</dd>
     </dl>
     <dd>
-        The environment/context variables and the elements of the <code>msg.payload</code>
-        array must be objects containing the following properties:
+        The elements of the <code>msg.payload</code> array must be objects
+        containing the following properties:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -245,6 +245,13 @@ SOFTWARE.
         certain events with a single input message. It is also possible to set
         specific elements in the array to <code>null</code> in order to ignore
         the corresponding events.
+    </dd>
+    <dd>
+        Environment and context variables can be specified as numbers, strings or
+        objects. For the latter, the object structure must be the same as for
+        message properties, see above. Numbers must be provided as milliseconds
+        elapsed since midnight and strings must contain either a time in 12 or 24
+        hour format, a sun time, a moon time or a custom sun time.
     </dd>
     <h3>Outputs</h3>
     <p>

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -25,8 +25,8 @@
         "error":
         {
             "noSchedule":       "No schedule configured",
-            "invalidCtxEvent":  "Invalid schedule event from context variable: __event__",
-            "invalidMsgEvent":  "Invalid schedule event from message property: __event__"
+            "invalidCtxEvent":  "Invalid schedule event from context variable",
+            "invalidMsgEvent":  "Invalid schedule event from message property"
         }
     }
 }

--- a/nodes/locales/en-US/scheduler.json
+++ b/nodes/locales/en-US/scheduler.json
@@ -8,9 +8,11 @@
             "outputPort":     "scheduled message",
             "eventTimes":     "event times",
             "schedule":       "Schedule",
+            "options":        "Options",
             "crontab":        "cron table",
             "multiPort":      "Dedicated output ports for schedule events",
             "nextEventPort":  "Output port for event times",
+            "delayOnStart":   "Delay messages on start by",
             "disabled":       "Start with disabled schedule"
         },
         "status":
@@ -18,7 +20,7 @@
             "noSchedule":        "no schedule",
             "noTime":            "no time",
             "disabledSchedule":  "disabled",
-            "nextEvent":         "next event at"
+            "nextEvent":         "next event"
         },
         "error":
         {

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -296,9 +296,7 @@ SOFTWARE.
         <dd>Value of the state</dd>
     </dl>
     <dd>
-        The <code>trigger</code> property has the following structure (the same
-        structure is used when loading triggers from environment or context
-        variables):
+        The <code>trigger</code> property has the following structure:
     </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
@@ -310,6 +308,13 @@ SOFTWARE.
         <dt class="optional">random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
     </dl>
+    <dd>
+        Environment and context variables can be specified as numbers, strings or
+        objects. For the latter, the object structure must be the same as for
+        message property <code>trigger</code>, see above. Numbers must be provided
+        as milliseconds elapsed since midnight and strings must contain either a
+        time in 12 or 24 hour format, a sun time, a moon time or a custom sun time.
+    </dd>
     <dd>
         The <code>state</code> property has the following structure:
     </dd>
@@ -333,10 +338,10 @@ SOFTWARE.
         <dt>operands<span class="property-type">object | array</span></dt>
         <dd>Operands for comparison; content is depending on operator</dd>
     </dl>
-    <p>
+    <dd>
         If <code>operator</code> is "days", <code>operands</code> must be
         an object containing the following properties:
-    </p>
+    </dd>
     <dl class="message-properties">
         <dt>type<span class="property-type">string</span></dt>
         <dd>
@@ -353,20 +358,20 @@ SOFTWARE.
         <dt>exclude<span class="property-type">boolean</span></dt>
         <dd>Negated result</dd>
     </dl>
-    <p>
+    <dd>
         If <code>operator</code> is "weekdays", <code>operands</code>
         must be an object. It may contain boolean properties with names of
         days of the week. If <code>true</code>, the condition is fullfilled
         for trigger times on that day or not fulfilled if the property is
         <code>false</code> or not present.
-    </p>
-    <p>
+    </dd>
+    <dd>
         If <code>operator</code> is "months", <code>operands</code>
         must be an object. It may contain boolean properties with names of
         months of the year. If <code>true</code>, the condition is fullfilled
         for trigger times in that month or not fulfilled if the property is
         <code>false</code> or not present.
-    </p>
+    </dd>
     <h3>Output</h3>
     <p>
         Whenever the state changes and the output is configured to be a message

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -187,8 +187,8 @@ SOFTWARE.
     <dl class="message-properties">
         <dt>topic<span class="property-type">string</span></dt>
         <dd>
-            Control command to be executed;
-            one of "trigger", "get", "getid", "set", "reset" or "reload"
+            Control command to be executed; one of "trigger", "get", "getid",
+            "set", "reset", "reload", "pause" or "resume"
         </dd>
         <dt class="optional">payload<span class="property-type">number</span></dt>
         <dd>Identifier of the state to trigger or activate</dd>
@@ -204,8 +204,8 @@ SOFTWARE.
         The following commands are currently supported:
         <ul>
             <li>
-                <code>trigger</code>: Only allowed in passive trigger mode. If
-                <code>msg.payload</code> contains a valid identifier of a
+                <code>trigger</code>: Only supported in passive trigger mode.
+                If <code>msg.payload</code> contains a valid identifier of a
                 configured state, that state will be activated provided that
                 the configured conditions are met. If <code>msg.payload</code>
                 is not set, checks if the trigger time of a configured state
@@ -246,6 +246,19 @@ SOFTWARE.
                 <code>reload</code>: Forces state triggers to be recalculated
                 (also reloads programmed data from environment and context
                 variables).
+            </li>
+            <li>
+                <code>pause</code>: Suppresses automatic state changes when
+                trigger times have been reached. Does nothing if passive trigger
+                mode is enabled.
+            </li>
+            <li>
+                <code>resume</code>: Resumes automatic state changes. Does
+                nothing if passive trigger mode is enabled. Note that this
+                command does not reset the current state to the state that
+                would have normally been activated during paused period.
+                Additionally use the <code>reset</code> command to also have
+                the state reset.
             </li>
         </ul>
     </dd>

--- a/nodes/locales/en-US/state.json
+++ b/nodes/locales/en-US/state.json
@@ -15,16 +15,15 @@
         },
         "status":
         {
-            "noStates":          "no states",
-            "noState":           "no current state",
-            "currentState":      "current state",
-            "until":             "until"
+            "noStates":      "no states",
+            "noState":       "no current state",
+            "currentState":  "current state",
+            "until":         "until"
         },
         "error":
         {
             "noStates":           "No states configured",
-            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__",
-            "commandNotAllowed":  "Command only allowed in passive trigger mode"
+            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__"
         }
     }
 }

--- a/nodes/locales/en-US/state.json
+++ b/nodes/locales/en-US/state.json
@@ -23,7 +23,7 @@
         "error":
         {
             "noStates":           "No states configured",
-            "invalidCtxTrigger":  "Invalid state trigger from context variable: __trigger__"
+            "invalidCtxTrigger":  "Invalid state trigger from context variable"
         }
     }
 }

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -62,11 +62,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>
@@ -168,11 +168,11 @@ SOFTWARE.
                             <ul>
                                 <li>
                                     Number of milliseconds elapsed since the UNIX
-                                    epoch
+                                    epoch (universal time)
                                 </li>
                                 <li>
                                     Number of milliseconds elapsed since midnight
-                                    if value is smaller than 86.400.000
+                                    (local time) if value is smaller than 86.400.000
                                 </li>
                             </ul>
                         </li>

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -447,7 +447,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-untilType")});
             const untilOffset =
                     $("#node-input-untilOffset")

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -425,7 +425,8 @@ SOFTWARE.
                                 "jsonata",
                                 "env",
                                 "global",
-                                "flow"],
+                                "flow",
+                                "msg"],
                             typeField: $("#node-input-customRepetitionType")});
             const untilDate =
                     $("#node-input-untilDate")

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -383,7 +383,7 @@ module.exports = function(RED)
         {
             let ret = {};
 
-            if ((type == "env") || (type == "global") || (type == "flow"))
+            if ((type == "env") || (type == "global") || (type == "flow") || (type == "msg"))
             {
                 let ctxData = undefined;
 
@@ -405,10 +405,14 @@ module.exports = function(RED)
                         ctxData = value;
                     }
                 }
-                else
+                else if ((type == "global") || (type == "flow"))
                 {
                     const ctx = RED.util.parseContextStore(value);
                     ctxData = node.context()[type].get(ctx.key, ctx.store);
+                }
+                else
+                {
+                    ctxData = RED.util.getMessageProperty(node.message, value);
                 }
 
                 if (isValidFlatUntilTime(ctxData))

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -31,23 +31,37 @@ SOFTWARE.
         <label for="node-input-config"><i class="fa fa-cog"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.config"></span></label>
         <input type="text" id="node-input-config" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.config">
     </div>
-    <div class="form-row node-input-scheduleList-row" style="padding-top: 10px">
-        <label for="node-input-scheduleList"><i class="fa fa-calendar-o"></i> <span data-i18n="scheduler.label.schedule"></span></label>
-        <div class="form-row">
-            <ol id="node-input-scheduleList"></ol>
+    <div class="form-row" style="margin-bottom: 0px;">
+        <ul style="min-width: 600px; margin-bottom: 20px;" id="tab-row"></ul>
+    </div>
+    <div id="tabs-content">
+        <div id="tab-schedule" style="display: none;">
+            <div class="form-row list-row">
+                <div class="form-row">
+                    <ol id="node-input-scheduleList"></ol>
+                </div>
+            </div>
         </div>
-    </div>
-    <div class="form-row">
-        <input id="node-input-multiPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
-    </div>
-    <div class="form-row">
-        <input id="node-input-nextEventPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-nextEventPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.nextEventPort"></label>
-    </div>
-    <div class="form-row">
-        <input id="node-input-disabled" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
-        <label for="node-input-disabled" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.disabled"></label>
+        <div id="tab-options" style="display: none;">
+            <div class="form-row">
+                <input id="node-input-disabled" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-disabled" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.disabled"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-multiPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-multiPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.multiPort"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-nextEventPort" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-nextEventPort" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.nextEventPort"></label>
+            </div>
+            <div class="form-row">
+                <input id="node-input-delayOnStart" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+                <label for="node-input-delayOnStart" style="margin-bottom: 0px; width: auto;" data-i18n="scheduler.label.delayOnStart"></label>
+                <input id="node-input-onStartDelay" type="text" placeholder="0.1" style="width: 45px; height: 28px;">&nbsp;
+                <span data-i18n="node-red-contrib-chronos/chronos-config:common.list.unit.seconds"></span>
+            </div>
+        </div>
     </div>
 </script>
 
@@ -136,6 +150,10 @@ SOFTWARE.
                     return v.length > 0;
                 }
             },
+            disabled:
+            {
+                value: false
+            },
             multiPort:
             {
                 value: false
@@ -144,9 +162,14 @@ SOFTWARE.
             {
                 value: false
             },
-            disabled:
+            delayOnStart:
             {
-                value: false
+                value: true
+            },
+            onStartDelay:
+            {
+                value:    0.1,
+                validate: RED.validators.number(true)
             },
             outputs:
             {
@@ -156,6 +179,21 @@ SOFTWARE.
         oneditprepare: function()
         {
             const node = this;
+
+            const tabs = RED.tabs.create(
+            {
+                id: "tab-row",
+                onchange: function(tab)
+                {
+                    $("#tabs-content").children().hide();
+                    $("#" + tab.id).show();
+                    RED.tray.resize();
+                }
+            });
+
+            tabs.addTab({id: "tab-schedule", iconClass: "fa fa-calendar", label: node._("scheduler.label.schedule")});
+            tabs.addTab({id: "tab-options", iconClass: "fa fa-cogs", label: node._("scheduler.label.options")});
+            tabs.activateTab("tab-schedule");
 
             const scheduleList = $("#node-input-scheduleList").css("min-width", "500px").css("min-height", "150px").editableList(
             {
@@ -442,6 +480,17 @@ SOFTWARE.
                 }
             });
 
+            // backward compatibility to v1.23.x and earlier
+            if (typeof node.delayOnStart == "undefined")
+            {
+                $("#node-input-delayOnStart").prop("checked", true);
+            }
+
+            $("#node-input-delayOnStart").on("change", function()
+            {
+                $("#node-input-onStartDelay").attr("disabled", !$("#node-input-delayOnStart").prop("checked"));
+            });
+
             node.schedule.forEach(data =>
             {
                 scheduleList.editableList("addItem", data);
@@ -552,19 +601,26 @@ SOFTWARE.
         },
         oneditresize: function(size)
         {
-            const scheduleListRow = $("#dialog-form>div.node-input-scheduleList-row");
-            const otherRows = $("#dialog-form>div:not(.node-input-scheduleList-row)");
+            const listRow = $("#dialog-form div.list-row");
+            const otherRows = $("#dialog-form>div");
             let height = size.height;
 
             for (let i=0; i<otherRows.length; ++i)
             {
-                height -= $(otherRows[i]).outerHeight(true);
+                let row = $(otherRows[i]);
+
+                if (row.is(":visible") && (row.attr("id") != "tabs-content"))
+                {
+                    height -= row.outerHeight(true);
+                }
             }
 
-            height -= (parseInt(scheduleListRow.css("marginTop")) + parseInt(scheduleListRow.css("marginBottom")));
-            height -= $("#dialog-form>div.node-input-scheduleList-row>label").outerHeight(true);
+            height -= (parseInt(listRow.css("marginTop")) + parseInt(listRow.css("marginBottom")));
 
-            $("#node-input-scheduleList").editableList("height", height);
+            if ($("#tab-schedule").is(":visible"))
+            {
+                $("#node-input-scheduleList").editableList("height", height);
+            }
         }
     });
 </script>

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -393,8 +393,7 @@ SOFTWARE.
                     triggerType.on("change", function()
                     {
                         const type = triggerType.typedInput("type");
-                        if ((type === "crontab") || (type === "env") ||
-                            (type === "global") || (type === "flow"))
+                        if (type === "crontab")
                         {
                             offsetBox.hide();
                         }
@@ -448,13 +447,18 @@ SOFTWARE.
                     triggerType._prevType = data.trigger.type;
                     triggerType.typedInput("type", data.trigger.type);
 
-                    if ((data.trigger.type != "crontab") &&
-                        (data.trigger.type != "env") &&
-                        (data.trigger.type != "global") &&
-                        (data.trigger.type != "flow"))
+                    if (data.trigger.type != "crontab")
                     {
-                        triggerOffset.spinner("value", data.trigger.offset);
-                        triggerRandom.prop("checked", data.trigger.random);
+                        triggerOffset.spinner(
+                                        "value",
+                                        (typeof data.trigger.offset != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.offset
+                                            : 0);
+                        triggerRandom.prop(
+                                        "checked",
+                                        (typeof data.trigger.random != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.random
+                                            : false);
                     }
                     else
                     {
@@ -519,8 +523,7 @@ SOFTWARE.
                 data.trigger.type = triggerType.typedInput("type");
                 data.trigger.value = triggerType.typedInput("value");
 
-                if ((data.trigger.type != "crontab") && (data.trigger.type != "env") &&
-                    (data.trigger.type != "global") && (data.trigger.type != "flow"))
+                if (data.trigger.type != "crontab")
                 {
                     data.trigger.offset = triggerOffset.spinner("value");
                     data.trigger.random = triggerRandom.prop("checked");

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -897,9 +897,9 @@ SOFTWARE.
         },
         oneditresize: function(size)
         {
+            const listRow = $("#dialog-form div.list-row");
+            const otherRows = $("#dialog-form>div");
             let height = size.height;
-            let listRow = $("#dialog-form div.list-row");
-            let otherRows = $("#dialog-form>div");
 
             for (let i=0; i<otherRows.length; ++i)
             {

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -462,10 +462,7 @@ SOFTWARE.
                     trigger.on("change", function()
                     {
                         let type = trigger.typedInput("type");
-                        if ((type === "env") ||
-                            (type === "global") ||
-                            (type === "flow") ||
-                            (type === "manual"))
+                        if (type === "manual")
                         {
                             offsetBox.hide();
                         }
@@ -498,13 +495,18 @@ SOFTWARE.
                     trigger._prevType = data.trigger.type;
                     trigger.typedInput("type", data.trigger.type);
 
-                    if ((data.trigger.type != "env") &&
-                        (data.trigger.type != "global") &&
-                        (data.trigger.type != "flow") &&
-                        (data.trigger.type != "manual"))
+                    if (data.trigger.type != "manual")
                     {
-                        triggerOffset.spinner("value", data.trigger.offset);
-                        triggerRandom.prop("checked", data.trigger.random);
+                        triggerOffset.spinner(
+                                        "value",
+                                        (typeof data.trigger.offset != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.offset
+                                            : 0);
+                        triggerRandom.prop(
+                                        "checked",
+                                        (typeof data.trigger.random != "undefined")  // backward compatibility to v1.23.0 and below
+                                            ? data.trigger.random
+                                            : false);
                     }
                     else
                     {
@@ -836,10 +838,7 @@ SOFTWARE.
                     data.trigger.value = trigger.typedInput("value");
                 }
 
-                if ((data.trigger.type != "env") &&
-                    (data.trigger.type != "global") &&
-                    (data.trigger.type != "flow") &&
-                    (data.trigger.type != "manual"))
+                if (data.trigger.type != "manual")
                 {
                     data.trigger.offset = $(this).find(".node-input-triggerOffset").spinner("value");
                     data.trigger.random = $(this).find(".node-input-triggerRandom").prop("checked");

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -327,7 +327,7 @@ module.exports = function(RED)
 
                                             node.debug("[State:" + node.currentState.data.id + "] Starting timer for timeout of " + timeout + " milliseconds");
                                             node.currentState.timer = setTimeout(resetCurrentState, timeout);
-                                            node.trace("[State:" + node.currentState.data.id + "] Successfully started timer with ID " + node.currentState.timer);
+                                            node.debug("[State:" + node.currentState.data.id + "] Successfully started timer with ID " + node.currentState.timer);
 
                                             node.currentState.until = node.currentState.since.clone();
                                             node.currentState.until.add(timeout, "milliseconds");
@@ -834,7 +834,7 @@ module.exports = function(RED)
                     node.debug("[State:" + state.data.id + "] Starting timer for trigger at " + state.triggerTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
                     node.currentState.timer = setTimeout(async() =>
                     {
-                        node.debug("[State:" + state.data.id + "] Timer expired");
+                        node.trace("[State:" + state.data.id + "] Timer with ID " + node.currentState.timer + " expired");
                         delete node.currentState.timer;
 
                         if (await evalConditions(state.triggerTime))
@@ -854,7 +854,7 @@ module.exports = function(RED)
                         updateStatus();
                     }, state.triggerTime.diff(chronos.getCurrentTime(node)));
 
-                    node.trace("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer);
+                    node.debug("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer);
                 }
             }
         }
@@ -863,7 +863,7 @@ module.exports = function(RED)
         {
             if (node.currentState.timer)
             {
-                node.trace("Cancelling active timer with ID " + node.currentState.timer);
+                node.debug("Cancelling active timer with ID " + node.currentState.timer);
 
                 clearTimeout(node.currentState.timer);
                 delete node.currentState.timer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.23.0",
+    "version": "1.24.0",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -30,14 +30,14 @@
     },
     "devDependencies": {
         "eslint": "^8.57.0",
-        "jsonata": "^2.0.4",
+        "jsonata": "^2.0.5",
         "mocha": "^10.4.0",
         "node-red": "^3.1.9",
-        "node-red-node-test-helper": "^0.3.3",
+        "node-red-node-test-helper": "^0.3.4",
         "nyc": "^15.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^17.0.1"
+        "sinon": "^17.0.2"
     },
     "main": "none",
     "scripts": {


### PR DESCRIPTION
### Added
- Added possibility to delay any message sent by the scheduler node on node start by an arbitrary duration.
- Added new commands "pause" and "resume" to state nodes for temporarily suspending automatic state changes.
- Added support for basic and extended input formats from environment/context variables to scheduler nodes (limited to times only).
- Added support for basic and extended input formats from environment/context variables to state nodes (limited to times only).
- Added support for basic and extended input formats from environment/context variables for until time to repeat nodes.
- Added support for retrieving custom repetition data and until time from arbitrary message properties to repeat nodes.
- Added support for retrieving custom delay data from arbitrary message properties to delay nodes.
- Added support for changing the time zone / UTC offset of the target's local time in the convert rule of time change nodes.
- Added example flows for the state node.

### Changed
- Optimized resource usage of the scheduler node by starting only a single timer for the next upcoming event instead of one timer per enabled event.
- Removed usage of Node-RED event `flows:started` and replaced it with a configurable fixed delay on node start (see also above).
- Improved fetching of environment variables for all nodes in case the user specified the variable in the form `${VAR_NAME}` instead of variable name only.

### Fixed
- Fixed non-working localization of date/time strings (please note that localization is limited to supported languages and their regions).
- Fixed wrong interpretation of numerical input of milliseconds since midnight in some areas.