### PR TITLE
Fix non-considered offset for sun/moon times after one day

### DIFF
--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -509,6 +509,11 @@ module.exports = function(RED)
                 else
                 {
                     node.sendTime = chronos.getTime(RED, node, node.sendTime.add(1, "days"), type, value);
+
+                    if (offset != 0)
+                    {
+                        node.sendTime.add(random ? Math.round(Math.random() * offset) : offset, "minutes");
+                    }
                 }
             }
 
@@ -517,7 +522,7 @@ module.exports = function(RED)
             {
                 delete node.delayTimer;
                 flushQueue();
-            }, node.sendTime.diff(now));
+            }, node.sendTime.diff(chronos.getCurrentTime(node)));
         }
 
         async function setupCustomDelayTimer(msg)


### PR DESCRIPTION
This pull request fixes a bug in delay node which caused the configured offset not to be applied for sun/moon times if the configured point in time was in the past.