### PR TITLE
Add possibility to specify comparison precision for time switch and filter node

### DIFF
--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -349,7 +349,11 @@ SOFTWARE.
                     const operator = $("<select/>", {class: "node-input-operator", style: "width: auto;"})
                                         .appendTo(operatorBox);
                     const operGrp = $("<optgroup></optgroup>").attr("label", node._("node-red-contrib-chronos/chronos-config:common.list.condition.operators"))
+                                        .append($("<option></option>").val("equal").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.equal")))
+                                        .append($("<option></option>").val("notEqual").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.notEqual")))
                                         .append($("<option></option>").val("before").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.before")))
+                                        .append($("<option></option>").val("until").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.until")))
+                                        .append($("<option></option>").val("since").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.since")))
                                         .append($("<option></option>").val("after").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.after")))
                                         .append($("<option></option>").val("between").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.between")))
                                         .append($("<option></option>").val("outside").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.outside")))
@@ -390,28 +394,52 @@ SOFTWARE.
                                         .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time2Row1);
 
-                    $("<label/>", {style: "width: auto; margin-right: 6px;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
+                                        .html("<span style='margin-right: 6px;'>&#8597;</span>")
                                         .appendTo(time1Row2);
                     const offset1 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset1", style: "width: 50px !important;"})
                                         .appendTo(time1Row2)
                                         .spinner(offsetInput);
-                    const random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                    const random1Label = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.label.random"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-random' aria-hidden='true'></i>")
                                         .appendTo(time1Row2);
-                    $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: auto;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.random"))
+                    const random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                                        .appendTo(random1Label);
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-bullseye' aria-hidden='true'></i>")
+                                        .appendTo(time1Row2);
+                    const precision1 = $("<select/>", {class: "node-input-precision1", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: 117px; margin-left: 4px;"})
+                                        .append($("<option></option>").val("millisecond").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.millisecond")))
+                                        .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
+                                        .append($("<option></option>").val("minute").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.minute")))
+                                        .append($("<option></option>").val("hour").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.hour")))
+                                        .append($("<option></option>").val("day").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.day")))
+                                        .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
+                                        .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .appendTo(time1Row2);
 
-                    $("<label/>", {style: "width: auto; margin-right: 6px;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
+                                        .html("<span style='margin-right: 6px;'>&#8597;</span>")
                                         .appendTo(time2Row2);
                     const offset2 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset2", style: "width: 50px !important;"})
                                         .appendTo(time2Row2)
                                         .spinner(offsetInput);
-                    const random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                    const random2Label = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.label.random"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-random' aria-hidden='true'></i>")
                                         .appendTo(time2Row2);
-                    $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: auto;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.random"))
+                    const random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                                        .appendTo(random2Label);
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-bullseye' aria-hidden='true'></i>")
+                                        .appendTo(time2Row2);
+                    const precision2 = $("<select/>", {class: "node-input-precision2", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: 117px; margin-left: 4px;"})
+                                        .append($("<option></option>").val("millisecond").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.millisecond")))
+                                        .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
+                                        .append($("<option></option>").val("minute").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.minute")))
+                                        .append($("<option></option>").val("hour").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.hour")))
+                                        .append($("<option></option>").val("day").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.day")))
+                                        .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
+                                        .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .appendTo(time2Row2);
 
                     const dayType = $("<select/>", {class: "node-input-dayType", style: "width: auto; margin-left: 4px;"})
@@ -506,7 +534,11 @@ SOFTWARE.
                         var value = $(this).val();
                         switch (value)
                         {
+                            case "equal":
+                            case "notEqual":
                             case "before":
+                            case "until":
+                            case "since":
                             case "after":
                             {
                                 timeBox.show();
@@ -706,39 +738,77 @@ SOFTWARE.
 
                     operator.val(data.operator);
 
-                    if ((data.operator == "before") || (data.operator == "after"))
+                    if ((data.operator == "equal") ||
+                        (data.operator == "notEqual") ||
+                        (data.operator == "before") ||
+                        (data.operator == "until") ||
+                        (data.operator == "since") ||
+                        (data.operator == "after"))
                     {
+                        // backward compatibility to v1.0.2 and below
+                        if (typeof data.operands.offset == "undefined")
+                        {
+                            data.operands.offset = 0;
+                            data.operands.random = false;
+                        }
+                        // backward compatibility to v1.24.0 and below
+                        if (typeof data.operands.precision == "undefined")
+                        {
+                            data.operands.precision = "millisecond";
+                        }
+
                         time1._prevType = data.operands.type;
                         time1.typedInput("type", data.operands.type);
                         time1.typedInput("value", data.operands.value);
-                        if (data.operands.offset &&  // backwards compatibility to v1.0.2
-                            (data.operands.offset != 0))
+                        offset1.spinner("value", data.operands.offset);
+                        random1.prop("checked", data.operands.random);
+                        precision1.val(data.operands.precision);
+                        if ((data.operands.offset != 0) || (data.operands.precision != "millisecond"))
                         {
-                            offset1.spinner("value", data.operands.offset);
-                            random1.prop("checked", data.operands.random);
                             showExtensionRow1();
                         }
                     }
                     else if ((data.operator == "between") || (data.operator == "outside"))
                     {
+                        // backward compatibility to v1.0.2 and below
+                        if (typeof data.operands[0].offset == "undefined")
+                        {
+                            data.operands[0].offset = 0;
+                            data.operands[0].random = false;
+                        }
+                        if (typeof data.operands[1].offset == "undefined")
+                        {
+                            data.operands[1].offset = 0;
+                            data.operands[1].random = false;
+                        }
+                        // backward compatibility to v1.24.0 and below
+                        if (typeof data.operands[0].precision == "undefined")
+                        {
+                            data.operands[0].precision = "millisecond";
+                        }
+                        if (typeof data.operands[1].precision == "undefined")
+                        {
+                            data.operands[1].precision = "millisecond";
+                        }
+
                         time1._prevType = data.operands[0].type;
                         time1.typedInput("type", data.operands[0].type);
                         time1.typedInput("value", data.operands[0].value);
+                        offset1.spinner("value", data.operands[0].offset);
+                        random1.prop("checked", data.operands[0].random);
+                        precision1.val(data.operands[0].precision);
                         time2._prevType = data.operands[1].type;
                         time2.typedInput("type", data.operands[1].type);
                         time2.typedInput("value", data.operands[1].value);
-                        if (data.operands[0].offset &&  // backwards compatibility to v1.0.2
-                            (data.operands[0].offset != 0))
+                        offset2.spinner("value", data.operands[1].offset);
+                        random2.prop("checked", data.operands[1].random);
+                        precision2.val(data.operands[1].precision);
+                        if ((data.operands[0].offset != 0) || (data.operands[0].precision != "millisecond"))
                         {
-                            offset1.spinner("value", data.operands[0].offset);
-                            random1.prop("checked", data.operands[0].random);
                             showExtensionRow1();
                         }
-                        if (data.operands[1].offset &&  // backwards compatibility to v1.0.2
-                            (data.operands[1].offset != 0))
+                        if ((data.operands[1].offset != 0) || (data.operands[1].precision != "millisecond"))
                         {
-                            offset2.spinner("value", data.operands[1].offset);
-                            random2.prop("checked", data.operands[1].random);
                             showExtensionRow2();
                         }
                     }
@@ -838,16 +908,24 @@ SOFTWARE.
                 const  offset2 = $(this).find(".node-input-offset2");
                 const  random1 = $(this).find(".node-input-random1");
                 const  random2 = $(this).find(".node-input-random2");
+                const precision1 = $(this).find(".node-input-precision1");
+                const precision2 = $(this).find(".node-input-precision2");
 
                 data.operator = $(this).find(".node-input-operator").val();
 
-                if ((data.operator == "before") || (data.operator == "after"))
+                if ((data.operator == "equal") ||
+                    (data.operator == "notEqual") ||
+                    (data.operator == "before") ||
+                    (data.operator == "until") ||
+                    (data.operator == "since") ||
+                    (data.operator == "after"))
                 {
                     data.operands = {};
                     data.operands.type = time1.typedInput("type");
                     data.operands.value = time1.typedInput("value");
                     data.operands.offset = offset1.spinner("value");
                     data.operands.random = random1.prop("checked");
+                    data.operands.precision = precision1.val();
                 }
                 else if ((data.operator == "between") || (data.operator == "outside"))
                 {
@@ -856,10 +934,12 @@ SOFTWARE.
                     data.operands[0].value = time1.typedInput("value");
                     data.operands[0].offset = offset1.spinner("value");
                     data.operands[0].random = random1.prop("checked");
+                    data.operands[0].precision = precision1.val();
                     data.operands[1].type = time2.typedInput("type");
                     data.operands[1].value = time2.typedInput("value");
                     data.operands[1].offset = offset2.spinner("value");
                     data.operands[1].random = random2.prop("checked");
+                    data.operands[1].precision = precision2.val();
                 }
                 else if (data.operator == "days")
                 {

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -25,8 +25,9 @@
         },
         "tooltip":
         {
-            "offset":  "Versatz (in Minuten)",
-            "expand":  "Aus-/Einklappen"
+            "offset":     "Versatz (in Minuten)",
+            "precision":  "Genauigkeit",
+            "expand":     "Aus-/Einklappen"
         },
         "list":
         {
@@ -58,7 +59,11 @@
                 "sources":    "Quelle",
                 "operator":
                 {
+                    "equal":      "==",
+                    "notEqual":   "!=",
                     "before":     "Vor",
+                    "until":      "Bis",
+                    "since":      "Ab",
                     "after":      "Nach",
                     "between":    "Zwischen",
                     "outside":    "Außerhalb",

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -124,17 +124,33 @@ SOFTWARE.
             linken Seite gibt es die folgenden Möglichkeiten:
             <ul>
                 <li>
+                    Operator <i>==</i>: Prüft ob die Basiszeit mit der spezifizierten
+                    Zeit identisch ist.
+                </li>
+                <li>
+                    Operator <i>!=</i>: Prüft ob die Basiszeit nicht mit der
+                    spezifizierten Zeit identisch ist.
+                </li>
+                <li>
                     Operator <i>Vor</i>: Prüft ob die Basiszeit früher als die
                     spezifizierte Zeit ist.
                 </li>
                 <li>
-                    Operator <i>Nach</i>: Prüft ob die Basiszeit gleich oder später als
-                    die spezifizierte Zeit ist.
+                    Operator <i>Bis</i>: Prüft ob die Basiszeit früher als oder
+                    gleich wie die spezifizierte Zeit ist.
                 </li>
                 <li>
-                    Operator <i>Zwischen</i>: Prüft ob die Basiszeit gleich oder später
-                    als die erste und früher als die zweite spezifizierte Zeit
-                    ist.
+                    Operator <i>Ab</i>: Prüft ob die Basiszeit gleich wie oder
+                    später als die spezifizierte Zeit ist.
+                </li>
+                <li>
+                    Operator <i>Nach</i>: Prüft ob die Basiszeit später als die
+                    spezifizierte Zeit ist.
+                </li>
+                <li>
+                    Operator <i>Zwischen</i>: Prüft ob die Basiszeit gleich wie oder
+                    später als die erste und früher als oder gleich wie die zweite
+                    spezifizierte Zeit ist.
                 </li>
                 <li>
                     Operator <i>Außerhalb</i>: Prüft ob die Basiszeit früher als die
@@ -234,9 +250,10 @@ SOFTWARE.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines
-            (wahlweise zufälligen) Versatzes verschoben werden. Die
-            entsprechenden Eingabefelder können über den Pfeil-Knopf auf
-            der rechten Seite ausgeklappt werden.
+            (wahlweise zufälligen) Versatzes verschoben werden und die
+            Genauigkeit der Zeitpunkte für den Vergleich kann festgelegt
+            werden. Die entsprechenden Eingabefelder können über den
+            Pfeil-Knopf auf der rechten Seite ausgeklappt werden.
         </dd>
         <dt>Alle Bedingungen müssen zutreffen</dt>
         <dd>
@@ -263,14 +280,17 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>operator<span class="property-type">string</span></dt>
-        <dd>Operator für den Vergleich; entweder "before", "after", "between", "outside", "days", "weekdays" oder "months"</dd>
+        <dd>
+            Operator für den Vergleich; entweder "equal", "notEqual", "before", "until",
+            "since", "after", "between", "outside", "days", "weekdays" oder "months"
+        </dd>
         <dt class="optional">operands<span class="property-type">object | array</span></dt>
         <dd>Operanden für den Vergleich; der Inhalt ist abhängig vom Operator</dd>
     </dl>
     <p>
         Wenn <code>operator</code> folgendes enthält:
         <ul>
-            <li>"before" oder "after", muss <code>operands</code> ein Objekt sein</li>
+            <li>"equal", "notEqual", "before", "until", "since" oder "after", muss <code>operands</code> ein Objekt sein</li>
             <li>"between" oder "outside", muss <code>operands</code> ein Array mit zwei Objekten sein, die den zwei Operanden entsprechen</li>
         </ul>
         Die Objekte müssen jeweils folgende Eigenschaften enthalten:
@@ -284,6 +304,11 @@ SOFTWARE.
         <dd>Zeitlicher Versatz zum Operandenwert</dd>
         <dt>random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
+        <dt class="optional">precision<span class="property-type">string</span></dt>
+        <dd>
+            Vergleichsgenauigkeit; entweder "millisecond", "second",
+            "minute", "hour", "day", "month" oder "year"
+        </dd>
     </dl>
     <p>
         Wenn <code>operator</code> "days" enthält, muss <code>operands</code> ein

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -99,17 +99,33 @@ SOFTWARE.
             linken Seite gibt es die folgenden Möglichkeiten:
             <ul>
                 <li>
+                    Operator <i>==</i>: Prüft ob die Basiszeit mit der spezifizierten
+                    Zeit identisch ist.
+                </li>
+                <li>
+                    Operator <i>!=</i>: Prüft ob die Basiszeit nicht mit der
+                    spezifizierten Zeit identisch ist.
+                </li>
+                <li>
                     Operator <i>Vor</i>: Prüft ob die Basiszeit früher als die
                     spezifizierte Zeit ist.
                 </li>
                 <li>
-                    Operator <i>Nach</i>: Prüft ob die Basiszeit gleich oder später als
-                    die spezifizierte Zeit ist.
+                    Operator <i>Bis</i>: Prüft ob die Basiszeit früher als oder
+                    gleich wie die spezifizierte Zeit ist.
                 </li>
                 <li>
-                    Operator <i>Zwischen</i>: Prüft ob die Basiszeit gleich oder später
-                    als die erste und früher als die zweite spezifizierte Zeit
-                    ist.
+                    Operator <i>Ab</i>: Prüft ob die Basiszeit gleich wie oder
+                    später als die spezifizierte Zeit ist.
+                </li>
+                <li>
+                    Operator <i>Nach</i>: Prüft ob die Basiszeit später als die
+                    spezifizierte Zeit ist.
+                </li>
+                <li>
+                    Operator <i>Zwischen</i>: Prüft ob die Basiszeit gleich wie oder
+                    später als die erste und früher als oder gleich wie die zweite
+                    spezifizierte Zeit ist.
                 </li>
                 <li>
                     Operator <i>Außerhalb</i>: Prüft ob die Basiszeit früher als die
@@ -213,9 +229,10 @@ SOFTWARE.
                 </li>
             </ul>
             Die spezifizierten Zeitpunkte können zusätzlich mittels eines
-            (wahlweise zufälligen) Versatzes verschoben werden. Die
-            entsprechenden Eingabefelder können über den Pfeil-Knopf auf
-            der rechten Seite ausgeklappt werden.
+            (wahlweise zufälligen) Versatzes verschoben werden und die
+            Genauigkeit der Zeitpunkte für den Vergleich kann festgelegt
+            werden. Die entsprechenden Eingabefelder können über den
+            Pfeil-Knopf auf der rechten Seite ausgeklappt werden.
         </dd>
         <dt>Bei erster Übereinstimmung aufhören</dt>
         <dd>
@@ -239,14 +256,18 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>operator<span class="property-type">string</span></dt>
-        <dd>Operator für den Vergleich; entweder "before", "after", "between", "outside", "days", "weekdays", "months" oder "otherwise"</dd>
+        <dd>
+            Operator für den Vergleich; entweder "equal", "notEqual", "before", "until",
+            "since", "after", "between", "outside", "days", "weekdays", "months"
+            oder "otherwise"
+        </dd>
         <dt class="optional">operands<span class="property-type">object | array</span></dt>
         <dd>Operanden für den Vergleich; der Inhalt ist abhängig vom Operator</dd>
     </dl>
     <p>
         Wenn <code>operator</code> folgendes enthält:
         <ul>
-            <li>"before" oder "after", muss <code>operands</code> ein Objekt sein</li>
+            <li>"equal", "notEqual", "before", "until", "since" oder "after", muss <code>operands</code> ein Objekt sein</li>
             <li>"between" oder "outside", muss <code>operands</code> ein Array mit zwei Objekten sein, die den zwei Operanden entsprechen</li>
         </ul>
         Die Objekte müssen jeweils folgende Eigenschaften enthalten:
@@ -260,6 +281,11 @@ SOFTWARE.
         <dd>Zeitlicher Versatz zum Operandenwert</dd>
         <dt>random<span class="property-type">boolean</span></dt>
         <dd>Zufälliger Zeitversatz</dd>
+        <dt class="optional">precision<span class="property-type">string</span></dt>
+        <dd>
+            Vergleichsgenauigkeit; entweder "millisecond", "second",
+            "minute", "hour", "day", "month" oder "year"
+        </dd>
     </dl>
     <p>
         Wenn <code>operator</code> "days" enthält, muss <code>operands</code> ein

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -25,8 +25,9 @@
         },
         "tooltip":
         {
-            "offset":  "Offset (in minutes)",
-            "expand":  "expand/collapse"
+            "offset":     "offset (in minutes)",
+            "precision":  "precision",
+            "expand":     "expand/collapse"
         },
         "list":
         {
@@ -58,7 +59,11 @@
                 "sources":    "Source",
                 "operator":
                 {
+                    "equal":      "==",
+                    "notEqual":   "!=",
                     "before":     "before",
+                    "until":      "until",
+                    "since":      "since",
                     "after":      "after",
                     "between":    "between",
                     "outside":    "outside",

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -116,16 +116,32 @@ SOFTWARE.
             the left side, the following possibilities are available:
             <ul>
                 <li>
+                    Operator <i>==</i>: Checks if the base time is the same as the
+                    specified time.
+                </li>
+                <li>
+                    Operator <i>!=</i>: Checks if the base time is not the same as the
+                    specified time.
+                </li>
+                <li>
                     Operator <i>before</i>: Checks if the base time is earlier than the
                     specified time.
                 </li>
                 <li>
-                    Operator <i>after</i>: Checks if the base time is equal to or later
+                    Operator <i>until</i>: Checks if the base time is earlier than or
+                    equal to the specified time.
+                </li>
+                <li>
+                    Operator <i>since</i>: Checks if the base time is equal to or later
                     than the specified time.
                 </li>
                 <li>
+                    Operator <i>after</i>: Checks if the base time is later than the
+                    specified time.
+                </li>
+                <li>
                     Operator <i>between</i>: Checks if the base time is equal to or later
-                    than the first and earlier than the second specified time.
+                    than the first and earlier than or equal to the second specified time.
                 </li>
                 <li>
                     Operator <i>outside</i>: Checks if the base time is earlier than the
@@ -215,7 +231,8 @@ SOFTWARE.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally
-            randomized) offset, accessible through the expand/collapse arrow on
+            randomized) offset and set to a certain precision for the comparison.
+            These settings are accessible through the expand/collapse arrow on
             the right side.
         </dd>
     </dl>
@@ -231,14 +248,17 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>operator<span class="property-type">string</span></dt>
-        <dd>Operator for comparison; one of "before", "after", "between", "outside", "days", "weekdays" or "months"</dd>
+        <dd>
+            Operator for comparison; one of "equal", "notEqual", "before", "until",
+            "since", "after", "between", "outside", "days", "weekdays", or "months"
+        </dd>
         <dt class="optional">operands<span class="property-type">object | array</span></dt>
         <dd>Operands for comparison; content is depending on operator</dd>
     </dl>
     <p>
         If <code>operator</code> is:
         <ul>
-            <li>"before" or "after", <code>operands</code> must be an object</li>
+            <li>"equal", "notEqual", "before", "until", "since" or "after", <code>operands</code> must be an object</li>
             <li>"between" or "outside", <code>operands</code> must be an array containing two objects corresponding to the first and second operand</li>
         </ul>
         The objects must each include the following properties:
@@ -252,6 +272,11 @@ SOFTWARE.
         <dd>Offset to the operand time</dd>
         <dt>random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
+        <dt class="optional">precision<span class="property-type">string</span></dt>
+        <dd>
+            Comparison precision; one of "millisecond", "second",
+            "minute", "hour", "day", "month" or "year"
+        </dd>
     </dl>
     <p>
         If <code>operator</code> is "days", <code>operands</code> must be

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -91,16 +91,32 @@ SOFTWARE.
             possibilities are available:
             <ul>
                 <li>
+                    Operator <i>==</i>: Checks if the base time is the same as the
+                    specified time.
+                </li>
+                <li>
+                    Operator <i>!=</i>: Checks if the base time is not the same as the
+                    specified time.
+                </li>
+                <li>
                     Operator <i>before</i>: Checks if the base time is earlier than the
                     specified time.
                 </li>
                 <li>
-                    Operator <i>after</i>: Checks if the base time is equal to or later
+                    Operator <i>until</i>: Checks if the base time is earlier than or
+                    equal to the specified time.
+                </li>
+                <li>
+                    Operator <i>since</i>: Checks if the base time is equal to or later
                     than the specified time.
                 </li>
                 <li>
+                    Operator <i>after</i>: Checks if the base time is later than the
+                    specified time.
+                </li>
+                <li>
                     Operator <i>between</i>: Checks if the base time is equal to or later
-                    than the first and earlier than the second specified time.
+                    than the first and earlier than or equal to the second specified time.
                 </li>
                 <li>
                     Operator <i>outside</i>: Checks if the base time is earlier than the
@@ -194,7 +210,8 @@ SOFTWARE.
                 </li>
             </ul>
             The specified times can additionally be shifted by an (optionally
-            randomized) offset, accessible through the expand/collapse arrow on
+            randomized) offset and set to a certain precision for the comparison.
+            These settings are accessible through the expand/collapse arrow on
             the right side.
         </dd>
         <dt>Stop on first match</dt>
@@ -217,14 +234,18 @@ SOFTWARE.
     </p>
     <dl class="message-properties">
         <dt>operator<span class="property-type">string</span></dt>
-        <dd>Operator for comparison; one of "before", "after", "between", "outside", "days", "weekdays", "months" or "otherwise"</dd>
+        <dd>
+            Operator for comparison; one of "equal", "notEqual", "before", "until",
+            "since", "after", "between", "outside", "days", "weekdays", "months"
+            or "otherwise"
+        </dd>
         <dt class="optional">operands<span class="property-type">object | array</span></dt>
         <dd>Operands for comparison; content is depending on operator</dd>
     </dl>
     <p>
         If <code>operator</code> is:
         <ul>
-            <li>"before" or "after", <code>operands</code> must be an object</li>
+            <li>"equal", "notEqual", "before", "until", "since" or "after", <code>operands</code> must be an object</li>
             <li>"between" or "outside", <code>operands</code> must be an array containing two objects corresponding to the first and second operand</li>
         </ul>
         The objects must each include the following properties:
@@ -238,6 +259,11 @@ SOFTWARE.
         <dd>Offset to the operand time</dd>
         <dt>random<span class="property-type">boolean</span></dt>
         <dd>Randomized offset</dd>
+        <dt class="optional">precision<span class="property-type">string</span></dt>
+        <dd>
+            Comparison precision; one of "millisecond", "second",
+            "minute", "hour", "day", "month" or "year"
+        </dd>
     </dl>
     <p>
         If <code>operator</code> is "days", <code>operands</code> must be

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -318,7 +318,11 @@ SOFTWARE.
                     const operator = $("<select/>", {class: "node-input-operator", style: "width: auto;"})
                                         .appendTo(operatorBox);
                     const operGrp = $("<optgroup></optgroup>").attr("label", node._("node-red-contrib-chronos/chronos-config:common.list.condition.operators"))
+                                        .append($("<option></option>").val("equal").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.equal")))
+                                        .append($("<option></option>").val("notEqual").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.notEqual")))
                                         .append($("<option></option>").val("before").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.before")))
+                                        .append($("<option></option>").val("until").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.until")))
+                                        .append($("<option></option>").val("since").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.since")))
                                         .append($("<option></option>").val("after").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.after")))
                                         .append($("<option></option>").val("between").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.between")))
                                         .append($("<option></option>").val("outside").text(node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator.outside")))
@@ -360,28 +364,52 @@ SOFTWARE.
                                         .html("<i class='fa fa-angle-right' aria-hidden='true'></i>")
                                         .appendTo(time2Row1);
 
-                    $("<label/>", {style: "width: auto; margin-right: 6px;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
+                                        .html("<span style='margin-right: 6px;'>&#8597;</span>")
                                         .appendTo(time1Row2);
                     const offset1 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset1", style: "width: 50px !important;"})
                                         .appendTo(time1Row2)
                                         .spinner(offsetInput);
-                    const random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                    const random1Label = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.label.random"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-random' aria-hidden='true'></i>")
                                         .appendTo(time1Row2);
-                    $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: auto;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.random"))
+                    const random1 = $("<input/>", {type: "checkbox", class: "node-input-random1", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                                        .appendTo(random1Label);
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-bullseye' aria-hidden='true'></i>")
+                                        .appendTo(time1Row2);
+                    const precision1 = $("<select/>", {class: "node-input-precision1", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: 117px; margin-left: 4px;"})
+                                        .append($("<option></option>").val("millisecond").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.millisecond")))
+                                        .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
+                                        .append($("<option></option>").val("minute").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.minute")))
+                                        .append($("<option></option>").val("hour").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.hour")))
+                                        .append($("<option></option>").val("day").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.day")))
+                                        .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
+                                        .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .appendTo(time1Row2);
 
-                    $("<label/>", {style: "width: auto; margin-right: 6px;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.offset"))
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), style: "display: inline-block; width: auto; margin-bottom: 0px;"})
+                                        .html("<span style='margin-right: 6px;'>&#8597;</span>")
                                         .appendTo(time2Row2);
                     const offset2 = $("<input/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.offset"), class: "node-input-offset2", style: "width: 50px !important;"})
                                         .appendTo(time2Row2)
                                         .spinner(offsetInput);
-                    const random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                    const random2Label = $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.label.random"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-random' aria-hidden='true'></i>")
                                         .appendTo(time2Row2);
-                    $("<label/>", {style: "margin-left: 4px; margin-bottom: 0px; width: auto;"})
-                                        .text(node._("node-red-contrib-chronos/chronos-config:common.label.random"))
+                    const random2 = $("<input/>", {type: "checkbox", class: "node-input-random2", style: "width: auto; margin-top: 0px; margin-bottom: 1px; margin-left: 6px;"})
+                                        .appendTo(random2Label);
+                    $("<label/>", {title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: auto; margin-left: 10px; margin-bottom: 0px;"})
+                                        .html("<i class='fa fa-bullseye' aria-hidden='true'></i>")
+                                        .appendTo(time2Row2);
+                    const precision2 = $("<select/>", {class: "node-input-precision2", title: node._("node-red-contrib-chronos/chronos-config:common.tooltip.precision"), style: "width: 117px; margin-left: 4px;"})
+                                        .append($("<option></option>").val("millisecond").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.millisecond")))
+                                        .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
+                                        .append($("<option></option>").val("minute").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.minute")))
+                                        .append($("<option></option>").val("hour").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.hour")))
+                                        .append($("<option></option>").val("day").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.day")))
+                                        .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
+                                        .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .appendTo(time2Row2);
 
                     const dayType = $("<select/>", {class: "node-input-dayType", style: "width: auto; margin-left: 4px;"})
@@ -476,7 +504,11 @@ SOFTWARE.
                         var value = $(this).val();
                         switch (value)
                         {
+                            case "equal":
+                            case "notEqual":
                             case "before":
+                            case "until":
+                            case "since":
                             case "after":
                             {
                                 timeBox.show();
@@ -676,39 +708,77 @@ SOFTWARE.
 
                     operator.val(data.operator);
 
-                    if ((data.operator == "before") || (data.operator == "after"))
+                    if ((data.operator == "equal") ||
+                        (data.operator == "notEqual") ||
+                        (data.operator == "before") ||
+                        (data.operator == "until") ||
+                        (data.operator == "since") ||
+                        (data.operator == "after"))
                     {
+                        // backward compatibility to v1.0.2 and below
+                        if (typeof data.operands.offset == "undefined")
+                        {
+                            data.operands.offset = 0;
+                            data.operands.random = false;
+                        }
+                        // backward compatibility to v1.24.0 and below
+                        if (typeof data.operands.precision == "undefined")
+                        {
+                            data.operands.precision = "millisecond";
+                        }
+
                         time1._prevType = data.operands.type;
                         time1.typedInput("type", data.operands.type);
                         time1.typedInput("value", data.operands.value);
-                        if (data.operands.offset &&  // backwards compatibility to v1.0.2
-                            (data.operands.offset != 0))
+                        offset1.spinner("value", data.operands.offset);
+                        random1.prop("checked", data.operands.random);
+                        precision1.val(data.operands.precision);
+                        if ((data.operands.offset != 0) || (data.operands.precision != "millisecond"))
                         {
-                            offset1.spinner("value", data.operands.offset);
-                            random1.prop("checked", data.operands.random);
                             showExtensionRow1();
                         }
                     }
                     else if ((data.operator == "between") || (data.operator == "outside"))
                     {
+                        // backward compatibility to v1.0.2 and below
+                        if (typeof data.operands[0].offset == "undefined")
+                        {
+                            data.operands[0].offset = 0;
+                            data.operands[0].random = false;
+                        }
+                        if (typeof data.operands[1].offset == "undefined")
+                        {
+                            data.operands[1].offset = 0;
+                            data.operands[1].random = false;
+                        }
+                        // backward compatibility to v1.24.0 and below
+                        if (typeof data.operands[0].precision == "undefined")
+                        {
+                            data.operands[0].precision = "millisecond";
+                        }
+                        if (typeof data.operands[1].precision == "undefined")
+                        {
+                            data.operands[1].precision = "millisecond";
+                        }
+
                         time1._prevType = data.operands[0].type;
                         time1.typedInput("type", data.operands[0].type);
                         time1.typedInput("value", data.operands[0].value);
+                        offset1.spinner("value", data.operands[0].offset);
+                        random1.prop("checked", data.operands[0].random);
+                        precision1.val(data.operands[0].precision);
                         time2._prevType = data.operands[1].type;
                         time2.typedInput("type", data.operands[1].type);
                         time2.typedInput("value", data.operands[1].value);
-                        if (data.operands[0].offset &&  // backwards compatibility to v1.0.2
-                            (data.operands[0].offset != 0))
+                        offset2.spinner("value", data.operands[1].offset);
+                        random2.prop("checked", data.operands[1].random);
+                        precision2.val(data.operands[1].precision);
+                        if ((data.operands[0].offset != 0) || (data.operands[0].precision != "millisecond"))
                         {
-                            offset1.spinner("value", data.operands[0].offset);
-                            random1.prop("checked", data.operands[0].random);
                             showExtensionRow1();
                         }
-                        if (data.operands[1].offset &&  // backwards compatibility to v1.0.2
-                            (data.operands[1].offset != 0))
+                        if ((data.operands[1].offset != 0) || (data.operands[1].precision != "millisecond"))
                         {
-                            offset2.spinner("value", data.operands[1].offset);
-                            random2.prop("checked", data.operands[1].random);
                             showExtensionRow2();
                         }
                     }
@@ -851,17 +921,25 @@ SOFTWARE.
                 const offset2 = $(this).find(".node-input-offset2");
                 const random1 = $(this).find(".node-input-random1");
                 const random2 = $(this).find(".node-input-random2");
+                const precision1 = $(this).find(".node-input-precision1");
+                const precision2 = $(this).find(".node-input-precision2");
 
                 data.operator = $(this).find(".node-input-operator").val();
                 data.label = node._("node-red-contrib-chronos/chronos-config:common.list.condition.operator." + data.operator);
 
-                if ((data.operator == "before") || (data.operator == "after"))
+                if ((data.operator == "equal") ||
+                    (data.operator == "notEqual") ||
+                    (data.operator == "before") ||
+                    (data.operator == "until") ||
+                    (data.operator == "since") ||
+                    (data.operator == "after"))
                 {
                     data.operands = {};
                     data.operands.type = time1.typedInput("type");
                     data.operands.value = time1.typedInput("value");
                     data.operands.offset = offset1.spinner("value");
                     data.operands.random = random1.prop("checked");
+                    data.operands.precision = precision1.val();
 
                     if ((data.operands.type == "time") || (data.operands.type == "custom"))
                     {
@@ -911,10 +989,12 @@ SOFTWARE.
                     data.operands[0].value = time1.typedInput("value");
                     data.operands[0].offset = offset1.spinner("value");
                     data.operands[0].random = random1.prop("checked");
+                    data.operands[0].precision = precision1.val();
                     data.operands[1].type = time2.typedInput("type");
                     data.operands[1].value = time2.typedInput("value");
                     data.operands[1].offset = offset2.spinner("value");
                     data.operands[1].random = random2.prop("checked");
+                    data.operands[1].precision = precision2.val();
 
                     data.label += " ";
                     if ((data.operands[0].type == "time") || (data.operands[0].type == "custom"))


### PR DESCRIPTION
This pull request adds the possibility to specify the precision for time comparisons in time switch and filter nodes (previously, comparison was always on millisecond precision). The precision is applicable to the operators _before_, _after_, _between_ and _outside_ as well as to the new operators _==_, _!=_, _until_ and _since_. The new operators have been added to have more comparison flexibility in case of lower comparison precisions. The precision ranges from the granularity of milliseconds up to the granularity of years. Additionally, the new JSONata function `$isSame()` corresponding to the _==_ operator has been added. The functions `$isBefore()`, `$isAfter()`, `$isBetween()` and `$isOutside()` have been updated to work with precisions, too.

### ‼️ Breaking Changes ‼️
- Operator _after_ previously had the meaning of "same and after" and now has the meaning of "after" only. The new operator _since_ takes over the meaning of "same and after".
- The JSONata functions `$isBetween()` and `$isOutside()` have two additional, non-optional arguments `precision1` and `precision2` denoting the precisions for the two times to compare.