### PR TITLE
Support for durations and more in time change node

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -31,10 +31,24 @@ SOFTWARE.
         <label for="node-input-config"><i class="fa fa-cog"></i> <span data-i18n="node-red-contrib-chronos/chronos-config:common.label.config"></span></label>
         <input type="text" id="node-input-config" data-i18n="[placeholder]node-red-contrib-chronos/chronos-config:common.label.config">
     </div>
-    <div class="form-row node-input-taskList-row" style="padding-top: 10px">
-        <label for="node-input-taskList" style="width: auto;"><i class="fa fa-random"></i> <span data-i18n="change.label.rules"></span></label>
+    <div class="form-row">
+        <label for="node-input-mode"><i class="fa fa-clock-o"></i> <span data-i18n="change.label.mode"></span></label>
+        <select id="node-input-mode" style="width: 70%;">
+            <option value="moment" data-i18n="change.list.mode.moment"></option>
+            <option value="duration" data-i18n="change.list.mode.duration"></option>
+        </select>
+    </div>
+    <div class="form-row" style="padding-top: 10px">
+        <label style="width: auto;"><i class="fa fa-random"></i> <span data-i18n="change.label.rules"></span></label>
+    </div>
+    <div id="node-input-momentRules-row" class="form-row node-input-list-row">
         <div class="form-row">
-            <ol id="node-input-taskList"></ol>
+            <ol id="node-input-momentRules"></ol>
+        </div>
+    </div>
+    <div id="node-input-durationRules-row" class="form-row node-input-list-row">
+        <div class="form-row">
+            <ol id="node-input-durationRules"></ol>
         </div>
     </div>
 </script>
@@ -62,7 +76,7 @@ SOFTWARE.
         },
         outputLabels: function(index)
         {
-            return this.conditions[index].label;
+            return this._("change.label.outputPort");
         },
         defaults:
         {
@@ -75,6 +89,10 @@ SOFTWARE.
                 value:    "",
                 type:     "chronos-config",
                 required: true
+            },
+            mode:
+            {
+                value: "time"
             },
             rules:
             {
@@ -90,117 +108,151 @@ SOFTWARE.
         {
             const node = this;
 
-            const taskList = $("#node-input-taskList").css("min-width", "510px").css("min-height", "150px").editableList(
+            const sunTimes =
+            [
+                {
+                    value: "nightEnd",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nightEnd")
+                },
+                {
+                    value: "nauticalDawn",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nauticalDawn")
+                },
+                {
+                    value: "dawn",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.dawn")
+                },
+                {
+                    value: "sunrise",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunrise")
+                },
+                {
+                    value: "sunriseEnd",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunriseEnd")
+                },
+                {
+                    value: "goldenHourEnd",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.goldenHourEnd")
+                },
+                {
+                    value: "solarNoon",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.solarNoon")
+                },
+                {
+                    value: "goldenHour",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.goldenHour")
+                },
+                {
+                    value: "sunsetStart",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunsetStart")
+                },
+                {
+                    value: "sunset",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunset")
+                },
+                {
+                    value: "dusk",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.dusk")
+                },
+                {
+                    value: "nauticalDusk",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nauticalDusk")
+                },
+                {
+                    value: "night",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.night")
+                },
+                {
+                    value: "nadir",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nadir")
+                }
+            ];
+
+            const moonTimes =
+            [
+                {
+                    value: "rise",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.moon.rise")
+                },
+                {
+                    value: "set",
+                    label: node._("node-red-contrib-chronos/chronos-config:common.list.moon.set")
+                }
+            ];
+
+            const nowInput =
+            {
+                value: "now",
+                label: node._("change.label.now"),
+                hasValue: false
+            };
+
+            const dateInput =
+            {
+                value: "date",
+                label: node._("change.label.date"),
+                icon: "fa fa-calendar",
+                hasValue: true,
+                validate: /^([2-9]\d\d\d)-([1-9]|0[1-9]|1[0-2])-([1-9]|0[1-9]|[12]\d|3[01])$/
+            };
+
+            const sunTimeInput =
+            {
+                value: "sun",
+                label: node._("node-red-contrib-chronos/chronos-config:common.label.sun"),
+                icon: "fa fa-sun-o",
+                options: sunTimes
+            };
+
+            const moonTimeInput =
+            {
+                value: "moon",
+                label: node._("node-red-contrib-chronos/chronos-config:common.label.moon"),
+                icon: "fa fa-moon-o",
+                options: moonTimes
+            };
+
+            const customInput =
+            {
+                value: "custom",
+                label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
+                icon: "fa fa-user-o",
+                hasValue: true,
+                validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
+            };
+
+            const partInput =
+            {
+                value: "num",
+                label: node._("change.label.number"),
+                icon: "red/images/typedInput/09.svg",
+                hasValue: true,
+                min: -27000,
+                max: 27000,
+                validate: function(v)
+                {
+                    return (v >= partInput.min) && (v <= partInput.max);
+                }
+            };
+
+            const addsubInput =
+            {
+                value: "num",
+                label: node._("change.label.number"),
+                icon: "red/images/typedInput/09.svg",
+                hasValue: true,
+                validate: function(v)
+                {
+                    return (v >= 1) && (v <= 1000000);
+                }
+            };
+
+            const timeRules = $("#node-input-momentRules").css("min-width", "510px").css("min-height", "150px").editableList(
             {
                 removable: true,
                 sortable: true,
                 addItem: function(item, index, data)
                 {
-                    const sunTimes =
-                    [
-                        {
-                            value: "nightEnd",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nightEnd")
-                        },
-                        {
-                            value: "nauticalDawn",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nauticalDawn")
-                        },
-                        {
-                            value: "dawn",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.dawn")
-                        },
-                        {
-                            value: "sunrise",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunrise")
-                        },
-                        {
-                            value: "sunriseEnd",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunriseEnd")
-                        },
-                        {
-                            value: "goldenHourEnd",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.goldenHourEnd")
-                        },
-                        {
-                            value: "solarNoon",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.solarNoon")
-                        },
-                        {
-                            value: "goldenHour",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.goldenHour")
-                        },
-                        {
-                            value: "sunsetStart",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunsetStart")
-                        },
-                        {
-                            value: "sunset",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.sunset")
-                        },
-                        {
-                            value: "dusk",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.dusk")
-                        },
-                        {
-                            value: "nauticalDusk",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nauticalDusk")
-                        },
-                        {
-                            value: "night",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.night")
-                        },
-                        {
-                            value: "nadir",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.sun.nadir")
-                        }
-                    ];
-
-                    const moonTimes =
-                    [
-                        {
-                            value: "rise",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.moon.rise")
-                        },
-                        {
-                            value: "set",
-                            label: node._("node-red-contrib-chronos/chronos-config:common.list.moon.set")
-                        }
-                    ];
-
-                    const numericValidator = function(event, ui)
-                    {
-                        var value = parseInt($(this).spinner("value"), 10);
-                        var min = $(this).spinner("option", "min");
-                        var max = $(this).spinner("option", "max");
-                        if (isNaN(value) ||
-                            (value < min))
-                        {
-                            $(this).spinner("value", min);
-                        }
-                        else if (value > max)
-                        {
-                            $(this).spinner("value", max);
-                        }
-                    };
-
-                    const nowInput =
-                    {
-                        value: "now",
-                        label: node._("change.label.now"),
-                        icon: "fa fa-clock-o",
-                        hasValue: false
-                    };
-
-                    const dateInput =
-                    {
-                        value: "date",
-                        label: node._("change.label.date"),
-                        icon: "fa fa-calendar",
-                        hasValue: true,
-                        validate: /^([2-9]\d\d\d)-([1-9]|0[1-9]|1[0-2])-([1-9]|0[1-9]|[12]\d|3[01])$/
-                    };
-
                     const timeInput =
                     {
                         value: "time",
@@ -210,77 +262,75 @@ SOFTWARE.
                         validate: /^(\d|0\d|1\d|2[0-3]):([0-5]\d)(:([0-5]\d))?\s*(a|am|A|AM|p|pm|P|PM)?$/
                     };
 
-                    const sunTimeInput =
-                    {
-                        value: "sun",
-                        label: node._("node-red-contrib-chronos/chronos-config:common.label.sun"),
-                        icon: "fa fa-sun-o",
-                        options: sunTimes
-                    };
-
-                    const moonTimeInput =
-                    {
-                        value: "moon",
-                        label: node._("node-red-contrib-chronos/chronos-config:common.label.moon"),
-                        icon: "fa fa-moon-o",
-                        options: moonTimes
-                    };
-
-                    const customInput =
-                    {
-                        value: "custom",
-                        label: node._("node-red-contrib-chronos/chronos-config:common.label.custom"),
-                        icon: "fa fa-user-o",
-                        hasValue: true,
-                        validate: /^[a-zA-Z][0-9a-zA-Z_]*$/
-                    };
-
-                    const partInput =
-                    {
-                        min: -270000,
-                        max: 270000,
-                        step: 1,
-                        change: numericValidator
-                    };
-
-                    const addsubInput =
-                    {
-                        min: 1,
-                        max: 1000000,
-                        step: 1,
-                        change: numericValidator
-                    };
-
                     const fragment = document.createDocumentFragment();
                     const actionBox = $("<div/>").appendTo(fragment);
                     const setBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
                     const changeBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
+                    const convertBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
 
                     const action = $("<select/>", {class: "node-input-action", style: "width: 120px;"})
                                         .append($("<option></option>").val("set").text(node._("change.list.action.set")))
                                         .append($("<option></option>").val("change").text(node._("change.list.action.change")))
+                                        .append($("<option></option>").val("convert").text(node._("change.list.action.convert")))
                                         .appendTo(actionBox);
 
                     $("<label/>", {style: "margin-bottom: 0px; width: 120px; text-align: right;"})
-                                        .text(node._("change.label.to"))
+                                        .text(node._("change.label.setTo"))
                                         .appendTo(setBox);
                     const setToBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(setBox);
-                    const setRow1 = $("<div/>").appendTo(setToBox);
-                    const setRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(setToBox);
+                    const setToRow1 = $("<div/>").appendTo(setToBox);
+                    const setToRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(setToBox);
 
                     const property = $("<input/>", {type: "text", class: "node-input-property", style: "margin-left: 8px;"})
                                         .appendTo(actionBox)
                                         .typedInput({types: ["global", "flow", "msg"]});
-                    property.typedInput("width", "280px");
+                    property.typedInput("width", "314px");
 
                     const date = $("<input/>", {type: "text", class: "node-input-date"})
-                                        .appendTo(setRow1)
+                                        .appendTo(setToRow1)
                                         .typedInput({types: [nowInput, dateInput, "jsonata"]});
-                    date.typedInput("width", "280px");
+                    date.typedInput("width", "314px");
+                    date._prevType = "now";
+                    date.on("change", function()
+                    {
+                        const type = date.typedInput("type");
+
+                        if ((type === "now") || (type === "jsonata"))
+                        {
+                            setToRow2.hide();
+                        }
+                        else
+                        {
+                            setToRow2.show();
+                        }
+
+                        if (type != date._prevType)
+                        {
+                            date._prevType = type;
+                            if (type != "now")
+                            {
+                                date.typedInput("value", "");
+                            }
+                        }
+                    });
+
                     const time = $("<input/>", {type: "text", class: "node-input-time"})
-                                        .appendTo(setRow2)
+                                        .appendTo(setToRow2)
                                         .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput]});
-                    time.typedInput("width", "280px");
+                    time.typedInput("width", "314px");
+                    time._prevType = "time";
+                    time.on("change", function()
+                    {
+                        const type = time.typedInput("type");
+                        if (type != time._prevType)
+                        {
+                            time._prevType = type;
+                            if ((type != "sun") && (type != "moon"))
+                            {
+                                time.typedInput("value", "");
+                            }
+                        }
+                    });
 
                     const changeType = $("<select/>", {class: "node-input-changeType", style: "width: 120px;"})
                                         .append($("<option></option>").val("set").text(node._("change.list.changeType.set")))
@@ -288,17 +338,13 @@ SOFTWARE.
                                         .append($("<option></option>").val("subtract").text(node._("change.list.changeType.subtract")))
                                         .append($("<option></option>").val("startOf").text(node._("change.list.changeType.startOf")))
                                         .append($("<option></option>").val("endOf").text(node._("change.list.changeType.endOf")))
-                                        .append($("<option></option>").val("toString").text(node._("change.list.changeType.toString")))
                                         .appendTo(changeBox);
 
                     const setPartBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const addsubBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
                     const startEndOfBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
-                    const convertBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
-                    const convertRow1 = $("<div/>").appendTo(convertBox);
-                    const convertRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(convertBox);
 
-                    const setPartType = $("<select/>", {class: "node-input-setPartType", style: "width: auto;"})
+                    const setPartType = $("<select/>", {class: "node-input-setPartType", style: "width: 118px;"})
                                         .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .append($("<option></option>").val("quarter").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.quarter")))
                                         .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
@@ -311,16 +357,18 @@ SOFTWARE.
                                         .append($("<option></option>").val("millisecond").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.millisecond")))
                                         .appendTo(setPartBox);
                     $("<label/>", {style: "margin-bottom: 0px; width: auto; text-align: right; margin-left: 4px; margin-right: 4px;"})
-                                        .text(node._("change.label.to"))
+                                        .text("=")
                                         .appendTo(setPartBox);
-                    const setPartValue = $("<input/>", {class: "node-input-setPartValue", style: "width: 100px !important;"})
+                    const setPartValue = $("<input/>", {type: "text", class: "node-input-setPartValue"})
                                         .appendTo(setPartBox)
-                                        .spinner(partInput);
+                                        .typedInput({types: [partInput, "env", "global", "flow", "msg"]});
+                    setPartValue.typedInput("width", "180px");
 
-                    const addsub = $("<input/>", {class: "node-input-addsub", style: "width: 100px !important;"})
+                    const addsub = $("<input/>", {type: "text", class: "node-input-addsub"})
                                         .appendTo(addsubBox)
-                                        .spinner(addsubInput);
-                    const addsubUnit = $("<select/>", {class: "node-input-addsubUnit", style: "width: auto; margin-left: 4px"})
+                                        .typedInput({types: [addsubInput, "env", "global", "flow", "msg"]});
+                    addsub.typedInput("width", "180px");
+                    const addsubUnit = $("<select/>", {class: "node-input-addsubUnit", style: "width: 130px; margin-left: 4px"})
                                         .append($("<option></option>").val("years").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.years")))
                                         .append($("<option></option>").val("quarters").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.quarters")))
                                         .append($("<option></option>").val("months").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.months")))
@@ -332,7 +380,7 @@ SOFTWARE.
                                         .append($("<option></option>").val("milliseconds").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.milliseconds")))
                                         .appendTo(addsubBox);
 
-                    const startEndOfArg = $("<select/>", {class: "node-input-startEndOfArg", style: "width: auto;"})
+                    const startEndOfArg = $("<select/>", {class: "node-input-startEndOfArg", style: "width: 314px;"})
                                         .append($("<option></option>").val("year").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.year")))
                                         .append($("<option></option>").val("quarter").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.quarter")))
                                         .append($("<option></option>").val("month").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.month")))
@@ -343,13 +391,20 @@ SOFTWARE.
                                         .append($("<option></option>").val("second").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.second")))
                                         .appendTo(startEndOfBox);
 
+                    $("<label/>", {style: "margin-bottom: 0px; width: 120px; text-align: right;"})
+                                        .text(node._("change.label.convertTo"))
+                                        .appendTo(convertBox);
+                    const convertToBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(convertBox);
+                    const convertToRow1 = $("<div/>").appendTo(convertToBox);
+                    const convertToRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(convertToBox);
+
                     const stringFormat =
                             $("<input/>", {
                                 type: "text",
                                 class: "node-input-stringFormat",
                                 title: node._("change.label.format"),
-                                placeholder: node._("change.label.formatPlaceholder")})
-                                    .appendTo(convertRow1)
+                                placeholder: node._("change.label.customFormat")})
+                                    .appendTo(convertToRow1)
                                     .typedInput({
                                         types: [
                                             {
@@ -380,11 +435,11 @@ SOFTWARE.
                                                     },
                                                     {
                                                         value: "iso8601",
-                                                        label: node._("change.list.convert.iso8601Format")
+                                                        label: node._("change.list.convert.iso8601")
                                                     },
                                                     {
                                                         value: "iso8601utc",
-                                                        label: node._("change.list.convert.iso8601UTCFormat")
+                                                        label: node._("change.list.convert.iso8601UTC")
                                                     }
                                                 ]
                                             },
@@ -395,14 +450,27 @@ SOFTWARE.
                                                 hasValue: true,
                                                 validate: /^.+$/
                                             }]});
-                    stringFormat.typedInput("width", "280px");
+                    stringFormat.typedInput("width", "314px");
+                    stringFormat._prevType = "predefined";
+                    stringFormat.on("change", function()
+                    {
+                        const type = stringFormat.typedInput("type");
+                        if (type != stringFormat._prevType)
+                        {
+                            stringFormat._prevType = type;
+                            if (type == "custom")
+                            {
+                                stringFormat.typedInput("value", "");
+                            }
+                        }
+                    });
 
                     const timeZone =
                             $("<input/>", {
                                 type: "text",
                                 class: "node-input-timeZone",
                                 title: node._("change.label.format")})
-                                    .appendTo(convertRow2)
+                                    .appendTo(convertToRow2)
                                     .typedInput({
                                         types: [
                                             {
@@ -424,12 +492,26 @@ SOFTWARE.
                                                 hasValue: true,
                                                 validate: /^(?:Z|[+-]\d\d:\d\d|-?\d+)$/
                                             }]});
-                    timeZone.typedInput("width", "280px");
+                    timeZone.typedInput("width", "314px");
+                    timeZone._prevType = "current";
+                    timeZone.on("change", function()
+                    {
+                        const type = timeZone.typedInput("type");
+                        if (type != timeZone._prevType)
+                        {
+                            timeZone._prevType = type;
+                            if (type != "current")
+                            {
+                                timeZone.typedInput("value", "");
+                            }
+                        }
+                    });
 
                     action.change(function()
                     {
                         setBox.hide();
                         changeBox.hide();
+                        convertBox.hide();
 
                         const value = $(this).val();
                         switch (value)
@@ -444,6 +526,11 @@ SOFTWARE.
                                 changeBox.show();
                                 break;
                             }
+                            case "convert":
+                            {
+                                convertBox.show();
+                                break;
+                            }
                         }
                     });
 
@@ -452,7 +539,6 @@ SOFTWARE.
                         setPartBox.hide();
                         addsubBox.hide();
                         startEndOfBox.hide();
-                        convertBox.hide();
 
                         const value = $(this).val();
                         switch (value)
@@ -474,11 +560,6 @@ SOFTWARE.
                                 startEndOfBox.show();
                                 break;
                             }
-                            case "toString":
-                            {
-                                convertBox.show();
-                                break;
-                            }
                         }
                     });
 
@@ -489,80 +570,67 @@ SOFTWARE.
                         {
                             case "year":
                             {
-                                setPartValue.spinner("option", "min", -270000);
-                                setPartValue.spinner("option", "max", 270000);
+                                partInput.min = -270000;
+                                partInput.max = 270000;
                                 break;
                             }
                             case "quarter":
                             {
-                                setPartValue.spinner("option", "min", 1);
-                                setPartValue.spinner("option", "max", 4);
+                                partInput.min = 1;
+                                partInput.max = 4;
                                 break;
                             }
                             case "month":
                             {
-                                setPartValue.spinner("option", "min", 1);
-                                setPartValue.spinner("option", "max", 12);
+                                partInput.min = 1;
+                                partInput.max = 12;
                                 break;
                             }
                             case "week":
                             {
-                                setPartValue.spinner("option", "min", 1);
-                                setPartValue.spinner("option", "max", 52);
+                                partInput.min = 1;
+                                partInput.max = 52;
                                 break;
                             }
                             case "weekday":
                             {
-                                setPartValue.spinner("option", "min", 1);
-                                setPartValue.spinner("option", "max", 7);
+                                partInput.min = 1;
+                                partInput.max = 7;
                                 break;
                             }
                             case "day":
                             {
-                                setPartValue.spinner("option", "min", 1);
-                                setPartValue.spinner("option", "max", 31);
+                                partInput.min = 1;
+                                partInput.max = 31;
                                 break;
                             }
                             case "hour":
                             {
-                                setPartValue.spinner("option", "min", 0);
-                                setPartValue.spinner("option", "max", 23);
+                                partInput.min = 0;
+                                partInput.max = 23;
                                 break;
                             }
                             case "minute":
                             {
-                                setPartValue.spinner("option", "min", 0);
-                                setPartValue.spinner("option", "max", 59);
+                                partInput.min = 0;
+                                partInput.max = 59;
                                 break;
                             }
                             case "second":
                             {
-                                setPartValue.spinner("option", "min", 0);
-                                setPartValue.spinner("option", "max", 59);
+                                partInput.min = 0;
+                                partInput.max = 59;
                                 break;
                             }
                             case "millisecond":
                             {
-                                setPartValue.spinner("option", "min", 0);
-                                setPartValue.spinner("option", "max", 999);
+                                partInput.min = 0;
+                                partInput.max = 999;
                                 break;
                             }
                         }
 
-                        numericValidator.call(setPartValue);
-                    });
-
-                    date.on("change", function()
-                    {
-                        const type = date.typedInput("type");
-                        if ((type === "now") || (type === "jsonata"))
-                        {
-                            setRow2.hide();
-                        }
-                        else
-                        {
-                            setRow2.show();
-                        }
+                        setPartValue.typedInput("validate");
                     });
 
                     const now = new Date();
@@ -571,59 +639,21 @@ SOFTWARE.
                         data = {action: "set", target: {type: "msg", name: "payload"}, type: "now"};
                     }
 
-                    setRow2.hide();
-
-                    // initialize to default
-                    changeType.val("add");
-                    addsubUnit.val("years");
-                    startEndOfArg.val("year");
-                    setPartType.val("year");
-                    setPartValue.spinner("value", now.getFullYear().toString());
-                    addsub.spinner("value", 1);
-
-                    action.val(data.action);
-                    property.typedInput("value", data.target.name);
-                    property.typedInput("type", data.target.type);
-
-                    if (data.action == "set")
+                    // backward compatibility to 1.24.0 and below
+                    if (data.action == "change")
                     {
-                        date.typedInput("type", data.type);
-                        if (data.type == "date")
+                        if (data.type == "toString")
                         {
-                            date.typedInput("value", data.date);
-                            time.typedInput("type", data.time.type);
-                            time.typedInput("value", data.time.value);
-                        }
-                        else if (data.type == "jsonata")
-                        {
-                            date.typedInput("value", data.expression);
-                        }
-                    }
-                    else if (data.action == "change")
-                    {
-                        if (data.type == "set")
-                        {
-                            setPartType.val(data.part);
-                            setPartValue.spinner("value", data.value);
-                        }
-                        else if ((data.type == "add") || (data.type == "subtract"))
-                        {
-                            addsub.spinner("value", data.value);
-                            addsubUnit.val(data.unit);
-                        }
-                        else if ((data.type == "startOf") || (data.type == "endOf"))
-                        {
-                            startEndOfArg.val(data.arg);
-                        }
-                        else if (data.type == "toString")
-                        {
+                            data.action = "convert";
+                            delete data.type;
+
                             // backward compatibility to v1.19.1 and below
                             if (!data.formatType)
                             {
                                 data.formatType = "custom";
                             }
 
-                            // backward compatibility to v1.21 and below
+                            // backward compatibility to v1.21.0 and below
                             if (data.formatType == "relative")
                             {
                                 data.formatType = "predefined";
@@ -650,14 +680,70 @@ SOFTWARE.
                                 data.tzType = "current";
                                 data.tzValue = "";
                             }
+                        }
+                        else if ((data.type == "set") || (data.type == "add") || (data.type == "subtract"))
+                        {
+                            if (typeof data.valueType == "undefined")
+                            {
+                                data.valueType = "num";
+                            }
+                        }
+                    }
 
-                            stringFormat.typedInput("type", data.formatType);
-                            stringFormat.typedInput("value", data.format);
+                    setToRow2.hide();
 
-                            timeZone.typedInput("type", data.tzType);
-                            timeZone.typedInput("value", data.tzValue);
+                    // initialize to default
+                    changeType.val("add");
+                    addsubUnit.val("years");
+                    startEndOfArg.val("year");
+                    setPartType.val("year");
+                    setPartValue.typedInput("value", now.getFullYear().toString());
+                    addsub.typedInput("value", 1);
+
+                    action.val(data.action);
+                    property.typedInput("value", data.target.name);
+                    property.typedInput("type", data.target.type);
+
+                    if (data.action == "set")
+                    {
+                        date.typedInput("type", data.type);
+                        if (data.type == "date")
+                        {
+                            date.typedInput("value", data.date);
+                            time.typedInput("type", data.time.type);
+                            time.typedInput("value", data.time.value);
+                        }
+                        else if (data.type == "jsonata")
+                        {
+                            date.typedInput("value", data.expression);
+                        }
+                    }
+                    else if (data.action == "change")
+                    {
+                        if (data.type == "set")
+                        {
+                            setPartType.val(data.part);
+                            setPartValue.typedInput("type", data.valueType);
+                            setPartValue.typedInput("value", data.value);
+                        }
+                        else if ((data.type == "add") || (data.type == "subtract"))
+                        {
+                            addsub.typedInput("type", data.valueType);
+                            addsub.typedInput("value", data.value);
+                            addsubUnit.val(data.unit);
+                        }
+                        else if ((data.type == "startOf") || (data.type == "endOf"))
+                        {
+                            startEndOfArg.val(data.arg);
                         }
                         changeType.val(data.type);
+                    }
+                    else if (data.action == "convert")
+                    {
+                        stringFormat.typedInput("type", data.formatType);
+                        stringFormat.typedInput("value", data.format);
+                        timeZone.typedInput("type", data.tzType);
+                        timeZone.typedInput("value", data.tzValue);
                     }
 
                     action.change();
@@ -668,92 +754,559 @@ SOFTWARE.
                 }
             });
 
-            node.rules.forEach(data =>
+            const durationRules = $("#node-input-durationRules").css("min-width", "510px").css("min-height", "150px").editableList(
             {
-                taskList.editableList("addItem", data);
+                removable: true,
+                sortable: true,
+                addItem: function(item, index, data)
+                {
+                    const timeInput =
+                    {
+                        value: "time",
+                        label: node._("node-red-contrib-chronos/chronos-config:common.label.time"),
+                        icon: "fa fa-clock-o",
+                        hasValue: true,
+                        validate: function(v) { return v; }
+                    };
+
+                    const fragment = document.createDocumentFragment();
+                    const actionBox = $("<div/>").appendTo(fragment);
+                    const setBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
+                    const changeBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
+                    const convertBox = $("<div/>", {style: "margin-top: 5px;"}).appendTo(fragment);
+
+                    const action = $("<select/>", {class: "node-input-action", style: "width: 120px;"})
+                                        .append($("<option></option>").val("set").text(node._("change.list.action.set")))
+                                        .append($("<option></option>").val("change").text(node._("change.list.action.change")))
+                                        .append($("<option></option>").val("convert").text(node._("change.list.action.convert")))
+                                        .appendTo(actionBox);
+
+                    $("<label/>", {style: "margin-bottom: 0px; width: 120px; text-align: right;"})
+                                        .text(node._("change.label.setTo"))
+                                        .appendTo(setBox);
+                    const setToBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(setBox);
+                    const setToRow1 = $("<div/>").appendTo(setToBox);
+                    const setToRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(setToBox);
+
+                    const property = $("<input/>", {type: "text", class: "node-input-property", style: "margin-left: 8px;"})
+                                        .appendTo(actionBox)
+                                        .typedInput({types: ["global", "flow", "msg"]});
+                    property.typedInput("width", "314px");
+
+                    const time1 = $("<input/>", {type: "text", class: "node-input-time1"})
+                                        .appendTo(setToRow1)
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg", nowInput]});
+                    time1.typedInput("width", "314px");
+                    time1._prevType = "time";
+                    time1.on("change", function()
+                    {
+                        const type = time1.typedInput("type");
+                        if (type != time1._prevType)
+                        {
+                            time1._prevType = type;
+                            if ((type != "sun") && (type != "moon"))
+                            {
+                                time1.typedInput("value", "");
+                            }
+                        }
+                    });
+
+                    const time2 = $("<input/>", {type: "text", class: "node-input-time2"})
+                                        .appendTo(setToRow2)
+                                        .typedInput({types: [timeInput, sunTimeInput, moonTimeInput, customInput, "env", "global", "flow", "msg", nowInput]});
+                    time2.typedInput("width", "314px");
+                    time2._prevType = "time";
+                    time2.on("change", function()
+                    {
+                        const type = time2.typedInput("type");
+                        if (type != time2._prevType)
+                        {
+                            time2._prevType = type;
+                            if ((type != "sun") && (type != "moon"))
+                            {
+                                time2.typedInput("value", "");
+                            }
+                        }
+                    });
+
+                    const changeType = $("<select/>", {class: "node-input-changeType", style: "width: 120px;"})
+                                        .append($("<option></option>").val("add").text(node._("change.list.changeType.add")))
+                                        .append($("<option></option>").val("subtract").text(node._("change.list.changeType.subtract")))
+                                        .appendTo(changeBox);
+
+                    const addsubBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(changeBox);
+
+                    const addsub = $("<input/>", {type: "text", class: "node-input-addsub"})
+                                        .appendTo(addsubBox)
+                                        .typedInput({types: [addsubInput, "env", "global", "flow", "msg"]});
+                    addsub.typedInput("width", "180px");
+                    const addsubUnit = $("<select/>", {class: "node-input-addsubUnit", style: "width: 130px; margin-left: 4px"})
+                                        .append($("<option></option>").val("years").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.years")))
+                                        .append($("<option></option>").val("months").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.months")))
+                                        .append($("<option></option>").val("weeks").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.weeks")))
+                                        .append($("<option></option>").val("days").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.days")))
+                                        .append($("<option></option>").val("hours").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.hours")))
+                                        .append($("<option></option>").val("minutes").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.minutes")))
+                                        .append($("<option></option>").val("seconds").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.seconds")))
+                                        .append($("<option></option>").val("milliseconds").text(node._("node-red-contrib-chronos/chronos-config:common.list.unit.milliseconds")))
+                                        .appendTo(addsubBox);
+
+                    $("<label/>", {style: "margin-bottom: 0px; width: 120px; text-align: right;"})
+                                        .text(node._("change.label.convertTo"))
+                                        .appendTo(convertBox);
+                    const convertToBox = $("<div/>", {style: "display: inline-block; vertical-align: middle; width: auto; margin-left: 8px;"}).appendTo(convertBox);
+                    const convertToRow1 = $("<div/>").appendTo(convertToBox);
+                    const convertToRow2 = $("<div/>", {style: "margin-top: 5px;"}).appendTo(convertToBox);
+
+                    const stringFormat =
+                            $("<input/>", {
+                                type: "text",
+                                class: "node-input-stringFormat",
+                                title: node._("change.label.format"),
+                                placeholder: node._("change.label.customFormat")})
+                                    .appendTo(convertToRow1)
+                                    .typedInput({
+                                        types: [
+                                            {
+                                                value: "number",
+                                                label: node._("change.label.numericFormat"),
+                                                icon: "red/images/typedInput/09.svg",
+                                                options:
+                                                [
+                                                {
+                                                        value: "milliseconds",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.milliseconds")
+                                                    },
+                                                    {
+                                                        value: "seconds",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.seconds")
+                                                    },
+                                                    {
+                                                        value: "minutes",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.minutes")
+                                                    },
+                                                    {
+                                                        value: "hours",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.hours")
+                                                    },
+                                                    {
+                                                        value: "days",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.days")
+                                                    },
+                                                    {
+                                                        value: "weeks",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.weeks")
+                                                    },
+                                                    {
+                                                        value: "months",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.months")
+                                                    },
+                                                    {
+                                                        value: "years",
+                                                        label: node._("node-red-contrib-chronos/chronos-config:common.list.unit.years")
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                value: "string",
+                                                label: node._("change.label.stringFormat"),
+                                                icon: "red/images/typedInput/az.svg",
+                                                options:
+                                                [
+                                                    {
+                                                        value: "timespan",
+                                                        label: node._("change.list.convert.timespan")
+                                                    },
+                                                    {
+                                                        value: "timespan10th",
+                                                        label: node._("change.list.convert.timespan10th")
+                                                    },
+                                                    {
+                                                        value: "timespan100th",
+                                                        label: node._("change.list.convert.timespan100th")
+                                                    },
+                                                    {
+                                                        value: "timespanMillis",
+                                                        label: node._("change.list.convert.timespanMillis")
+                                                    },
+                                                    {
+                                                        value: "textualTimespan",
+                                                        label: node._("change.list.convert.textualTimespan")
+                                                    },
+                                                    {
+                                                        value: "iso8601",
+                                                        label: node._("change.list.convert.iso8601")
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                value: "custom",
+                                                label: node._("change.label.customFormat"),
+                                                icon: "fa fa-user-o",
+                                                hasValue: true,
+                                                validate: /^.+$/
+                                            }]});
+                    stringFormat.typedInput("width", "314px");
+                    stringFormat._prevType = "string";
+                    stringFormat.on("change", function()
+                    {
+                        const type = stringFormat.typedInput("type");
+
+                        if (type == "number")
+                        {
+                            convertToRow2.show();
+                        }
+                        else
+                        {
+                            convertToRow2.hide();
+                        }
+
+                        if (type != stringFormat._prevType)
+                        {
+                            stringFormat._prevType = type;
+                            if (type == "custom")
+                            {
+                                stringFormat.typedInput("value", "");
+                            }
+                        }
+                    });
+
+                    const precision =
+                            $("<input/>", {
+                                type: "text",
+                                class: "node-input-precision",
+                                title: node._("change.label.format")})
+                                    .appendTo(convertToRow2)
+                                    .typedInput({
+                                        types: [
+                                            {
+                                                value: "int",
+                                                label: node._("change.label.integer"),
+                                                icon: "fa fa-align-justify",
+                                                options:
+                                                [
+                                                    {
+                                                        value: "round",
+                                                        label: node._("change.list.int.round")
+                                                    },
+                                                    {
+                                                        value: "floor",
+                                                        label: node._("change.list.int.floor")
+                                                    },
+                                                    {
+                                                        value: "ceil",
+                                                        label: node._("change.list.int.ceil")
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                value: "float",
+                                                label: node._("change.label.float"),
+                                                icon: "fa fa-list",
+                                                hasValue: true,
+                                                validate: RED.validators.number
+                                            }]});
+                    precision.typedInput("width", "314px");
+                    precision._prevType = "int";
+                    precision.on("change", function()
+                    {
+                        const type = precision.typedInput("type");
+                        if (type != precision._prevType)
+                        {
+                            precision._prevType = type;
+                            if (type == "float")
+                            {
+                                precision.typedInput("value", "0");
+                            }
+                        }
+                    });
+
+                    action.change(function()
+                    {
+                        setBox.hide();
+                        changeBox.hide();
+                        convertBox.hide();
+
+                        const value = $(this).val();
+                        switch (value)
+                        {
+                            case "set":
+                            {
+                                setBox.show();
+                                break;
+                            }
+                            case "change":
+                            {
+                                changeBox.show();
+                                break;
+                            }
+                            case "convert":
+                            {
+                                convertBox.show();
+                                break;
+                            }
+                        }
+                    });
+
+                    const now = new Date();
+                    if (!("action" in data))
+                    {
+                        data = {action: "set", target: {type: "msg", name: "payload"}, time1: {type: "time", value: ""}, time2: {type: "time", value: ""}};
+                    }
+
+                    // initialize to default
+                    changeType.val("add");
+                    addsubUnit.val("years");
+                    addsub.typedInput("value", 1);
+
+                    action.val(data.action);
+                    property.typedInput("value", data.target.name);
+                    property.typedInput("type", data.target.type);
+
+                    if (data.action == "set")
+                    {
+                        time1.typedInput("type", data.time1.type);
+                        time1.typedInput("value", data.time1.value);
+                        time2.typedInput("type", data.time2.type);
+                        time2.typedInput("value", data.time2.value);
+                    }
+                    else if (data.action == "change")
+                    {
+                        if ((data.type == "add") || (data.type == "subtract"))
+                        {
+                            addsub.typedInput("type", data.valueType);
+                            addsub.typedInput("value", data.value);
+                            addsubUnit.val(data.unit);
+                        }
+                        changeType.val(data.type);
+                    }
+                    else if (data.action == "convert")
+                    {
+                        stringFormat.typedInput("type", data.formatType);
+                        stringFormat.typedInput("value", data.format);
+
+                        if (data.formatType == "number")
+                        {
+                            precision.typedInput("type", data.precisionType);
+                            precision.typedInput("value", data.precision);
+                        }
+                    }
+
+                    action.change();
+                    changeType.change();
+
+                    item[0].appendChild(fragment);
+                }
             });
+
+            const mode = $("#node-input-mode");
+
+            // backward compatibility to 1.24.0 and below
+            if (typeof node.mode == "undefined")
+            {
+                node.mode = "moment";
+                mode.val("moment");
+            }
+
+            mode.change(function()
+            {
+                $("#node-input-momentRules-row").hide();
+                $("#node-input-durationRules-row").hide();
+
+                const value = $(this).val();
+                switch (value)
+                {
+                    case "moment":
+                    {
+                        $("#node-input-momentRules-row").show();
+                        break;
+                    }
+                    case "duration":
+                    {
+                        $("#node-input-durationRules-row").show();
+                        break;
+                    }
+                }
+
+                RED.tray.resize();
+            });
+
+            mode.change();
+
+            let rules = undefined;
+            if (node.mode == "moment")
+            {
+                rules = timeRules;
+                durationRules.editableList("addItem", {});
+            }
+            else
+            {
+                rules = durationRules;
+                timeRules.editableList("addItem", {});
+            }
+
+            for (data of node.rules)
+            {
+                rules.editableList("addItem", data);
+            }
         },
         oneditsave: function()
         {
             const node = this;
-
-            const taskList = $("#node-input-taskList").editableList("items");
             node.rules = [];
 
-            taskList.each(function(index)
+            if ($("#node-input-mode").val() == "time")
             {
-                const data = {};
+                const rules = $("#node-input-momentRules").editableList("items");
 
-                const property = $(this).find(".node-input-property");
-                const date = $(this).find(".node-input-date");
-                const time = $(this).find(".node-input-time");
-                const stringFormat = $(this).find(".node-input-stringFormat");
-                const timeZone = $(this).find(".node-input-timeZone");
-
-                data.action = $(this).find(".node-input-action").val();
-                data.target = {};
-                data.target.type = property.typedInput("type");
-                data.target.name = property.typedInput("value");
-
-                if (data.action == "set")
+                rules.each(function(index)
                 {
-                    data.type = date.typedInput("type");
-                    if (data.type == "date")
+                    const data = {};
+
+                    data.action = $(this).find(".node-input-action").val();
+                    data.target = {};
+
+                    const property = $(this).find(".node-input-property");
+                    data.target.type = property.typedInput("type");
+                    data.target.name = property.typedInput("value");
+
+                    if (data.action == "set")
                     {
-                        data.date = date.typedInput("value");
-                        data.time = {};
-                        data.time.type = time.typedInput("type");
-                        data.time.value = time.typedInput("value");
+                        const date = $(this).find(".node-input-date");
+                        const time = $(this).find(".node-input-time");
+
+                        data.type = date.typedInput("type");
+                        if (data.type == "date")
+                        {
+                            data.date = date.typedInput("value");
+                            data.time = {};
+                            data.time.type = time.typedInput("type");
+                            data.time.value = time.typedInput("value");
+                        }
+                        else if (data.type == "jsonata")
+                        {
+                            data.expression = date.typedInput("value");
+                        }
                     }
-                    else if (data.type == "jsonata")
+                    else if (data.action == "change")
                     {
-                        data.expression = date.typedInput("value");
+                        data.type = $(this).find(".node-input-changeType").val();
+                        if (data.type == "set")
+                        {
+                            const setPartValue = $(this).find(".node-input-setPartValue");
+                            data.part = $(this).find(".node-input-setPartType").val();
+                            data.valueType = setPartValue.typedInput("type");
+                            data.value = setPartValue.typedInput("value");
+                        }
+                        else if ((data.type == "add") || (data.type == "subtract"))
+                        {
+                            const addsub = $(this).find(".node-input-addsub");
+                            data.valueType = addsub.typedInput("type");
+                            data.value = addsub.typedInput("value");
+                            data.unit = $(this).find(".node-input-addsubUnit").val();
+                        }
+                        else if ((data.type == "startOf") || (data.type == "endOf"))
+                        {
+                            data.arg = $(this).find(".node-input-startEndOfArg").val();
+                        }
                     }
-                }
-                else if (data.action == "change")
-                {
-                    data.type = $(this).find(".node-input-changeType").val();
-                    if (data.type == "set")
+                    else if (data.action == "convert")
                     {
-                        data.part = $(this).find(".node-input-setPartType").val();
-                        data.value = $(this).find(".node-input-setPartValue").spinner("value");
-                    }
-                    else if ((data.type == "add") || (data.type == "subtract"))
-                    {
-                        data.value = $(this).find(".node-input-addsub").spinner("value");
-                        data.unit = $(this).find(".node-input-addsubUnit").val();
-                    }
-                    else if ((data.type == "startOf") || (data.type == "endOf"))
-                    {
-                        data.arg = $(this).find(".node-input-startEndOfArg").val();
-                    }
-                    else if (data.type == "toString")
-                    {
+                        const stringFormat = $(this).find(".node-input-stringFormat");
+                        const timeZone = $(this).find(".node-input-timeZone");
+
                         data.formatType = stringFormat.typedInput("type");
                         data.format = stringFormat.typedInput("value");
                         data.tzType = timeZone.typedInput("type");
                         data.tzValue = timeZone.typedInput("value");
                     }
-                }
 
-                node.rules.push(data);
-            });
+                    node.rules.push(data);
+                });
+            }
+            else
+            {
+                const rules = $("#node-input-durationRules").editableList("items");
+
+                rules.each(function(index)
+                {
+                    const data = {};
+
+                    data.action = $(this).find(".node-input-action").val();
+                    data.target = {};
+
+                    const property = $(this).find(".node-input-property");
+                    data.target.type = property.typedInput("type");
+                    data.target.name = property.typedInput("value");
+
+                    if (data.action == "set")
+                    {
+                        const time1 = $(this).find(".node-input-time1");
+                        const time2 = $(this).find(".node-input-time2");
+
+                        data.time1 = {};
+                        data.time1.type = time1.typedInput("type");
+                        data.time1.value = time1.typedInput("value");
+
+                        data.time2 = {};
+                        data.time2.type = time2.typedInput("type");
+                        data.time2.value = time2.typedInput("value");
+                    }
+                    else if (data.action == "change")
+                    {
+                        data.type = $(this).find(".node-input-changeType").val();
+                        if ((data.type == "add") || (data.type == "subtract"))
+                        {
+                            const addsub = $(this).find(".node-input-addsub");
+                            data.valueType = addsub.typedInput("type");
+                            data.value = addsub.typedInput("value");
+                            data.unit = $(this).find(".node-input-addsubUnit").val();
+                        }
+                    }
+                    else if (data.action == "convert")
+                    {
+                        const stringFormat = $(this).find(".node-input-stringFormat");
+                        const precision = $(this).find(".node-input-precision");
+
+                        data.formatType = stringFormat.typedInput("type");
+                        data.format = stringFormat.typedInput("value");
+                        if (data.formatType == "number")
+                        {
+                            data.precisionType = precision.typedInput("type");
+                            data.precision = precision.typedInput("value");
+                        }
+                    }
+
+                    node.rules.push(data);
+                });
+            }
         },
         oneditresize: function(size)
         {
-            const conditionListRow = $("#dialog-form>div.node-input-taskList-row");
-            const otherRows = $("#dialog-form>div:not(.node-input-taskList-row)");
+            const conditionListRow = $("#dialog-form>div.node-input-list-row");
+            const otherRows = $("#dialog-form>div:not(.node-input-list-row)");
             let height = size.height;
 
             for (let i=0; i<otherRows.length; ++i)
             {
-                height -= $(otherRows[i]).outerHeight(true);
+                const row = $(otherRows[i]);
+
+                if (row.is(":visible"))
+                {
+                    height -= row.outerHeight(true);
+                }
             }
 
             height -= (parseInt(conditionListRow.css("marginTop")) + parseInt(conditionListRow.css("marginBottom")));
-            height -= $("#dialog-form>div.node-input-taskList-row>label").outerHeight(true);
 
-            $("#node-input-taskList").editableList("height", height);
+            if ($("#node-input-mode").val() == "time")
+            {
+                $("#node-input-momentRules").editableList("height", height);
+            }
+            else
+            {
+                $("#node-input-durationRules").editableList("height", height);
+            }
         }
     });
 </script>

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -722,7 +722,7 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
         (cond.operator == "after"))
     {
         const precision = (cond.operands.precision == "millisecond") ? undefined : cond.operands.precision;
-        const targetTime = getTime(RED, node, msg, baseTime.clone(), cond.operands.type, cond.operands.value);
+        const targetTime = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands.type, cond.operands.value);
 
         if (cond.operands.offset != 0)
         {
@@ -768,8 +768,8 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
     {
         const precision1 = (cond.operands[0].precision == "millisecond") ? undefined : cond.operands[0].precision;
         const precision2 = (cond.operands[1].precision == "millisecond") ? undefined : cond.operands[1].precision;
-        const time1 = getTime(RED, node, msg, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
-        const time2 = getTime(RED, node, msg, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
+        const time1 = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
+        const time2 = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
 
         if (cond.operands[0].offset != 0)
         {
@@ -816,61 +816,6 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
     }
 
     return result;
-}
-
-function getTime(RED, node, msg, baseTime, type, value)
-{
-    let ret = undefined;
-
-    if ((type == "env") || (type == "global") || (type == "flow") || (type == "msg"))
-    {
-        let ctxValue = undefined;
-
-        if (type == "env")
-        {
-            ctxValue = RED.util.evaluateNodeProperty(value, type, node);
-            if (!ctxValue)
-            {
-                ctxValue = value;
-            }
-        }
-        else if ((type == "global") || (type == "flow"))
-        {
-            const ctx = RED.util.parseContextStore(value);
-            ctxValue = node.context()[type].get(ctx.key, ctx.store);
-        }
-        else
-        {
-            ctxValue = RED.util.getMessageProperty(msg, value);
-        }
-
-        if (!ctxValue || ((typeof ctxValue != "number") && (typeof ctxValue != "string")))
-        {
-            throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"),
-                        {type: type, value: ctxValue});
-        }
-
-        ret = node.chronos.getTime(
-                            RED,
-                            node,
-                            baseTime,
-                            "auto",
-                            ctxValue);
-
-        if (!ret.isValid())
-        {
-            throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"),
-                        {type: type, value: ctxValue});
-        }
-    }
-    else
-    {
-        ret = node.chronos.getTime(RED, node, baseTime, type, value);
-    }
-
-    return ret;
 }
 
 function evaluateDateCondition(baseTime, cond)

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -24,22 +24,14 @@ SOFTWARE.
 
 <script type="text/html" data-help-name="chronos-change">
     <p>
-        Setzt oder ändert Zeitwerte aus Nachrichteneigenschaften, Flow-Variablen
-        oder globalen Variablen.
+        Setzt oder ändert Zeitwerte aus Nachrichteneigenschaften, Flow-Variablen oder globalen Variablen.
     </p>
     <h3>Details</h3>
     <p>
-        Dieser knoten setzt Nachrichteneigenschaften, Flow-Variablen oder globale
-        Variablen auf spezifische Zeiten oder ändert bzw. konvertiert Zeitstempel
-        aus diesen Eingabefeldern. Mehrere Aktionen, die in der angegebenen
-        Reihenfolge ausgeführt werden, können pro Knoten konfiguriert werden.
-        Es ist auch möglich, verschiedene Aktionen zu verketten, die dann auf
-        die gleiche Eigenschaft oder Variable angewendet werden.
+        Dieser Knoten setzt Nachrichteneigenschaften, Flow-Variablen oder globale Variablen auf spezifische Zeitpunkte oder Zeitspannen oder ändert bzw. konvertiert Zeitstempel oder Zeitspannen aus diesen Eingabefeldern. Mehrere Aktionen, die in der angegebenen Reihenfolge ausgeführt werden, können pro Knoten konfiguriert werden. Es ist auch möglich, verschiedene Aktionen zu verketten, die dann auf die gleiche Eigenschaft oder Variable angewendet werden.
     </p>
     <p>
-        Für weitere Informationen bitte die ausführliche Dokumentation im
-        <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node">Repository-Wiki</a>
-        öffnen (nur in Englisch verfügbar).
+        Für weitere Informationen bitte die ausführliche Dokumentation im <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node">Repository-Wiki</a> öffnen (nur in Englisch verfügbar).
     </p>
     <h3>Konfiguration</h3>
     <dl>
@@ -49,179 +41,262 @@ SOFTWARE.
         <dd>
             Ein Verweis auf den zu verwendenden Konfigurationsknoten.
         </dd>
+        <dt>Modus</dt>
+        <dd>
+            Der Zeitmodus, welcher entweder <i>Zeitpunkt</i> für feste Zeitpunkte oder <i>Zeitspanne</i> für Zeitbereiche sein kann.
+        </dd>
         <dt>Änderungsregeln</dt>
         <dd>
             <p>
-                Liste der Regeln zum Setzen oder Ändern von Zielwerten. Neue
-                Einträge können über den Button unterhalb der Liste hinzugefügt
-                werden. Vorhandene Einträge können neu angeordnet oder gelöscht
-                werden. Die folgenden Aktionen können gewählt werden:
+                Liste der Regeln zum Setzen oder Ändern von Zielwerten. Neue Einträge können über den Button unterhalb der Liste hinzugefügt werden. Vorhandene Einträge können neu angeordnet oder gelöscht werden. Die folgenden Aktionen können gewählt werden:
                 <ul>
                     <li>
-                        <i>Festlegen</i>: Setzt das gewählte Ziel auf ein
-                        bestimmtes Datum und eine bestimmte Zeit.
+                        <i>Festlegen</i>: Setzt das gewählte Ziel auf ein bestimmtes Datum und eine bestimmte Zeit oder auf den Bereich zwischen zwei Zeitpunkten.
                     </li>
                     <li>
-                        <i>Ändern</i>: Ändert den Zeitstempel des gewählten Ziels
-                        anhand der gewählten Änderungs- bzw. Konvertierungsregeln.
-                        Der zu ändernde Zielwert kann eine Zahl mit den Millisekunden
-                        seit Beginn der UNIX-Zeitzählung oder eine Zeichenkette
-                        sein, die ein Datum und eine Zeit enthält, die nach den
-                        Regeln von <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js</a>
-                        geparst werden kann.
+                        <i>Ändern</i>: Ändert den Zeitstempel oder die Zeitspanne des gewählten Ziels anhand der gewählten Änderungsregeln.
+                    </li>
+                    <li>
+                        <i>Konvertieren</i>: Konvertiert den Zeitstempel oder die Zeitspanne des gewählten Ziels anhand der gewählten Konvertierungssregeln.
+                    </li>
+                </ul>
+                Im Zeitpunktmodus kann der zu ändernde/konvertierende Zielwert folgendes Format haben:
+                <ul>
+                    <li>
+                        Zahl (Zeitstempel)
+                        <ul>
+                            <li>
+                                Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung (Weltzeit)
+                            </li>
+                            <li>
+                                Anzahl Millisekunden seit Mitternacht, (lokaler Zeit) wenn Wert kleiner als 86.400.000
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        Zeichenkette
+                        <ul>
+                            <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                            <li>Sonnenstand</li>
+                            <li>Mondstand</li>
+                            <li>Benutzerdefinierter Sonnenstand</li>
+                            <li>Datum und Uhrzeit in Region-spezifischem Format</li>
+                            <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                            <li>Datum und Sonnenstand</li>
+                            <li>Datum und Mondstand</li>
+                            <li>
+                                Datum und benutzerdefinierter Sonnenstand
+                            </li>
+                        </ul>
+                    </li>
+                </ul>
+                Im Zeitspannenmodus kann der zu ändernde/konvertierende Zielwert folgendes Format haben:
+                <ul>
+                    <li>
+                        Zahl
+                        <ul>
+                            <li>Anzahl von Millisekunden</li>
+                        </ul>
+                    </li>
+                    <li>
+                        Zeichenkette
+                        <ul>
+                            <li>Zeitspanne im ASP.NET-Stil</li>
+                            <li>Dauer im ISO 8601 Format</li>
+                        </ul>
                     </li>
                 </ul>
             </p>
             <p>
-                Rechts neben der Aktion für die Regel kann das zu setzende oder zu
-                ändernde Ziel ausgewählt werden. Das Ziel kann entweder eine
-                Nachrichteneigenschaft, eine Flow-Variable oder eine globale
-                Variable sein.
+                Rechts neben der Aktion für die Regel kann das zu setzende oder zu ändernde Ziel ausgewählt werden. Das Ziel kann entweder eine Nachrichteneigenschaft, eine Flow-Variable oder eine globale Variable sein.
             </p>
             <p>
-                Für die Aktion <i>Festlegen</i> gibt es folgende Auswahlmöglichkeiten:
+                Im Modus <i>Zeitpunkt</i> gibt es für die Aktion <i>Festlegen</i> folgende Auswahlmöglichkeiten:
                 <ul>
                     <li>
-                        <i>Aktuelle Zeit</i>: Legt das Ziel auf die aktuelle Uhrzeit
-                        des aktuellen Tages fest.
+                        <i>Aktuelle Zeit</i>: Legt das Ziel auf die aktuelle Uhrzeit des aktuellen Tages fest.
                     </li>
                     <li>
-                        <i>Datum & Uhrzeit</i>: Left das Ziel auf ein bestimmtes
-                        Datum und eine bestimmte Uhrzeit fest, siehe weiter unten
-                        für Details.
+                        <i>Datum & Uhrzeit</i>: Legt das Ziel auf ein bestimmtes Datum und eine bestimmte Uhrzeit fest, siehe weiter unten für Details.
                     </li>
                     <li>
-                        <i>JSONata</i>: Setzt das Ziel auf das Ergebnis des angegebenen
-                        JSONata-Ausdrucks. Es werden zusätzliche Zeitberechnungsfunktionen
-                        unterstützt und der aktuelle Zielwert kann über die Variable
-                        <code>$target</code> abgefragt werden.
+                        <i>JSONata</i>: Setzt das Ziel auf das Ergebnis des angegebenen JSONata-Ausdrucks. Es werden zusätzliche Zeitberechnungsfunktionen unterstützt und der aktuelle Zielwert kann über die Variable <code>$target</code> abgefragt werden.
                     </li>
                 </ul>
                 Für die Datums- und Uhrzeiteingabe muss das Datum in der Form
                 <code>JJJJ-MM-TT</code> angegeben werden und für die Zeit gilt:
                 <ul>
                     <li>
-                        <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt in der
-                        Form <code>hh:mm[:ss] [am|pm]</code> eingegeben werden.
+                        <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12- oder 24-Stunden-Format eingegeben werden..
                     </li>
                     <li>
-                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                        vorgegebener Werte ausgewählt werden.
+                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
                     </li>
                     <li>
-                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                        vorgegebener Werte ausgewählt werden.
+                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
                     </li>
                     <li>
-                        <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte
-                        Sonnenstände kann eingegeben werden.
+                        <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte Sonnenstände kann eingegeben werden.
+                    </li>
+                </ul>
+                Im Modus <i>Zeitspanne</i> müssen für die Aktion <i>Festlegen</i> zwei Zeitpunkte gesetzt werden: einen Anfangs- und einen Endzeitpunkt der Zeitspanne. Jeder Zeitpunkt kann wie folgt angegeben werden:
+                <ul>
+                    <li>
+                        <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12- oder 24-Stunden-Format eingegeben werden. Optional ist die Eingabe eines Datums und einer Zeit in Region-spezifischem oder ISO 8601 Format möglich.
+                    </li>
+                    <li>
+                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                    </li>
+                    <li>
+                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                    </li>
+                    <li>
+                        <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte Sonnenstände kann eingegeben werden.
+                    </li>
+                    <li>
+                        <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: Die Zeit wird aus einer Umgebungs- oder Kontextvariablen oder einer Nachrichteneigenschaft gelesen. Die Variablen/Eigenschaften können folgendes Format haben:
+                        <ul>
+                            <li>
+                                Zahl (Zeitstempel)
+                                <ul>
+                                    <li>
+                                        Anzahl Millisekunden seit Beginn der UNIX-Zeitzählung (Weltzeit)
+                                    </li>
+                                    <li>
+                                        Anzahl Millisekunden seit Mitternacht, (lokaler Zeit) wenn Wert kleiner als 86.400.000
+                                    </li>
+                                </ul>
+                            </li>
+                            <li>
+                                Zeichenkette
+                                <ul>
+                                    <li>Uhrzeit im 12- oder 24-Stunden-Format</li>
+                                    <li>Sonnenstand</li>
+                                    <li>Mondstand</li>
+                                    <li>Benutzerdefinierter Sonnenstand</li>
+                                    <li>Datum und Uhrzeit in Region-spezifischem Format</li>
+                                    <li>Datum und Uhrzeit in ISO 8601 Format</li>
+                                    <li>Datum und Sonnenstand</li>
+                                    <li>Datum und Mondstand</li>
+                                    <li>Datum und benutzerdefinierter Sonnenstand</li>
+                                </ul>
+                            </li>
+                        </ul>
                     </li>
                 </ul>
             </p>
             <p>
-                Für die Aktion <i>Ändern</i> können verschiedene Änderungs- und
-                Konvertierungsregeln ausgewählt werden:
+                Im Modus <i>Zeitpunkt</i> können für die Aktion <i>Ändern</i> folgende Konvertierungsregeln ausgewählt werden:
                 <ul>
                     <li>
-                        <i>Festlegen</i>: Ändert einen Teil des Zeitstempels
-                        von dem Ziel und setzt ihn auf den angegebenen Wert.
-                        Der zu ändernde Teil kann über die Dropdown-Box
-                        ausgewählt werden.
+                        <i>Festlegen</i>: Ändert einen Teil des Zeitstempels von dem Ziel und setzt ihn auf den angegebenen Wert. Der zu ändernde Teil kann über die Dropdown-Box ausgewählt werden. Der zu ändernde Wert kann direkt als Zahl eingegeben oder von einer Umgebungs-/Kontextvariablen oder einer Nachrichteneigenschaft abgerufen werden.
                     </li>
                     <li>
-                        <i>Hinzufügen</i>: Fügt Zeit zum Zeitstempel des Ziels
-                        in der angegeben Höhe hinzu. Die Einheit kann über die
-                        Dropdown-Box ausgewählt werden.
+                        <i>Hinzufügen</i>: Fügt Zeit zum Zeitstempel des Ziels in der angegeben Höhe hinzu. Die hinzuzufügende Zeit kann direkt als Zahl eingegeben oder von einer Umgebungs-/Kontextvariablen oder einer Nachrichteneigenschaft abgerufen werden. Die Einheit dieser Zeit kann über die Dropdown-Box ausgewählt werden.
                     </li>
                     <li>
-                        <i>Abziehen</i>: Wie <i>Hinzufügen</i>, aber zieht
-                        Zeit vom Zielzeitstempel ab.
+                        <i>Abziehen</i>: Wie <i>Hinzufügen</i>, aber zieht Zeit vom Zielzeitstempel ab.
                     </li>
                     <li>
-                        <i>Anfang von</i>: Setzt den Zeitstempel des Ziels auf
-                        den Anfang einer Zeiteinheit, die über die Dropdown-Box
-                        ausgewählt werden kann.
+                        <i>Anfang von</i>: Setzt den Zeitstempel des Ziels auf den Anfang einer Zeiteinheit, die über die Dropdown-Box ausgewählt werden kann.
                     </li>
                     <li>
-                        <i>Ende von</i>: Wie <i>Anfang von</i>, aber setzt den
-                        Zielzeitstempel auf das Ende einer Zeiteinheit.
+                        <i>Ende von</i>: Wie <i>Anfang von</i>, aber setzt den Zielzeitstempel auf das Ende einer Zeiteinheit.
+                    </li>
+                </ul>
+                Im Modus <i>Zeitspanne</i> können für die Aktion <i>Ändern</i> folgende Änderungsregeln ausgewählt werden:
+                <ul>
+                    <li>
+                        <i>Hinzufügen</i>: Fügt Zeit zur Zeitspanne des Ziels in der angegeben Höhe hinzu. Die hinzuzufügende Zeit kann direkt als Zahl eingegeben oder von einer Umgebungs-/Kontextvariablen oder einer Nachrichteneigenschaft abgerufen werden. Die Einheit dieser Zeit kann über die Dropdown-Box ausgewählt werden.
                     </li>
                     <li>
-                        <i>Konvertieren</i>: Konvertiert den Zeitstempel des
-                        Ziels in eine von mehreren möglichen Zeichenkettenrepräsentationen:
+                        <i>Abziehen</i>: Wie <i>Hinzufügen</i>, aber zieht Zeit von der Zielzeitspanne ab.
+                    </li>
+                </ul>
+            </p>
+            <p>
+                Im Modus <i>Zeitpunkt</i> können für die Aktion <i>Konvertieren</i> folgende Konvertierungsregeln ausgewählt werden:
+                <ul>
+                    <li>
+                        <i>Vordefiniertes Format</i>: Konvertiert den Zielzeitpunkt in eine Zeichenkette deren Format von einer Liste vorgegebener Formate ausgewählt werden kann.
+                    </li>
+                    <ul>
+                        <li>
+                            <i>Regional</i>: Zeichenkette, die das Datum und die Uhrzeit in einem Region-spezifischen Format enthält.
+                        </li>
+                        <li>
+                            <i>Regional (nur Datum)</i>: Zeichenkette, die das Datum in einem Region-spezifischen Format enthält.
+                        </li>
+                        <li>
+                            <i>Regional (nur Zeit)</i>: Zeichenkette, die die Uhrzeit in einem Region-spezifischen Format enthält.
+                        </li>
+                        <li>
+                            <i>Relative Zeit</i>: Zeichenkette, die die Zeit relativ zum jetzigen Zeitpunkt darstellt und undeutlicher wird, je weiter sie entfernt ist.
+                        </li>
+                        <li>
+                            <i>Kalender</i>: Zeichenkette, die die absolute Zeit (sofern nicht weiter entfernt als eine Woche) sowie das Datum relativ zum heutigen Tag (oder absolut, falls weiter entfernt als eine Woche) enthält.
+                        </li>
+                        <li>
+                            <i>ISO-8601</i>: ISO-8601 Zeichenkette in lokaler Zeit (entsprechend der konfigurierten Zeitzone).
+                        </li>
+                        <li>
+                            <i>ISO-8601 (UTC)</i>: ISO-8601 Zeichenkette in UTC-Zeit.
+                        </li>
+                    </ul>
+                    <li>
+                        <i>Benutzerdefiniertes Format</i>: Konvertiert den Zielzeitpunkt in eine Zeichenkette, die über das Texteingabefeld beliebig formatiert werden kann. Das Format ist im Detail im <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node#cust-moment">Wiki</a> beschrieben.
+                    </li>
+                </ul>
+                In der zweiten Zeile kann die lokale Zeit des Eingangszeitstempels geändert werden:
+                <ul>
+                    <li>
+                        <i>Aktuelle Zeitzone</i>: Die ursprüngliche Zeitzone (die Zeitzone, die im verwendeten Konfigurationsknoten eingestellt wurde) wird beibehalten.
+                    </li>
+                    <li>
+                        <i>Zeitzone</i>: Ein <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">gültiger Zeitzonenname</a> kann angegeben werden und die Zeit wird in die ensprechende Zeitzone konvertiert.
+                    </li>
+                    <li>
+                        <i>UTC-Versatz</i>: Ein Versatz in Minuten und/oder Stunden kann angegeben werden. Eine Zahl zwischen -16 und 16 wird als Stunden interpretiert, alle Zahlen außerhalb dieses Bereichs als Minuten. Zusätzlich ist es möglich, Stunden und Minuten in der Form <code>+/-HH:MM</code> anzugeben. Der Wert wird als Versatz zur UTC-Zeit angewendet.
+                    </li>
+                </ul>
+                Im Modus <i>Zeitspanne</i> können für die Aktion <i>Konvertieren</i> folgende Konvertierungsregeln ausgewählt werden:
+                <ul>
+                    <li>
+                        <i>Numerisches Format</i>: Konvertiert die Zielzeitspanne in eine Zahl in auswählbarem Format. In der zweiten Zeile kann de Genauigkeit der Zahl ausgewählt werden:
                         <ul>
                             <li>
-                                <i>Vordefiniertes Format</i>: Das Format der
-                                Zeichenkette kann aus einer Liste vordefinierter
-                                Formate ausgewählt werden.
+                                <i>Ganzzahl</i>: Eine Ganzzahl als Ergebnis der gerundeten, abgerundeten oder aufgerundeten Originalzahl.
                             </li>
-                            <ul>
-                                <li>
-                                    <i>Regional</i>: Zeichenkette, die das Datum
-                                    und die Uhrzeit in einem Region-spezifischen
-                                    Format enthält.
-                                </li>
-                                <li>
-                                    <i>Regional (nur Datum)</i>: Zeichenkette, die
-                                    das Datum in einem Region-spezifischen Format
-                                    enthält.
-                                </li>
-                                <li>
-                                    <i>Regional (nur Zeit)</i>: Zeichenkette, die
-                                    die Uhrzeit in einem Region-spezifischen Format
-                                    enthält.
-                                </li>
-                                <li>
-                                    <i>Relative Zeit</i>: Zeichenkette, die die Zeit
-                                    relativ zum jetzigen Zeitpunkt darstellt und
-                                    undeutlicher wird, je weiter sie entfernt ist.
-                                </li>
-                                <li>
-                                    <i>Kalender</i>: Zeichenkette, die die absolute
-                                    Zeit (sofern nicht weiter entfernt als eine
-                                    Woche) sowie das Datum relativ zum heutigen Tag
-                                    (oder absolut, falls weiter entfernt als eine Woche)
-                                    enthält.
-                                </li>
-                                <li>
-                                    <i>ISO-8601</i>: ISO-8601 Zeichenkette in lokaler
-                                    Zeit (entsprechend der konfigurierten Zeitzone).
-                                </li>
-                                <li>
-                                    <i>ISO-8601 (UTC)</i>: ISO-8601 Zeichenkette in
-                                    UTC-Zeit.
-                                </li>
-                            </ul>
                             <li>
-                                <i>Benutzerdefiniertes Format</i>: Die Zeichenkette
-                                kann über das Texteingabefeld beliebig angepasst werden.
-                                Das Format muss den Regeln von <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js</a>
-                                entsprechen.
+                                <i>Fließkommazahl</i>: Eine Fließkommazahl, deren Anzahl Dezimalstellen angegeben werden kann (0 bedeutet keine Begrenzung).
                             </li>
                         </ul>
-                        In der zweiten Zeile kann die lokale Zeit des Eingangszeitstempels
-                        geändert werden:
+                    </li>
+                    <li>
+                        <i>Zeichenketten-Format</i>: Konvertiert die Zielzeitspanne in eine Zeichenkette deren Format von einer Liste vorgegebener Formate ausgewählt werden kann.
                         <ul>
                             <li>
-                                <i>Aktuelle Zeitzone</i>: Die ursprüngliche Zeitzone
-                                (die Zeitzone, die im verwendeten Konfigurationsknoten
-                                eingestellt wurde) wird beibehalten.
+                                <i>Zeitspanne</i>: Zeichenkette, die die Dauer als Zeitspanne im ASP.NET-Stil mit Sekundengenauigkeit enthält.
                             </li>
                             <li>
-                                <i>Zeitzone</i>: Ein <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">gültiger Zeitzonenname</a>
-                                kann angegeben werden und die Zeit wird in die ensprechende
-                                Zeitzone konvertiert.
+                                <i>Zeitspanne (Zehntelsekunden)</i>: Wie <i>Zeitspanne</i> aber zusätzlich mit Zehntelsekunden.
                             </li>
                             <li>
-                                <i>UTC-Versatz</i>: Ein Versatz in Minuten und/oder
-                                Stunden kann angegeben werden. Eine Zahl zwischen
-                                -16 und 16 wird als Stunden interpretiert, alle Zahlen
-                                außerhalb dieses Bereichs als Minuten. Zusätzlich ist
-                                es möglich, Stunden und Minuten in der Form <code>+/-HH:MM</code>
-                                anzugeben. Der Wert wird als Versatz zur UTC-Zeit
-                                angewendet.
+                                <i>Zeitspanne (Hundertstelsekunden)</i>: Wie <i>Zeitspanne</i> aber zusätzlich mit Hundertstelsekunden.
+                            </li>
+                            <li>
+                                <i>Zeitspanne (Millisekunden)</i>: Wie <i>Zeitspanne</i> aber zusätzlich mit Millisekunden.
+                            </li>
+                            <li>
+                                <i>Textuelle Zeitspanne</i>: Zeichenkette mit einer textuellen Repräsentation der Dauer, die undeutlicher wird, je länger sie ist.
+                            </li>
+                            <li>
+                                <i>ISO-8601</i>: ISO-8601 Zeichenkette.
                             </li>
                         </ul>
+                    </li>
+                    <li>
+                        <i>Benutzerdefiniertes Format</i>: Konvertiert die Zielzeitspanne in eine Zeichenkette, die über das Texteingabefeld beliebig formatiert werden kann. Das Format ist im Detail im <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node#cust-duration">Wiki</a> beschrieben.
                     </li>
                 </ul>
             </p>
@@ -229,8 +304,7 @@ SOFTWARE.
     </dl>
     <h3>Eingabe</h3>
     <p>
-        Eingehende Nachrichten werden geändert, wenn es Regeln gibt, die sich
-        auf Nachrichteneigenschaften beziehen.
+        Eingehende Nachrichten werden geändert, wenn es Regeln gibt, die sich auf Nachrichteneigenschaften beziehen.
     </p>
     <h3>Ausgaben</h3>
     <p>

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -3,45 +3,69 @@
     {
         "label":
         {
-            "node":               "Änderung",
-            "rules":              "Änderungsregeln",
-            "to":                 "auf",
-            "now":                "Aktuelle Zeit",
-            "date":               "Datum & Uhrzeit",
-            "format":             "Format",
-            "predefinedFormat":   "Vordefiniertes Format",
-            "customFormat":       "Benutzerdefiniertes Format",
-            "currentTZ":          "Aktuelle Zeitzone",
-            "timeZone":           "Zeitzone",
-            "utcOffset":          "UTC-Versatz",
-            "formatPlaceholder":  "z.B.: YYYY-MM-DD HH:mm:ss"
+            "node":              "Änderung",
+            "outputPort":        "Veränderte Nachricht",
+            "mode":              "Modus",
+            "rules":             "Änderungsregeln",
+            "setTo":             "auf",
+            "convertTo":         "in",
+            "now":               "Aktuelle Zeit",
+            "date":              "Datum & Uhrzeit",
+            "number":            "Zahl",
+            "format":            "Format",
+            "numericFormat":     "Numerisches Format",
+            "stringFormat":      "Zeichenketten-Format",
+            "predefinedFormat":  "Vordefiniertes Format",
+            "customFormat":      "Benutzerdefiniertes Format",
+            "integer":           "Ganzzahl",
+            "float":             "Fließkommazahl",
+            "currentTZ":         "Aktuelle Zeitzone",
+            "timeZone":          "Zeitzone",
+            "utcOffset":         "UTC-Versatz"
         },
         "list":
         {
+            "mode":
+            {
+                "moment":    "Zeitpunkt",
+                "duration":  "Zeitspanne"
+            },
             "action":
             {
-                "set":     "Festlegen",
-                "change":  "Ändern"
+                "set":      "Festlegen",
+                "change":   "Ändern",
+                "convert":  "Konvertieren"
             },
             "changeType":
             {
-                "set":       "Festlegen",
-                "add":       "Hinzufügen",
-                "subtract":  "Abziehen",
-                "startOf":   "Anfang von",
-                "endOf":     "Ende von",
-                "timeZone":  "Zeitzone",
-                "toString":  "Konvertieren"
+                "set":        "Festlegen",
+                "add":        "Hinzufügen",
+                "subtract":   "Abziehen",
+                "numval":     "Zahlenwert",
+                "startOf":    "Anfang von",
+                "endOf":      "Ende von",
+                "timeZone":   "Zeitzone"
             },
             "convert":
             {
-                "regionalDateTime":   "Regional",
-                "regionalDate":       "Regional (nur Datum)",
-                "regionalTime":       "Regional (nur Zeit)",
-                "relativeTime":       "Relative Zeit",
-                "calendar":           "Kalender",
-                "iso8601Format":      "ISO-8601",
-                "iso8601UTCFormat":   "ISO-8601 (UTC)"
+                "regionalDateTime":  "Regional",
+                "regionalDate":      "Regional (nur Datum)",
+                "regionalTime":      "Regional (nur Zeit)",
+                "relativeTime":      "Relative Zeit",
+                "calendar":          "Kalender",
+                "textualTimespan":   "Textuelle Zeitspanne",
+                "timespan":          "Zeitspanne",
+                "timespan10th":      "Zeitspanne (Zehntelsekunden)",
+                "timespan100th":     "Zeitspanne (Hundertstelsekunden)",
+                "timespanMillis":    "Zeitspanne (Millisekunden)",
+                "iso8601":           "ISO-8601",
+                "iso8601UTC":        "ISO-8601 (UTC)"
+            },
+            "int":
+            {
+                "round":  "Runden",
+                "floor":  "Abrunden",
+                "ceil":   "Aufrunden"
             }
         },
         "status":
@@ -51,7 +75,8 @@
         "error":
         {
             "noTasks":          "Keine Regeln kongiguriert",
-            "invalidProperty":  "Ungültige Eigenschaft angegeben: __property__"
+            "invalidProperty":  "Ungültige Eigenschaft angegeben: __property__",
+            "NaN":              "Angegebener Wert ist keine Zahl"
         }
     }
 }

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -24,20 +24,14 @@ SOFTWARE.
 
 <script type="text/html" data-help-name="chronos-change">
     <p>
-        Sets or changes time values from message properties, flow variables or
-        global variables.
+        Sets or changes time or duration values from message properties, flow variables or global variables.
     </p>
     <h3>Details</h3>
     <p>
-        This node sets message properties, flow variables or global variables
-        to specific times or manipulates and converts timestamps from these
-        input fields. Multiple actions can be configured per node which will be
-        executed in the specified order. It is also possible to chain different
-        actions for the same property or variable.
+        This node sets message properties, flow variables or global variables to specific times or durations or manipulates and converts timestamps or timespans from these input fields. Multiple actions can be configured per node which will be executed in the specified order. It is also possible to chain different actions for the same property or variable.
     </p>
     <p>
-        For more information, please refer to the detailed documentation in the
-        <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node">repository wiki</a>.
+        For more information, please refer to the detailed documentation in the <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node">repository wiki</a>.
     </p>
     <h3>Configuration</h3>
     <dl>
@@ -47,170 +41,261 @@ SOFTWARE.
         <dd>
             A reference to the configuration node to be used.
         </dd>
+        <dt>Mode</dt>
+        <dd>
+            The time mode, which can be either <i>Moment</i> for moments in time or <i>Duration</i> for timespans.
+        </dd>
         <dt>Change Rules</dt>
         <dd>
             <p>
-                The list containing the rules for setting or changing target
-                values. New entries can be added using the button below the
-                list. Existing entries can be reordered or deleted. The following
-                actions can be selected:
+                The list containing the rules for setting, changing or converting target values. New entries can be added using the button below the list. Existing entries can be reordered or deleted. The following actions can be selected:
                 <ul>
                     <li>
-                        <i>Set</i>: Sets the selected target to a specific date
-                        and time.
+                        <i>Set</i>: Sets the selected target to a specific date and time in moment mode or to a timespan in duration mode.
                     </li>
                     <li>
-                        <i>Change</i>: Modifies the timestamp value of the
-                        selected target according to the configured manipulation
-                        and conversion rules. The original target value can be
-                        either a number containing the milliseconds elapsed since
-                        the UNIX epoch or a string containing a date and time
-                        which must be parsable according to
-                        <a href="https://momentjs.com/docs/#/parsing/string/">Moment.js documentation</a>.
+                        <i>Change</i>: Modifies the timestamp or timespan value of the selected target according to the configured manipulation rules.
+                    </li>
+                    <li>
+                        <i>Convert</i>: Converts the the timestamp or timespan value of the selected target according to the configured conversion rules.
                     </li>
                 </ul>
-            </p>
-            <p>
-                To the right of the rule action, the target to set or change
-                can be selected. This can be either a message property, a flow
-                variable or a global variable.
-            </p>
-            <p>
-                For the set action, the following possibilities can be selected:
+                In moment mode, the original target value can have the following format:
                 <ul>
                     <li>
-                        <i>current time</i>: Sets the target to the current time
-                        of the current day.
-                    </li>
-                    <li>
-                        <i>date and time</i>: Sets the target to a specific date
-                        and time. See below for more details.
-                    </li>
-                    <li>
-                        <i>expression</i>: Sets the target to the result of the
-                        provided JSONata expression. Additional time calculation
-                        functions are supported and the current target value can
-                        be accessed through variable <code>$target</code>.
-                    </li>
-                </ul>
-                For the date and time input, the date has to be entered in the
-                form <code>YYYY-MM-DD</code> and the time can be provided in the
-                following ways:
-                <ul>
-                    <li>
-                        <i>time of day</i>: A specific time can be entered
-                        directly in the form <code>hh:mm[:ss] [am|pm]</code>.
-                    </li>
-                    <li>
-                        <i>sun position</i>: The sun position can be selected
-                        from a list of predefined values.
-                    </li>
-                    <li>
-                        <i>moon position</i>: The moon position can be selected
-                        from a list of predefined values.
-                    </li>
-                    <li>
-                        <i>custom sun position</i>: One of the user-defined sun position
-                        names can be entered.
-                    </li>
-                </ul>
-            </p>
-            <p>
-                For the change action, different types of manipulation and
-                conversion can be selected:
-                <ul>
-                    <li>
-                        <i>Set</i>: Modifies a part of the target timestamp.
-                        The part to be changed can be selected in the dropdown
-                        box.
-                    </li>
-                    <li>
-                        <i>Add</i>: Adds time to the target timestamp. The amount
-                        of time has to entered as number and the unit of time
-                        to be added can be selected in the dropdown box.
-                    </li>
-                    <li>
-                        <i>Subtract</i>: Similar to <i>Add</i>, but subtracts
-                        time from the target timestamp.
-                    </li>
-                    <li>
-                        <i>Start of</i>: Sets the target timestamp to the start
-                        of a unit of time. The latter can be selected in the
-                        dropdown box.
-                    </li>
-                    <li>
-                        <i>End of</i>: Similar to <i>Start of</i>, but sets the
-                        target timestamp to the end of a unit of time.
-                    </li>
-                    <li>
-                        <i>Convert</i>: Converts the target timestamp to
-                        different kind of string representations:
+                        Number (timestamp)
                         <ul>
                             <li>
-                                <i>predefined format</i>: String format can be
-                                chosen from a list of predefined formats.
+                                Number of milliseconds elapsed since the UNIX
+                                epoch (universal time)
                             </li>
-                            <ul>
-                                <li>
-                                    <i>regional</i>: String containing the date
-                                    and the time in a region-specific format.
-                                </li>
-                                <li>
-                                    <i>regional (date only)</i>: String containing
-                                    the date in a region-specific format.
-                                </li>
-                                <li>
-                                    <i>regional (time only)</i>: String containing
-                                    the time in a region-specific format.
-                                </li>
-                                <li>
-                                    <i>relative time</i>: String representing the time
-                                    relative to the current time, being less precise
-                                    the farer away it is.
-                                </li>
-                                <li>
-                                    <i>calendar</i>: String containing the absolute
-                                    time (if not farer away than one week) and the
-                                    date relative to today (or absolute if farer away
-                                    than one week).
-                                </li>
-                                <li>
-                                    <i>ISO-8601</i>: ISO-8601 string as local time
-                                    (according to configured time zone).
-                                </li>
-                                <li>
-                                    <i>ISO-8601 (UTC)</i>: ISO-8601 string as UTC
-                                    time.
-                                </li>
-                            </ul>
                             <li>
-                                <i>custom format</i>: String can be customized
-                                by specifying the format via the text box which
-                                must follow the rules from the <a href="https://momentjs.com/docs/#/displaying/format/">Moment.js documentation</a>.
+                                Number of milliseconds elapsed since midnight
+                                (local time) if value is smaller than 86.400.000
                             </li>
                         </ul>
-                        In the second row, it is possible to change the local time
-                        of the input timestamp:
+                    </li>
+                    <li>
+                        String
+                        <ul>
+                            <li>Time in 12 or 24 hour format</li>
+                            <li>Sun time</li>
+                            <li>Moon time</li>
+                            <li>Custom sun time</li>
+                            <li>Date and time in region-specific format</li>
+                            <li>Date and time in ISO 8601 format</li>
+                            <li>Date and sun time</li>
+                            <li>Date and moon time</li>
+                            <li>Date and custom sun time</li>
+                        </ul>
+                    </li>
+                </ul>
+                In duration mode, the original target value can have the following format:
+                <ul>
+                    <li>
+                        Number
+                        <ul>
+                            <li>Number of milliseconds</li>
+                        </ul>
+                    </li>
+                    <li>
+                        String
+                        <ul>
+                            <li>Timespan in ASP.NET style</li>
+                            <li>Duration in ISO 8601 format</li>
+                        </ul>
+                    </li>
+                </ul>
+            </p>
+            <p>
+                To the right of the rule action, the target to set, change or convert can be selected. This can be either a message property, a flow variable or a global variable.
+            </p>
+            <p>
+                For the set action in moment mode, the following possibilities can be selected:
+                <ul>
+                    <li>
+                        <i>current time</i>: Sets the target to the current time of the current day.
+                    </li>
+                    <li>
+                        <i>date and time</i>: Sets the target to a specific date and time, see below for more details.
+                    </li>
+                    <li>
+                        <i>expression</i>: Sets the target to the result of the provided JSONata expression. Additional time calculation functions are supported and the current target value can be accessed through variable <code>$target</code>.
+                    </li>
+                </ul>
+                For the date and time input, the date has to be entered in the form <code>YYYY-MM-DD</code> and the time can be provided in the following ways:
+                <ul>
+                    <li>
+                        <i>time of day</i>: A specific time can be entered directly in 12 or 24 hour format.
+                    </li>
+                    <li>
+                        <i>sun position</i>: The sun position can be selected from a list of predefined values.
+                    </li>
+                    <li>
+                        <i>moon position</i>: The moon position can be selected from a list of predefined values.
+                    </li>
+                    <li>
+                        <i>custom sun position</i>: One of the user-defined sun position names can be entered.
+                    </li>
+                </ul>
+                For the set action in duration mode, two times need to be selected: a start time and another time for the end of the time span. Each time can be provided in the following ways:
+                <ul>
+                    <li>
+                        <i>time of day</i>: A specific time can be entered directly in 12 or 24 hour format. Optionally it is possible to specify a date and a time using regional or ISO 8601 format.
+                    </li>
+                    <li>
+                        <i>sun position</i>: The sun position can be selected from a list of predefined values.
+                    </li>
+                    <li>
+                        <i>moon position</i>: The moon position can be selected from a list of predefined values.
+                    </li>
+                    <li>
+                        <i>custom sun position</i>: One of the user-defined sun position names can be entered.
+                    </li>
+                    <li>
+                        <i>env</i>, <i>global</i>, <i>flow</i>, <i>msg</i>: The time is retrieved from an environment variable, a context variable or a message property. The variables/properties can have the following format:
                         <ul>
                             <li>
-                                <i>current time zone</i>: The original time zone (the
-                                time zone configured in the associated configuration
-                                node) is kept unmodified.
+                                Number (timestamp)
+                                <ul>
+                                    <li>
+                                        Number of milliseconds elapsed since the UNIX epoch (universal time)
+                                    </li>
+                                    <li>
+                                        Number of milliseconds elapsed since midnight (local time) if value is smaller than 86.400.000
+                                    </li>
+                                </ul>
                             </li>
                             <li>
-                                <i>time zone</i>: The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>
-                                can be specified and the time is converted to that
-                                time zone.
-                            </li>
-                            <li>
-                                <i>UTC offset</i>: An offset in minutes and/or hours
-                                can be specified. A number between -16 and 16 is
-                                interpreted as hours, a number outside of that range
-                                as minutes. Additionally, it is possible to specify
-                                hours and minutes in the form <code>+/-HH:MM</code>.
-                                The value is applied as offset to the UTC time.
+                                String
+                                <ul>
+                                    <li>Time in 12 or 24 hour format</li>
+                                    <li>Sun time</li>
+                                    <li>Moon time</li>
+                                    <li>Custom sun time</li>
+                                    <li>Date and time in region-specific format</li>
+                                    <li>Date and time in ISO 8601 format</li>
+                                    <li>Date and sun time</li>
+                                    <li>Date and moon time</li>
+                                    <li>Date and custom sun time</li>
+                                </ul>
                             </li>
                         </ul>
+                    </li>
+                </ul>
+            </p>
+            <p>
+                For the change action in moment mode, the following types of manipulation can be selected:
+                <ul>
+                    <li>
+                        <i>Set</i>: Modifies a part of the target timestamp. The part to be changed can be selected in the dropdown box. The value to be set has to be entered as number or can be retrieved from an environment/context variable or message property.
+                    </li>
+                    <li>
+                        <i>Add</i>: Adds time to the target timestamp. The amount of time has to entered as number or can be retrieved from an environment/context variable or message property. The unit of time to be added can be selected in the dropdown box.
+                    </li>
+                    <li>
+                        <i>Subtract</i>: Similar to <i>Add</i>, but subtracts time from the target timestamp.
+                    </li>
+                    <li>
+                        <i>Start of</i>: Sets the target timestamp to the start of a unit of time. The latter can be selected in the dropdown box.
+                    </li>
+                    <li>
+                        <i>End of</i>: Similar to <i>Start of</i>, but sets the target timestamp to the end of a unit of time.
+                    </li>
+                </ul>
+                For the change action in duration mode, the following types of manipulation can be selected:
+                <ul>
+                    <li>
+                        <i>Add</i>: Adds time to the target timespan. The amount of time has to entered as number or can be retrieved from an environment/context variable or message property. The unit of time to be added can be selected in the dropdown box.
+                    </li>
+                    <li>
+                        <i>Subtract</i>: Similar to <i>Add</i>, but subtracts time from the target timespan.
+                    </li>
+                </ul>
+            </p>
+            <p>
+                For the convert action in moment mode, the following types of convertion can be selected:
+                <ul>
+                    <li>
+                        <i>predefined format</i>: Converts the target timestamp to a string whose format can be chosen from a list of predefined formats.
+                    </li>
+                    <ul>
+                        <li>
+                            <i>regional</i>: String containing the date and the time in a region-specific format.
+                        </li>
+                        <li>
+                            <i>regional (date only)</i>: String containing the date in a region-specific format.
+                        </li>
+                        <li>
+                            <i>regional (time only)</i>: String containing the time in a region-specific format.
+                        </li>
+                        <li>
+                            <i>relative time</i>: String representing the time relative to the current time, being less precise the farer away it is.
+                        </li>
+                        <li>
+                            <i>calendar</i>: String containing the absolute time (if not farer away than one week) and the date relative to today (or absolute if farer away than one week).
+                        </li>
+                        <li>
+                            <i>ISO-8601</i>: ISO-8601 string as local time (according to configured time zone).
+                        </li>
+                        <li>
+                            <i>ISO-8601 (UTC)</i>: ISO-8601 string as UTC time.
+                        </li>
+                    </ul>
+                    <li>
+                        <i>custom format</i>: Converts the target timestamp to a string which can be formatted via the text box. See <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node#cust-moment">format documentation</a> in the wiki for more information</a>.
+                    </li>
+                </ul>
+                In the second row, it is possible to change the local time of the input timestamp:
+                <ul>
+                    <li>
+                        <i>current time zone</i>: The original time zone (the time zone configured in the associated configuration node) is kept unmodified.
+                    </li>
+                    <li>
+                        <i>time zone</i>: The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a> can be specified and the time is converted to that time zone.
+                    </li>
+                    <li>
+                        <i>UTC offset</i>: An offset in minutes and/or hours can be specified. A number between -16 and 16 is interpreted as hours, a number outside of that range as minutes. Additionally, it is possible to specify hours and minutes in the form <code>+/-HH:MM</code>. The value is applied as offset to the UTC time.
+                    </li>
+                </ul>
+                For the convert action in duration mode, the following types of convertion can be selected:
+                <ul>
+                    <li>
+                        <i>numeric format</i>: Converts the target timespan to a number in a selectable unit. In the second row, the precision for the numeric representation can be chosen:
+                        <ul>
+                            <li>
+                                <i>integer number</i>: An integer number that is the result of rounding, rounding down or rounding up the original number.
+                            </li>
+                            <li>
+                                <i>floating point number</i>: A floating point number whose number of decimal places can be specified (0 means no limitations).
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <i>string format</i>: Converts the target timespan to a string whose format can be chosen from a list of predefined formats.
+                        <ul>
+                            <li>
+                                <i>timespan</i>: String containing the duration as ASP.NET style timespan in seconds granularity.
+                            </li>
+                            <li>
+                                <i>timespan (1/10th of a second)</i>: Like <i>timespan</i> but additionally containing 1/10th fractional seconds.
+                            </li>
+                            <li>
+                                <i>timespan (1/100th of a second)</i>: Like <i>timespan</i> but additionally containing 1/100th fractional seconds.
+                            </li>
+                            <li>
+                                <i>timespan (milliseconds)</i>: Like <i>timespan</i> but additionally containing milliseconds.
+                            </li>
+                            <li>
+                                <i>textual timespan</i>: String containing a textual representation of the duration, being less precise the longer it is.
+                            </li>
+                            <li>
+                                <i>ISO-8601</i>: ISO-8601 duration string.
+                            </li>
+                        </ul>
+                    </li>
+                    <li>
+                        <i>custom format</i>: Converts the target timespan to a string which can be formatted via the text box. See <a href="https://github.com/jensrossbach/node-red-contrib-chronos/wiki/Time-Change-Node#cust-duration">format documentation</a> in the wiki for more information</a>.
                     </li>
                 </ul>
             </p>
@@ -218,8 +303,7 @@ SOFTWARE.
     </dl>
     <h3>Input</h3>
     <p>
-        Incoming messages are modified if there are change rules containing
-        message property based targets.
+        Incoming messages are modified if there are change rules containing message property based targets.
     </p>
     <h3>Outputs</h3>
     <p>

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -3,45 +3,69 @@
     {
         "label":
         {
-            "node":               "time change",
-            "rules":              "Change Rules",
-            "to":                 "to",
-            "now":                "current time",
-            "date":               "date & time",
-            "format":             "Format",
-            "predefinedFormat":   "predefined format",
-            "customFormat":       "custom format",
-            "currentTZ":          "current time zone",
-            "timeZone":           "time zone",
-            "utcOffset":          "UTC offset",
-            "formatPlaceholder":  "e.g.: YYYY-MM-DD HH:mm:ss"
+            "node":              "time change",
+            "outputPort":        "changed message",
+            "mode":              "Mode",
+            "rules":             "Change Rules",
+            "setTo":             "to",
+            "convertTo":         "to",
+            "now":               "current time",
+            "date":              "date & time",
+            "number":            "number",
+            "format":            "Format",
+            "numericFormat":     "numeric format",
+            "stringFormat":      "string format",
+            "predefinedFormat":  "predefined format",
+            "customFormat":      "custom format",
+            "integer":           "integer number",
+            "float":             "floating point number",
+            "currentTZ":         "current time zone",
+            "timeZone":          "time zone",
+            "utcOffset":         "UTC offset"
         },
         "list":
         {
+            "mode":
+            {
+                "moment":    "Moment",
+                "duration":  "Duration"
+            },
             "action":
             {
-                "set":     "Set",
-                "change":  "Change"
+                "set":      "Set",
+                "change":   "Change",
+                "convert":  "Convert"
             },
             "changeType":
             {
-                "set":       "Set",
-                "add":       "Add",
-                "subtract":  "Subtract",
-                "startOf":   "Start of",
-                "endOf":     "End of",
-                "timeZone":  "Time zone",
-                "toString":  "Convert"
+                "set":        "Set",
+                "add":        "Add",
+                "subtract":   "Subtract",
+                "numval":     "Num. value",
+                "startOf":    "Start of",
+                "endOf":      "End of",
+                "timeZone":   "Time zone"
             },
             "convert":
             {
-                "regionalDateTime":   "regional",
-                "regionalDate":       "regional (date only)",
-                "regionalTime":       "regional (time only)",
-                "relativeTime":       "relative time",
-                "calendar":           "calendar",
-                "iso8601Format":      "ISO-8601",
-                "iso8601UTCFormat":   "ISO-8601 (UTC)"
+                "regionalDateTime":  "regional",
+                "regionalDate":      "regional (date only)",
+                "regionalTime":      "regional (time only)",
+                "relativeTime":      "relative time",
+                "calendar":          "calendar",
+                "textualTimespan":   "textual timespan",
+                "timespan":          "timespan",
+                "timespan10th":      "timespan (1/10 of a second)",
+                "timespan100th":     "timespan (1/100 of a second)",
+                "timespanMillis":    "timespan (milliseconds)",
+                "iso8601":           "ISO-8601",
+                "iso8601UTC":        "ISO-8601 (UTC)"
+            },
+            "int":
+            {
+                "round":  "round",
+                "floor":  "round down",
+                "ceil":   "round up"
             }
         },
         "status":
@@ -51,7 +75,8 @@
         "error":
         {
             "noTasks":          "No rules configured",
-            "invalidProperty":  "Invalid property specified: __property__"
+            "invalidProperty":  "Invalid property specified: __property__",
+            "NaN":              "Provided value is not a number"
         }
     }
 }


### PR DESCRIPTION
This pull request brings a large extension to time change node. The biggest part of this is the support for durations (timespans / periods of time). Now it is possible to select a time mode for an instance of the time change node. The _moment_ mode is the classic mode to deal with timestamps (moments in time) and the _duration_ mode is the new mode to deal with timespans. In duration mode, timespans can be created by specifying a start and an end time. Timespans can also be modified by adding or subtracting a specific amount of time (similar to what is possible for timestamps) and they can be converted to different number and string formats.

Additionally, the change action _Set_ (moment mode only) and the change actions _Add_ and _Subtract_ (both moment and duration modes) now support to retrieve the time portion from environment/context variables or message properties.