### PR TITLE
Fix inconsistent translation of time part in status text

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -154,7 +154,6 @@ function getTimeFrom(node, source)
     }
 
     ret.locale(node.locale);
-
     return ret;
 }
 
@@ -215,6 +214,7 @@ function getUserTime(RED, node, day, value, timeOnly = false)
         throw new TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"), {type: "time", value: value});
     }
 
+    ret.locale(node.locale);
     return ret;
 }
 


### PR DESCRIPTION
This pull request fixes a bug where the locale/language was not correctly set for times of type time of day.