### PR TITLE
Release 1.25.3

### DIFF
--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -80,16 +80,16 @@ module.exports = function(RED)
                 {
                     node.schedule[i].port = settings.schedule[i].output.port;
                 }
+                else
+                {
+                    node.schedule[i].port = 0;
+                }
             }
 
-            if (settings.multiPort)
+            node.ports = [];
+            for (let i=0; i<settings.outputs; ++i)
             {
-                node.ports = [];
-
-                for (let i=0; i<settings.outputs; ++i)
-                {
-                    node.ports.push(null);
-                }
+                node.ports.push(null);
             }
 
             if (settings.nextEventPort)
@@ -879,15 +879,11 @@ module.exports = function(RED)
 
         function sendMessage(entry)
         {
-            if (settings.multiPort)
+            if (node.ports.length > 1)
             {
                 node.ports[entry.port] = entry.msg;
                 node.send(node.ports);
                 node.ports[entry.port] = null;
-            }
-            else if (settings.nextEventPort)
-            {
-                node.send(entry.notification ? [null, entry.msg] : [entry.msg, null]);
             }
             else
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.25.2",
+    "version": "1.25.3",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",


### PR DESCRIPTION
### Fixed
- Fixed a bug that caused scheduler node to crash when trying to send next event message and being configured to have only a single output port and an next event port.