### PR TITLE
Fix invalid date shown for next event of crontab schedule

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -146,6 +146,10 @@ function getTimeFrom(node, source)
             ret = getMoment(node, source);
         }
     }
+    else if ((typeof source == "object") && (source instanceof Date))
+    {
+        ret = getMoment(node, source);
+    }
 
     if (!ret)
     {


### PR DESCRIPTION
This pull request fixes a regression which caused the time of the next event shown in the status of scheduler node to be displayed as 'Invalid date'.