### PR TITLE
Release 1.25.5

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -146,6 +146,10 @@ function getTimeFrom(node, source)
             ret = getMoment(node, source);
         }
     }
+    else if ((typeof source == "object") && (source instanceof Date))
+    {
+        ret = getMoment(node, source);
+    }
 
     if (!ret)
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.25.4",
+    "version": "1.25.5",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",


### PR DESCRIPTION
### Fixed
- Fixed a regression which caused the time of the next event shown in the status of scheduler node to be displayed as 'Invalid date'.