### PR TITLE
Clone initially forwarded message from repeat node

### DIFF
--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -182,7 +182,7 @@ module.exports = function(RED)
                             {
                                 if (await scheduleMessage(msg))
                                 {
-                                    send(node.message);
+                                    send(RED.util.cloneMessage(node.message));
                                 }
 
                                 done();


### PR DESCRIPTION
This pull request fixes a problem with the initial message forwarded by the repeat node if "When message arrives on input" is set to "forward message" or "forced forward message" to be the original message instead of a clone. The fix avoids that modifications of that initially forwarded message change the original incoming message.