### PR TITLE
Queue limit for delay node

### DIFF
--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -88,7 +88,23 @@ SOFTWARE.
         <input id="node-input-customDelayType" type="hidden">
         <input id="node-input-customDelayValue" type="hidden">
     </div>
-    <div class="form-row" style="padding-top: 10px">
+    <div class="form-row" style="padding-top: 10px;">
+        <input id="node-input-limitQueue" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
+        <label for="node-input-limitQueue" style="margin-bottom: 0px; width: auto;" data-i18n="delay.label.limitQueue"></label>&nbsp;
+        <input id="node-input-queueLimit" type="text" placeholder="10" style="width: 45px; height: 28px;">&nbsp;
+        <span data-i18n="delay.label.queueUnit"></span>
+    </div>
+    <div class="form-row" style="margin-bottom: 4px;">
+        <label for="node-input-msgIngress" style="width: auto;"><i class="fa fa-sign-in"></i> <span data-i18n="delay.label.msgIngress"></span></label>
+    </div>
+    <div class="form-row">
+        <select id="node-input-msgIngress" style="margin-left: 104px; width: auto;">
+            <option value="drop:incoming" data-i18n="delay.list.msgIngress.dropIncoming"></option>
+            <option value="drop:oldest" data-i18n="delay.list.msgIngress.dropOldest"></option>
+            <option value="flush:oldest" data-i18n="delay.list.msgIngress.flushOldest"></option>
+        </select>
+    </div>
+    <div class="form-row">
         <input id="node-input-preserveCtrlProps" type="checkbox" style="margin-top: 0px; margin-bottom: 1px; width: auto;">
         <label for="node-input-preserveCtrlProps" style="margin-bottom: 0px; width: auto;" data-i18n="node-red-contrib-chronos/chronos-config:common.label.preserveCtrlProps"></label>
     </div>
@@ -326,6 +342,19 @@ SOFTWARE.
 
                         return res;
                     }
+                },
+                limitQueue:
+                {
+                    value: false
+                },
+                queueLimit:
+                {
+                    value:    10,
+                    validate: RED.validators.number(true)
+                },
+                msgIngress:
+                {
+                    value: "drop:incoming"
                 },
                 preserveCtrlProps:
                 {
@@ -674,6 +703,22 @@ SOFTWARE.
                 $("#node-input-delayType").change();
                 when.typedInput("value", $("#node-input-whenValue").val());
                 customDelay.typedInput("value", $("#node-input-customDelayValue").val());
+
+                // backward compatibility to v1.25.6 and earlier
+                if (typeof node.limitQueue == "undefined")
+                {
+                    $("#node-input-limitQueue").prop("checked", false);
+                }
+                if (typeof node.msgIngress == "undefined")
+                {
+                    $("#node-input-msgIngress").val("drop:incoming");
+                }
+
+                $("#node-input-limitQueue").on("change", function()
+                {
+                    $("#node-input-queueLimit").attr("disabled", !$("#node-input-limitQueue").prop("checked"));
+                    $("#node-input-msgIngress").attr("disabled", !$("#node-input-limitQueue").prop("checked"));
+                });
             },
             oneditsave: function()
             {

--- a/nodes/locales/de/delay.html
+++ b/nodes/locales/de/delay.html
@@ -137,6 +137,32 @@ SOFTWARE.
             des Variablenformats (Eigenschaften <code>fixedDuration</code>,
             <code>randomDuration</code> und <code>when</code>).
         </dd>
+        <dt>Warteschlange begrenzen</dt>
+        <dd>
+            Wenn aktiviert, kann die Nachrichten-Warteschlange auf eine
+            maximale Anzahl zu puffernde Nachrichten begrenzt werden.
+        </dd>
+        <dt>Beim Eintreffen einer Nachricht bei voller Warteschlange</dt>
+        <dd>
+            Gibt an, was passieren soll, wenn eine Nachricht eintrifft und
+            die Nachrichten-Warteschlange bereits die Obergrenze erreicht hat.
+            <ul>
+                <li>
+                    <i>Eingehende Nachricht verwerfen</i>: Die eingehende
+                    Nachricht wird verworfen.
+                </li>
+                <li>
+                    <i>Älteste Nachricht verwerfen</i>: Die älteste Nachricht
+                    in der Warteschlange wird verworfen und die eingehende
+                    Nachricht wird gepuffert.
+                </li>
+                <li>
+                    <i>Älteste Nachricht weiterleiten</i>: Die älteste
+                    Nachricht in der Warteschlange wird weitergeleitet und
+                    die eingehende Nachricht wird gepuffert.
+                </li>
+            </ul>
+        </dd>
         <dt>Steuereigenschaften in Nachrichten beibehalten</dt>
         <dd>
             Wenn aktiviert, werden Steuereigenschaften, wie unten in Abschnitt

--- a/nodes/locales/de/delay.json
+++ b/nodes/locales/de/delay.json
@@ -9,7 +9,10 @@
             "duration":          "Dauer",
             "when":              "Wann",
             "delay":             "Verzögerung",
-            "randomizerMillis":  "Zufallswert immer in Millisekundenauflösung"
+            "randomizerMillis":  "Zufallswert immer in Millisekundenauflösung",
+            "limitQueue":        "Warteschlange begrenzen auf",
+            "queueUnit":         "Nachrichten",
+            "msgIngress":        "Beim Eintreffen einer Nachricht bei voller Warteschlange"
         },
         "list":
         {
@@ -19,6 +22,12 @@
                 "randomDuration":  "Zufällige Dauer",
                 "pointInTime":     "Zeitpunkt",
                 "custom":          "Benutzerdefiniert"
+            },
+            "msgIngress":
+            {
+                "dropIncoming":  "Eingehende Nachricht verwerfen",
+                "dropOldest":    "Älteste Nachricht verwerfen",
+                "flushOldest":   "Älteste Nachricht weiterleiten"
             }
         },
         "status":

--- a/nodes/locales/en-US/delay.html
+++ b/nodes/locales/en-US/delay.html
@@ -132,6 +132,32 @@ SOFTWARE.
             (properties <code>fixedDuration</code>, <code>randomDuration</code>
             and <code>when</code>).
         </dd>
+        <dt>Limit queue</dt>
+        <dd>
+            If selected, the message queue can be limited to a maximum number
+            of messages that will be queued.
+        </dd>
+        <dt>When message arrives on input and queue is full</dt>
+        <dd>
+            Specifies the behavior when a message arrives at the input port
+            and the queue limit is already reached.
+            <ul>
+                <li>
+                    <i>drop incoming message</i>: The incoming message will
+                    be dropped.
+                </li>
+                <li>
+                    <i>drop oldest message</i>: The oldest message in the
+                    queue will be dropped and the incoming message will be
+                    enqueued.
+                </li>
+                <li>
+                    <i>flush oldest message</i>: The oldest message in the
+                    queue will be sent out and the incoming message will be
+                    enqueued.
+                </li>
+            </ul>
+        </dd>
         <dt>Preserve control properties in messages</dt>
         <dd>
             If selected, control properties as described below in section

--- a/nodes/locales/en-US/delay.json
+++ b/nodes/locales/en-US/delay.json
@@ -9,7 +9,10 @@
             "duration":          "Duration",
             "when":              "When",
             "delay":             "Delay",
-            "randomizerMillis":  "Random value always in milliseconds granularity"
+            "randomizerMillis":  "Random value always in milliseconds granularity",
+            "limitQueue":        "Limit queue to",
+            "queueUnit":         "messages",
+            "msgIngress":        "When message arrives on input and queue is full"
         },
         "list":
         {
@@ -19,6 +22,12 @@
                 "randomDuration":  "Random Duration",
                 "pointInTime":     "Point in Time",
                 "custom":          "Custom"
+            },
+            "msgIngress":
+            {
+                "dropIncoming":  "drop incoming message",
+                "dropOldest":    "drop oldest message",
+                "flushOldest":   "flush oldest message"
             }
         },
         "status":


### PR DESCRIPTION
This pull request adds the possibility to limit the message queue of delay node to a specific maximum number of queued messages. It is further possible to specify the behavior upon message ingress when the queue is already full. You can choose between dropping the incoming message, dropping the oldest message in the queue and flushing the oldest message in the queue (in the latter two cases, the incoming message is enqueued).

Resolves #5