### PR TITLE
Manual timing / unlimited timeout for delay node

### DIFF
--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -38,6 +38,7 @@ SOFTWARE.
             <option value="randomDuration" data-i18n="delay.list.delayType.randomDuration"></option>
             <option value="pointInTime" data-i18n="delay.list.delayType.pointInTime"></option>
             <option value="custom" data-i18n="delay.list.delayType.custom"></option>
+            <option value="unlimited" data-i18n="delay.list.delayType.unlimited"></option>
         </select>
     </div>
     <div id="form-row-fixedDuration" class="form-row">

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -424,9 +424,13 @@ module.exports = function(RED)
                 {
                     setupTimePointDelayTimer(whenType, whenValue, whenOffset, whenRandom);
                 }
-                else
+                else if (delayType == "custom")
                 {
                     await setupCustomDelayTimer(msg);
+                }
+                else
+                {
+                    node.debug("No timer setup due to unlimited delay");
                 }
             }
 
@@ -814,6 +818,10 @@ module.exports = function(RED)
                     });
 
                     node.status({fill: "blue", shape: "dot", text: node.msgQueue.length + " " + RED._("delay.status.queuedUntil") + " " + when});
+                }
+                else
+                {
+                    node.status({fill: "blue", shape: "dot", text: node.msgQueue.length + " " + RED._("delay.status.queuedUnlimited")});
                 }
             }
             else

--- a/nodes/locales/de/delay.html
+++ b/nodes/locales/de/delay.html
@@ -73,6 +73,11 @@ SOFTWARE.
                     benutzerdefinierter JSONata-Ausdruck spezifiziert
                     oder aus einer Kontextvariablen geladen.
                 </li>
+                <li>
+                    <i>Unbegrenzt</i>: Die Verzögerung ist unbegenzt und
+                    die gepufferten Nachrichten müssen explizit über eine
+                    entsprechende Eingangsnachricht weitergeleitet werden.
+                </li>
             </ul>
         </dd>
         <dt>Dauer</dt>

--- a/nodes/locales/de/delay.json
+++ b/nodes/locales/de/delay.json
@@ -21,7 +21,8 @@
                 "fixedDuration":   "Feste Dauer",
                 "randomDuration":  "Zufällige Dauer",
                 "pointInTime":     "Zeitpunkt",
-                "custom":          "Benutzerdefiniert"
+                "custom":          "Benutzerdefiniert",
+                "unlimited":       "Unbegrenzt"
             },
             "msgIngress":
             {
@@ -32,9 +33,10 @@
         },
         "status":
         {
-            "queuedFor":    "wartend für",
-            "queuedUntil":  "wartend bis",
-            "error":        "Fehler"
+            "queuedFor":        "wartend für",
+            "queuedUntil":      "wartend bis",
+            "queuedUnlimited":  "unbegrenzt wartend",
+            "error":            "Fehler"
         }
     }
 }

--- a/nodes/locales/en-US/delay.html
+++ b/nodes/locales/en-US/delay.html
@@ -70,6 +70,11 @@ SOFTWARE.
                     <i>Custom</i>: The delay is specified by a user-defined
                     JSONata expression or taken from a context variable.
                 </li>
+                <li>
+                    <i>Unlimited</i>: The delay is unlimited and the queue
+                    must be flushed explicitly via an appropriate input
+                    message.
+                </li>
             </ul>
         </dd>
         <dt>Duration</dt>

--- a/nodes/locales/en-US/delay.json
+++ b/nodes/locales/en-US/delay.json
@@ -21,7 +21,8 @@
                 "fixedDuration":   "Fixed Duration",
                 "randomDuration":  "Random Duration",
                 "pointInTime":     "Point in Time",
-                "custom":          "Custom"
+                "custom":          "Custom",
+                "unlimited":       "Unlimited"
             },
             "msgIngress":
             {
@@ -32,9 +33,10 @@
         },
         "status":
         {
-            "queuedFor":    "queued for",
-            "queuedUntil":  "queued until",
-            "error":        "error"
+            "queuedFor":        "queued for",
+            "queuedUntil":      "queued until",
+            "queuedUnlimited":  "queued unlimited",
+            "error":            "error"
         }
     }
 }


### PR DESCRIPTION
This pull request adds the possibility to specify an unlimited timeout for the delay node. With this delay type, incoming messages are queued forever or until the queue is flushed explicitly via an appropriate input message.

Resolves #200