### PR TITLE
Bump version to 1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.25.6",
+    "version": "1.26.0",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -44,20 +44,20 @@
     "dependencies": {
         "cronosjs": "^1.7.1",
         "moment": "^2.30.1",
-        "moment-timezone": "^0.5.45",
+        "moment-timezone": "^0.5.47",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^9.6.0",
-        "jsonata": "^2.0.5",
-        "mocha": "^10.5.2",
-        "node-red": "^4.0.1",
+        "eslint": "^9.20.0",
+        "jsonata": "^2.0.6",
+        "mocha": "^11.1.0",
+        "node-red": "^4.0.8",
         "node-red-node-test-helper": "^0.3.4",
-        "nyc": "^17.0.0",
+        "nyc": "^17.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^18.0.0"
+        "sinon": "^19.0.2"
     },
     "main": "none",
     "scripts": {
@@ -69,7 +69,7 @@
         "node": ">=12.0.0"
     },
     "node-red": {
-        "version": ">=1.0.0",
+        "version": ">=3.1.1",
         "nodes": {
             "chronos-config": "nodes/config.js",
             "chronos-scheduler": "nodes/scheduler.js",


### PR DESCRIPTION
This pull request bumps the node-red-contrib-chronos component version to 1.26.0. Additionally it updates dependencies to latest versions as far as possible.

### ‼️Important Node‼️
Minimum required Node-RED version has been raised to 3.1.1, please update your Node-RED version if you are still using an older one.