### PR TITLE
Fix height of condition list in state node UI

### DIFF
--- a/nodes/state.html
+++ b/nodes/state.html
@@ -884,7 +884,7 @@ SOFTWARE.
             oneditresize: function(size)
             {
                 const listRow = $("#dialog-form div.list-row");
-                const otherRows = $("#dialog-form>div");
+                let otherRows = $("#dialog-form>div");
                 let height = size.height;
 
                 for (let i=0; i<otherRows.length; ++i)


### PR DESCRIPTION
This pull request fixes the height of the condition list in the state node UI. Now it scales again across the complete available height in the view.