### PR TITLE
Add missing options documentation to scheduler node help

### DIFF
--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -49,7 +49,7 @@ SOFTWARE.
         <dd>
             Ein Verweis auf den zu verwendenden Konfigurationsknoten.
         </dd>
-        <dt>Zeitplan</dt>
+        <dt>Reiter Zeitplan</dt>
         <dd>
             Liste der geplanten Zeitereignisse. Neue Einträge können über den
             Button unterhalb der Liste hinzugefügt werden. Vorhandene Einträge
@@ -118,6 +118,16 @@ SOFTWARE.
                 </li>
             </ul>
         </dd>
+        <dt>Reiter Optionen</dt>
+        <dd>
+            Allgemeine Optionen, die konfiguriert werden können und nachfolgend
+            beschrieben sind.
+        </dd>
+        <dt>Mit inaktivem Zeitplan starten</dt>
+        <dd>
+            Wenn aktiviert, wird der Zeitplan beim Starten des Knotens initial
+            deaktiviert.
+        </dd>
         <dt>Separate Ausgabe-Ports für Zeitereignisse</dt>
         <dd>
             Wenn aktiviert, wird für jedes Zeitereignis, das eine Nachricht als
@@ -136,10 +146,11 @@ SOFTWARE.
             <code>msg.payload</code> und ein Array mit Zeitstempeln aller
             Zeitereignisse in <code>msg.events</code>.
         </dd>
-        <dt>Mit inaktivem Zeitplan starten</dt>
+        <dt>Beim Starten Nachrichten verzögern</dt>
         <dd>
-            Wenn aktiviert, wird der Zeitplan beim Starten des Knotens initial
-            deaktiviert.
+            Wenn aktiviert, werden alle Nachrichten, die zum Startzeitpunkt des
+            Knotens versendet werden sollen, um die angegebene Zeitspanne
+            verzögert (standardmäßig um 0,1 Sekunden).
         </dd>
     </dl>
     <h3>Eingabe</h3>

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -46,9 +46,9 @@ SOFTWARE.
         <dd>
             A reference to the configuration node to be used.
         </dd>
-        <dt>Schedule</dt>
+        <dt>Schedule tab</dt>
         <dd>
-            The list containing the scheduled events. New entries can be added
+            List containing the scheduled events. New entries can be added
             using the button below the list. Existing entries can be reordered
             or deleted. For each entry, a schedule time and an output can be
             configured:
@@ -110,6 +110,15 @@ SOFTWARE.
                 </li>
             </ul>
         </dd>
+        <dt>Options tab</dt>
+        <dd>
+            General options that can be configured and are described below.
+        </dd>
+        <dt>Start with disabled schedule</dt>
+        <dd>
+            If selected, the configured schedule will be initially disabled when
+            the node starts.
+        </dd>
         <dt>Dedicated output ports for schedule events</dt>
         <dd>
             If selected, for each event which produces a message as output, a
@@ -128,10 +137,10 @@ SOFTWARE.
             the next schedule event in <code>msg.payload</code> and an array
             with timestamps from all schedule events in <code>msg.events</code>.
         </dd>
-        <dt>Start with disabled schedule</dt>
+        <dt>Delay messages on start</dt>
         <dd>
-            If selected, the configured schedule will be initially disabled when
-            the node starts.
+            If selected, any message that is to be sent directly when the node
+            starts is delayed by the specified time (defaults to 0.1 seconds).
         </dd>
     </dl>
     <h3>Input</h3>


### PR DESCRIPTION
This pull request adds missing documentation for the option _Delay messages on start by X second(s)_ as well as documentation about the tabs to the online help of scheduler node.