### PR TITLE
Fix reload schedule using flow variable

### DIFF
--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -455,8 +455,7 @@ module.exports = function(RED)
                 if (validateFlatContextData(ctxData))
                 {
                     data.orig = {trigger: data.config.trigger};
-                    data.config.trigger.type = "auto:time";
-                    data.config.trigger.value = ctxData;
+                    data.config.trigger = {type: "auto:time", value: ctxData};
                 }
                 else if (validateFullStructuredContextData(ctxData))
                 {


### PR DESCRIPTION
This pull request fixes a bug where reloading a schedule trigger from context variables containing the time in basic or extended format did not work.

Resolves #212