### PR TITLE
Retrieve time zone from environment and (on-the-fly) from context

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -202,7 +202,7 @@ SOFTWARE.
 
                             if ((mode == "moment") && (item.action == "convert") && (item.tzType === "timeZone") && !item.tzValue)
                             {
-                                errors.push(this._("change.error.invalidTimeZone"));
+                                errors.push(this._("node-red-contrib-chronos/chronos-config:common.error.invalidTimeZone"));
                             }
 
                             if ((mode == "moment") && (item.action == "convert") && (item.tzType === "utcOffset") && !PATTERN_UTC_OFFSET.test(item.tzValue))

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -31,6 +31,7 @@ module.exports = function(RED)
         const node = this;
         RED.nodes.createNode(this, settings);
 
+        node.RED = RED;
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
@@ -44,7 +45,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!node.chronos.validateConfiguration(RED, node))
+        if (!node.chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -202,10 +203,8 @@ module.exports = function(RED)
                                             msg,
                                             rule.target,
                                             node.chronos.getTime(
-                                                    RED,
                                                     node,
                                                     node.chronos.getUserDate(
-                                                            RED,
                                                             node,
                                                             rule.date),
                                                     rule.time.type,
@@ -219,7 +218,7 @@ module.exports = function(RED)
 
                                         try
                                         {
-                                            expression = node.chronos.getJSONataExpression(RED, node, rule.expression);
+                                            expression = node.chronos.getJSONataExpression(node, rule.expression);
 
                                             // time change node specific JSONata extensions
                                             expression.assign("target", getValue(msg, rule.target.name, rule.target.type));
@@ -291,7 +290,6 @@ module.exports = function(RED)
                                 if ((typeof property == "number") || (typeof property == "string"))
                                 {
                                     input = node.chronos.getTime(
-                                                            RED,
                                                             node,
                                                             node.chronos.getCurrentTime(node),
                                                             (typeof property == "number")
@@ -434,7 +432,6 @@ module.exports = function(RED)
                                     (rule.time1.type == "now")
                                         ? now
                                         : node.chronos.retrieveTime(
-                                            RED,
                                             node,
                                             msg,
                                             now.clone(),
@@ -444,7 +441,6 @@ module.exports = function(RED)
                                     (rule.time2.type == "now")
                                         ? now
                                         : node.chronos.retrieveTime(
-                                            RED,
                                             node,
                                             msg,
                                             now.clone(),
@@ -459,7 +455,6 @@ module.exports = function(RED)
                                     {
                                         // shift time1 one day into the past
                                         time1 = node.chronos.retrieveTime(
-                                                                RED,
                                                                 node,
                                                                 msg,
                                                                 now.clone().subtract(1, "day"),
@@ -470,7 +465,6 @@ module.exports = function(RED)
                                     {
                                         // shift time2 one day into the future
                                         time2 = node.chronos.retrieveTime(
-                                                                RED,
                                                                 node,
                                                                 msg,
                                                                 now.clone().add(1, "day"),

--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -59,19 +59,19 @@ function validateCondition(node, cond)
     return true;
 }
 
-function convertCondition(RED, node, cond, num)
+function convertCondition(node, cond, num)
 {
     if ((typeof cond != "object") || !cond)
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Condition: Not an object or null"});
     }
 
     if (!/^(equal|notEqual|before|until|since|after|between|outside|days|weekdays|months|otherwise)$/.test(cond.operator))
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operator: Invalid value", value: cond.operator});
     }
 
@@ -82,7 +82,7 @@ function convertCondition(RED, node, cond, num)
         (cond.operator == "since") ||
         (cond.operator == "after"))
     {
-        validateOperand(RED, node, cond.operands, num);
+        validateOperand(node, cond.operands, num);
     }
 
     if ((cond.operator == "between") || (cond.operator == "outside"))
@@ -90,12 +90,12 @@ function convertCondition(RED, node, cond, num)
         if (!cond.operands || !Array.isArray(cond.operands) || (cond.operands.length != 2))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Not an array, invalid number of elements or null"});
         }
 
-        validateOperand(RED, node, cond.operands[0], num);
-        validateOperand(RED, node, cond.operands[1], num);
+        validateOperand(node, cond.operands[0], num);
+        validateOperand(node, cond.operands[1], num);
     }
 
     if (cond.operator == "days")
@@ -103,14 +103,14 @@ function convertCondition(RED, node, cond, num)
         if ((typeof cond.operands != "object") || !cond.operands)
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Not an object or null"});
         }
 
         if (!/^(first|second|third|fourth|fifth|last|even|specific)$/.test(cond.operands.type))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid type", value: cond.operands.type});
         }
 
@@ -118,7 +118,7 @@ function convertCondition(RED, node, cond, num)
             !/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday|day|workday|weekend)$/.test(cond.operands.day))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid day", value: cond.operands.day});
         }
 
@@ -126,7 +126,7 @@ function convertCondition(RED, node, cond, num)
             !/^(monday|tuesday|wednesday|thursday|friday|saturday|sunday|day)$/.test(cond.operands.day))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid day", value: cond.operands.day});
         }
 
@@ -136,14 +136,14 @@ function convertCondition(RED, node, cond, num)
             && !/^(january|february|march|april|may|june|july|august|september|october|november|december)$/.test(cond.operands.month))))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid day or month"});
         }
 
         if (typeof cond.operands.exclude != "boolean")
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid exclude", value: cond.operands.exclude});
         }
     }
@@ -153,7 +153,7 @@ function convertCondition(RED, node, cond, num)
         if ((typeof cond.operands != "object") || !cond.operands)
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Not an object or null"});
         }
 
@@ -166,7 +166,7 @@ function convertCondition(RED, node, cond, num)
             (("saturday" in cond.operands) && (typeof cond.operands.saturday != "boolean")))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid weekday property", value: cond.operands});
         }
     }
@@ -176,7 +176,7 @@ function convertCondition(RED, node, cond, num)
         if ((typeof cond.operands != "object") || !cond.operands)
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Not an object or null"});
         }
 
@@ -194,7 +194,7 @@ function convertCondition(RED, node, cond, num)
             (("december" in cond.operands) && (typeof cond.operands.december != "boolean")))
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                         {condition: num, error: "Operand: Invalid month property", value: cond.operands});
         }
     }
@@ -261,19 +261,19 @@ function convertCondition(RED, node, cond, num)
     return convCond;
 }
 
-function validateOperand(RED, node, operand, num)
+function validateOperand(node, operand, num)
 {
     if ((typeof operand != "object") || !operand)
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operand: Not an object or null"});
     }
 
     if (!/^(time|sun|moon|custom)$/.test(operand.type))
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operand: Invalid type", value: operand.type});
     }
 
@@ -283,14 +283,14 @@ function validateOperand(RED, node, operand, num)
         || ((operand.type == "moon") && !node.chronos.PATTERN_MOONTIME.test(operand.value)))
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operand: Invalid value", value: operand.value});
     }
 
     if (!node.chronos.validateOffset(operand))
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operand: Invalid offset", value: operand});
     }
 
@@ -298,12 +298,12 @@ function validateOperand(RED, node, operand, num)
         ((typeof operand.precision == "string") && !/^(millisecond|second|minute|hour|day|month|year)$/.test(operand.precision)))
     {
         throw new node.chronos.TimeError(
-                    RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
+                    node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidCondition"),
                     {condition: num, error: "Operand: Invalid precision", value: operand.precision});
     }
 }
 
-async function evaluateCondition(RED, node, msg, baseTime, cond, id)
+async function evaluateCondition(node, msg, baseTime, cond, id)
 {
     let result = false;
 
@@ -313,7 +313,7 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
 
         try
         {
-            expression = node.chronos.getJSONataExpression(RED, node, cond.expression);
+            expression = node.chronos.getJSONataExpression(node, cond.expression);
 
             // time switch/filter node specific JSONata extensions
             expression.assign("baseTime", baseTime.valueOf());
@@ -321,12 +321,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isSame", (ts, type, value, offset, random, precision) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "equal",
                                     operands: {
@@ -342,12 +340,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isBefore", (ts, type, value, offset, random, precision) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "before",
                                     operands: {
@@ -363,12 +359,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isAfter", async(ts, type, value, offset, random, precision) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "after",
                                     operands: {
@@ -384,12 +378,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isBetween", (ts, type1, value1, offset1, random1, precision1, type2, value2, offset2, random2, precision2) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "between",
                                     operands: [{
@@ -410,12 +402,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isOutside", (ts, type1, value1, offset1, random1, precision1, type2, value2, offset2, random2, precision2) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "outside",
                                     operands: [{
@@ -436,12 +426,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isFirstDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -455,12 +443,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isSecondDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -474,12 +460,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isThirdDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -493,12 +477,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isFourthDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -512,12 +494,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isFifthDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -531,12 +511,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isLastDay", (ts, day) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -550,12 +528,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isEvenDay", (ts) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -568,12 +544,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("isSpecificDay", (ts, day, month) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "days",
                                     operands: {
@@ -588,12 +562,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("matchesWeekdays", (ts, days) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "weekdays",
                                     operands: days},
@@ -604,12 +576,10 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("matchesMonths", (ts, months) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node, {
                                     operator: "months",
                                     operands: months},
@@ -620,19 +590,17 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
             expression.registerFunction("evaluateCondition", (ts, condition) =>
             {
                 return evalCondition(
-                            RED,
                             node,
                             msg,
                             node.chronos.getTimeFrom(node, ts),
                             convertCondition(
-                                RED,
                                 node,
                                 condition,
                                 id),
                             id);
             }, "<(sn)o:b>");
 
-            result = await node.chronos.evaluateJSONataExpression(RED, expression, msg);
+            result = await node.chronos.evaluateJSONataExpression(node.RED, expression, msg);
         }
         catch (e)
         {
@@ -648,26 +616,26 @@ async function evaluateCondition(RED, node, msg, baseTime, cond, id)
                     details.value = e.value;
                 }
 
-                throw new node.chronos.TimeError(RED._("node-red-contrib-chronos/chronos-config:common.error.evaluationFailed"), details);
+                throw new node.chronos.TimeError(node.RED._("node-red-contrib-chronos/chronos-config:common.error.evaluationFailed"), details);
             }
         }
 
         if (typeof result != "boolean")
         {
             throw new node.chronos.TimeError(
-                        RED._("node-red-contrib-chronos/chronos-config:common.error.notBoolean"),
+                        node.RED._("node-red-contrib-chronos/chronos-config:common.error.notBoolean"),
                         {condition: id, expression: cond.expression, result: result});
         }
     }
     else
     {
-        result = evalCondition(RED, node, msg, baseTime, cond, id);
+        result = evalCondition(node, msg, baseTime, cond, id);
     }
 
     return result;
 }
 
-function evalCondition(RED, node, msg, baseTime, cond, id)
+function evalCondition(node, msg, baseTime, cond, id)
 {
     let result = false;
 
@@ -679,7 +647,7 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
         {
             if (typeof cond.context.value == "string")
             {
-                ctxData = RED.util.evaluateNodeProperty(
+                ctxData = node.RED.util.evaluateNodeProperty(
                                         cond.context.value,
                                         cond.context.type,
                                         node);
@@ -691,17 +659,15 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
         }
         else
         {
-            const ctx = RED.util.parseContextStore(cond.context.value);
+            const ctx = node.RED.util.parseContextStore(cond.context.value);
             ctxData = node.context()[cond.context.type].get(ctx.key, ctx.store);
         }
 
         result = evalCondition(
-                    RED,
                     node,
                     msg,
                     baseTime,
                     convertCondition(
-                        RED,
                         node,
                         ctxData, id),
                     id);
@@ -716,7 +682,7 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
     {
         const precision = (cond.operands.precision == "millisecond") ? undefined : cond.operands.precision;
 
-        const targetTime = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands.type, cond.operands.value);
+        const targetTime = node.chronos.retrieveTime(node, msg, baseTime.clone(), cond.operands.type, cond.operands.value);
         targetTime.add(node.chronos.getRandomizedOffset(cond.operands.offset, cond.operands.random), "minutes");
 
         switch (cond.operator)
@@ -758,10 +724,10 @@ function evalCondition(RED, node, msg, baseTime, cond, id)
         const precision1 = (cond.operands[0].precision == "millisecond") ? undefined : cond.operands[0].precision;
         const precision2 = (cond.operands[1].precision == "millisecond") ? undefined : cond.operands[1].precision;
 
-        const time1 = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
+        const time1 = node.chronos.retrieveTime(node, msg, baseTime.clone(), cond.operands[0].type, cond.operands[0].value);
         time1.add(node.chronos.getRandomizedOffset(cond.operands[0].offset, cond.operands[0].random), "minutes");
 
-        const time2 = node.chronos.retrieveTime(RED, node, msg, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
+        const time2 = node.chronos.retrieveTime(node, msg, baseTime.clone(), cond.operands[1].type, cond.operands[1].value);
         time2.add(node.chronos.getRandomizedOffset(cond.operands[1].offset, cond.operands[1].random), "minutes");
 
         if (time1.isSame(time2, "day"))
@@ -953,7 +919,7 @@ function evaluateDateCondition(baseTime, cond)
     return result;
 }
 
-function getBaseTime(RED, node, msg)
+function getBaseTime(node, msg)
 {
     let ret = null;
 
@@ -969,13 +935,13 @@ function getBaseTime(RED, node, msg)
             case "global":
             case "flow":
             {
-                const ctx = RED.util.parseContextStore(node.baseTime);
+                const ctx = node.RED.util.parseContextStore(node.baseTime);
                 value = node.context()[node.baseTimeType].get(ctx.key, ctx.store);
                 break;
             }
             case "msg":
             {
-                value = RED.util.getMessageProperty(msg, node.baseTime);
+                value = node.RED.util.getMessageProperty(msg, node.baseTime);
                 break;
             }
         }

--- a/nodes/config.html
+++ b/nodes/config.html
@@ -49,7 +49,8 @@ SOFTWARE.
     </div>
     <div class="form-row">
         <label for="node-config-input-timezone"><i class="fa fa-globe"></i> <span data-i18n="config.label.timezone"></span></label>
-        <input type="text" id="node-config-input-timezone" data-i18n="[placeholder]config.label.hostTZ">
+        <input type="text" id="node-config-input-timezone" style="width: 70%;">
+        <input id="node-config-input-timezoneType" type="hidden">
     </div>
     <div class="form-row node-input-sunPositionList-row" style="padding-top: 10px">
         <label for="node-input-sunPositionList" style="width: auto;"><i class="fa fa-calendar-o"></i> <span data-i18n="config.label.sunPositions"></span></label>
@@ -60,336 +61,365 @@ SOFTWARE.
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType("chronos-config",
+    (function()
     {
-        category: "config",
-        icon:     "chronos_config.svg",
-        label:    function()
+        RED.nodes.registerType("chronos-config",
         {
-            return (this.name || ((this.credentials && this.credentials.latitude && this.credentials.longitude) ? (this.credentials.latitude + ", " + this.credentials.longitude) : this._("config.label.node")));
-        },
-        defaults:
-        {
-            name:
+            category: "config",
+            icon:     "chronos_config.svg",
+            label:    function()
             {
-                value: ""
+                return (this.name || ((this.credentials && (this.latitudeType == "num") && (this.longitudeType == "num") && this.credentials.latitude && this.credentials.longitude) ? (this.credentials.latitude + ", " + this.credentials.longitude) : this._("config.label.node")));
             },
-            latitudeType:
+            defaults:
             {
-                value: "num"
-            },
-            longitudeType:
-            {
-                value: "num"
-            },
-            timezone:
-            {
-                value: ""
-            },
-            sunPositions:
-            {
-                value: [],
-                validate: function(v)
+                name:
                 {
-                    if (v && (v.length > 0))
+                    value: ""
+                },
+                latitudeType:
+                {
+                    value: "num"
+                },
+                longitudeType:
+                {
+                    value: "num"
+                },
+                timezone:
+                {
+                    value: "",
+                    validate: function(v, opt)
                     {
-                        const EXP = /^[0-9a-zA-Z_]+$/;
-                        let valid = true;
-                        let names = [];
+                        let res = true;
 
-                        // check for invalid names
-                        for (let i=0; i<v.length; ++i)
+                        if ((this.timezoneType != "str") && !v)
                         {
-                            if (!EXP.test(v[i].riseName) || !EXP.test(v[i].setName))
-                            {
-                                valid = false;
-                                break;
-                            }
-
-                            names.push(v[i].riseName);
-                            names.push(v[i].setName);
-                            if (hasDuplicates(names))
-                            {
-                                valid = false;
-                                break;
-                            }
+                            res = opt ? this._("node-red-contrib-chronos/chronos-config:common.error.invalidTimeZone") : false;
                         }
 
-                        return valid;
+                        return res;
+                    }
+                },
+                timezoneType:
+                {
+                    value: "str"
+                },
+                sunPositions:
+                {
+                    value: [],
+                    validate: function(v)
+                    {
+                        if (v && (v.length > 0))
+                        {
+                            const EXP = /^[0-9a-zA-Z_]+$/;
+                            let valid = true;
+                            let names = [];
+
+                            // check for invalid names
+                            for (let i=0; i<v.length; ++i)
+                            {
+                                if (!EXP.test(v[i].riseName) || !EXP.test(v[i].setName))
+                                {
+                                    valid = false;
+                                    break;
+                                }
+
+                                names.push(v[i].riseName);
+                                names.push(v[i].setName);
+                                if (hasDuplicates(names))
+                                {
+                                    valid = false;
+                                    break;
+                                }
+                            }
+
+                            return valid;
+                        }
+                        else
+                        {
+                            return true;
+                        }
+
+                        function hasDuplicates(arr)
+                        {
+                            return arr.some(item =>
+                            {
+                                return (arr.indexOf(item) !== arr.lastIndexOf(item));
+                            });
+                        }
+                    }
+                }
+            },
+            credentials:
+            {
+                latitude:
+                {
+                    type: "text",
+                    value: ""
+                },
+                longitude:
+                {
+                    type: "text",
+                    value: ""
+                }
+            },
+            oneditprepare: function()
+            {
+                const node = this;
+
+                let latitude = undefined;
+                let longitude = undefined;
+                let noMapUpdate = false;
+
+                const latitudeInput = $("#node-config-input-latitude")
+                                        .typedInput({types: ["num", "env", "global"], typeField: "#node-config-input-latitudeType"});
+                const longitudeInput = $("#node-config-input-longitude")
+                                        .typedInput({types: ["num", "env", "global"], typeField: "#node-config-input-longitudeType"});
+
+                const timezoneInput = $("#node-config-input-timezone")
+                                        .typedInput({types: ["str", "env", "global"], typeField: "#node-config-input-timezoneType"});
+
+                const updateMap = function(force = false)
+                {
+                    let prevLatitude = latitude;
+                    let prevLongitude = longitude;
+
+                    if (latitudeInput.typedInput("type") == "num")
+                    {
+                        latitude = parseFloat(latitudeInput.typedInput("value"));
+                    }
+                    else if (latitudeInput.typedInput("type") == "env")
+                    {
+                        $.getJSON(
+                            "chronos_config", {
+                                command: "getenv",
+                                varname: latitudeInput.typedInput("value")})
+                                .done(result =>
+                        {
+                            latitude = parseFloat(result);
+
+                            if ((latitude != prevLatitude) || (longitude != prevLongitude))
+                            {
+                                relocateMap();
+                            }
+                        });
+                    }
+                    else if (latitudeInput.typedInput("type") == "global")
+                    {
+                        latitude = undefined;
+                    }
+
+                    if (longitudeInput.typedInput("type") == "num")
+                    {
+                        longitude = parseFloat(longitudeInput.typedInput("value"));
+                    }
+                    else if (longitudeInput.typedInput("type") == "env")
+                    {
+                        $.getJSON(
+                            "chronos_config", {
+                                command: "getenv",
+                                varname: longitudeInput.typedInput("value")})
+                                .done(result =>
+                        {
+                            longitude = parseFloat(result);
+
+                            if ((latitude != prevLatitude) || (longitude != prevLongitude))
+                            {
+                                relocateMap();
+                            }
+                        });
+                    }
+                    else if (longitudeInput.typedInput("type") == "global")
+                    {
+                        longitude = undefined;
+                    }
+
+                    if ((latitude != prevLatitude) || (longitude != prevLongitude) || force)
+                    {
+                        relocateMap();
+                    }
+                };
+
+                const relocateMap = function()
+                {
+                    const map = $("#node-config-input-map");
+
+                    if ((latitude !== undefined) && (longitude !== undefined) &&
+                        !Number.isNaN(latitude) && !Number.isNaN(longitude))
+                    {
+                        map.attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
+                                            + (longitude - 0.001) + ","
+                                            + (latitude - 0.001) + ","
+                                            + (longitude + 0.001) + ","
+                                            + (latitude + 0.001)
+                                            + "&layer=mapnik&marker="
+                                            + latitude + ","
+                                            + longitude);
+                        map.show();
                     }
                     else
                     {
-                        return true;
+                        map.hide();
                     }
+                };
 
-                    function hasDuplicates(arr)
+                const validateInput = function(event, ui)
+                {
+                    if (/^(\+|-)?\d+(\.\d+)?$/.test($(this).spinner("value")))
                     {
-                        return arr.some(item =>
+                        let value = parseFloat($(this).spinner("value"));
+                        let min = $(this).spinner("option", "min");
+                        let max = $(this).spinner("option", "max");
+
+                        if (value < min)
                         {
-                            return (arr.indexOf(item) !== arr.lastIndexOf(item));
+                            $(this).spinner("value", min);
+                        }
+                        else if (value > max)
+                        {
+                            $(this).spinner("value", max);
+                        }
+                    }
+                    else
+                    {
+                        $(this).spinner("value", 0);
+                    }
+                };
+
+                const sunAngleInput =
+                {
+                    min: -90,
+                    max: 90,
+                    step: 0.001,
+                    numberFormat: "n",
+                    change: validateInput
+                };
+
+                if (navigator.geolocation)
+                {
+                    $("#node-config-input-locationDetection").click(function()
+                    {
+                        navigator.geolocation.getCurrentPosition(pos =>
+                        {
+                            noMapUpdate = true;
+                            latitudeInput.typedInput("value", pos.coords.latitude);
+                            longitudeInput.typedInput("value", pos.coords.longitude);
+                            latitudeInput.typedInput("type", "num");
+                            longitudeInput.typedInput("type", "num");
+                            noMapUpdate = false;
+
+                            updateMap();
                         });
-                    }
-                }
-            }
-        },
-        credentials:
-        {
-            latitude:
-            {
-                type: "text",
-                value: "",
-                required: true
-            },
-            longitude:
-            {
-                type: "text",
-                value: "",
-                required: true
-            }
-        },
-        oneditprepare: function()
-        {
-            let node = this;
-            let latitude = undefined;
-            let longitude = undefined;
-            let noMapUpdate = false;
-
-            let latitudeInput = $("#node-config-input-latitude")
-                                    .typedInput({types: ["num", "env", "global"], typeField: "#node-config-input-latitudeType"});
-            let longitudeInput = $("#node-config-input-longitude")
-                                    .typedInput({types: ["num", "env", "global"], typeField: "#node-config-input-longitudeType"});
-
-            const updateMap = function()
-            {
-                let prevLatitude = latitude;
-                let prevLongitude = longitude;
-
-                if (latitudeInput.typedInput("type") == "num")
-                {
-                    latitude = parseFloat(latitudeInput.typedInput("value"));
+                    });
                 }
                 else
                 {
-                    $.getJSON(
-                        "chronos_config", {
-                            command: "getenv",
-                            varname: latitudeInput.typedInput("value")})
-                            .done(result =>
-                    {
-                        latitude = parseFloat(result);
+                    $("#node-config-input-locationDetection").hide();
+                }
 
-                        if ((latitude != prevLatitude) || (longitude != prevLongitude))
+                updateMap(true);
+
+                let sunPositionList = $("#node-input-sunPositionList").css("min-width", "500px").css("min-height", "150px").editableList(
+                {
+                    removable: true,
+                    sortable: true,
+                    addItem: function(item, index, data)
+                    {
+                        const fragment = document.createDocumentFragment();
+
+                        const angleLabel = $("<label/>", {style: "width: auto; margin-left: 5px; margin-bottom: 0px;"})
+                                            .text(node._("config.label.angle") + " ")
+                                            .appendTo(fragment);
+                        const angle = $("<input/>", {class: "node-input-angle", style: "width: 60px !important; margin-left: 4px;"})
+                                            .appendTo(angleLabel)
+                                            .spinner(sunAngleInput);
+                        const riseLabel = $("<label/>", {title: node._("config.label.riseName"), style: "width: auto; margin-left: 12px; margin-bottom: 0px;"})
+                                            .html("<i class='fa fa-arrow-up' aria-hidden='true'></i>")
+                                            .appendTo(fragment);
+                        const riseName = $("<input/>", {type: "text", class: "node-input-riseName", placeholder: node._("config.label.riseName"), style: "width: 110px; margin-left: 4px;"})
+                                            .appendTo(riseLabel);
+                        const setLabel = $("<label/>", {title: node._("config.label.setName"), style: "width: auto; margin-left: 12px; margin-bottom: 0px;"})
+                                            .html("<i class='fa fa-arrow-down' aria-hidden='true'></i>")
+                                            .appendTo(fragment);
+                        const setName = $("<input/>", {type: "text", class: "node-input-setName", placeholder: node._("config.label.setName"), style: "width: 110px; margin-left: 4px;"})
+                                            .appendTo(setLabel);
+
+                        if (!("angle" in data))
                         {
-                            relocateMap();
+                            data = {angle: 0, riseName: "", setName: ""};
                         }
-                    });
-                }
 
-                if (longitudeInput.typedInput("type") == "num")
-                {
-                    longitude = parseFloat(longitudeInput.typedInput("value"));
-                }
-                else
-                {
-                    $.getJSON(
-                        "chronos_config", {
-                            command: "getenv",
-                            varname: longitudeInput.typedInput("value")})
-                            .done(result =>
-                    {
-                        longitude = parseFloat(result);
+                        angle.spinner("value", data.angle);
+                        riseName.val(data.riseName);
+                        setName.val(data.setName);
 
-                        if ((latitude != prevLatitude) || (longitude != prevLongitude))
-                        {
-                            relocateMap();
-                        }
-                    });
-                }
-
-                if ((latitude != prevLatitude) || (longitude != prevLongitude))
-                {
-                    relocateMap();
-                }
-            };
-
-            const relocateMap = function()
-            {
-                let map = $("#node-config-input-map");
-
-                if (!Number.isNaN(latitude) && !Number.isNaN(longitude))
-                {
-                    map.attr("src", "https://www.openstreetmap.org/export/embed.html?bbox="
-                                        + (longitude - 0.001) + ","
-                                        + (latitude - 0.001) + ","
-                                        + (longitude + 0.001) + ","
-                                        + (latitude + 0.001)
-                                        + "&layer=mapnik&marker="
-                                        + latitude + ","
-                                        + longitude);
-                    map.show();
-                }
-                else
-                {
-                    map.hide();
-                }
-            };
-
-            const validateInput = function(event, ui)
-            {
-                if (/^(\+|-)?\d+(\.\d+)?$/.test($(this).spinner("value")))
-                {
-                    let value = parseFloat($(this).spinner("value"));
-                    let min = $(this).spinner("option", "min");
-                    let max = $(this).spinner("option", "max");
-
-                    if (value < min)
-                    {
-                        $(this).spinner("value", min);
+                        item[0].appendChild(fragment);
                     }
-                    else if (value > max)
-                    {
-                        $(this).spinner("value", max);
-                    }
-                }
-                else
-                {
-                    $(this).spinner("value", 0);
-                }
-            };
-
-            const sunAngleInput =
-            {
-                min: -90,
-                max: 90,
-                step: 0.001,
-                numberFormat: "n",
-                change: validateInput
-            };
-
-            if (navigator.geolocation)
-            {
-                $("#node-config-input-locationDetection").click(function()
-                {
-                    navigator.geolocation.getCurrentPosition(pos =>
-                    {
-                        noMapUpdate = true;
-                        latitudeInput.typedInput("value", pos.coords.latitude);
-                        longitudeInput.typedInput("value", pos.coords.longitude);
-                        latitudeInput.typedInput("type", "num");
-                        longitudeInput.typedInput("type", "num");
-                        noMapUpdate = false;
-
-                        updateMap();
-                    });
                 });
-            }
-            else
-            {
-                $("#node-config-input-locationDetection").hide();
-            }
 
-            updateMap();
-
-            let sunPositionList = $("#node-input-sunPositionList").css("min-width", "500px").css("min-height", "150px").editableList(
-            {
-                removable: true,
-                sortable: true,
-                addItem: function(item, index, data)
+                latitudeInput.on("change", function(event, type, value)
                 {
-                    let fragment = document.createDocumentFragment();
-
-                    let angleLabel = $("<label/>", {style: "width: auto; margin-left: 5px; margin-bottom: 0px;"})
-                                        .text(node._("config.label.angle") + " ")
-                                        .appendTo(fragment);
-                    let angle = $("<input/>", {class: "node-input-angle", style: "width: 60px !important; margin-left: 4px;"})
-                                        .appendTo(angleLabel)
-                                        .spinner(sunAngleInput);
-                    let riseLabel = $("<label/>", {title: node._("config.label.riseName"), style: "width: auto; margin-left: 12px; margin-bottom: 0px;"})
-                                        .html("<i class='fa fa-arrow-up' aria-hidden='true'></i>")
-                                        .appendTo(fragment);
-                    let riseName = $("<input/>", {type: "text", class: "node-input-riseName", placeholder: node._("config.label.riseName"), style: "width: 110px; margin-left: 4px;"})
-                                        .appendTo(riseLabel);
-                    let setLabel = $("<label/>", {title: node._("config.label.setName"), style: "width: auto; margin-left: 12px; margin-bottom: 0px;"})
-                                        .html("<i class='fa fa-arrow-down' aria-hidden='true'></i>")
-                                        .appendTo(fragment);
-                    let setName = $("<input/>", {type: "text", class: "node-input-setName", placeholder: node._("config.label.setName"), style: "width: 110px; margin-left: 4px;"})
-                                        .appendTo(setLabel);
-
-                    if (!("angle" in data))
+                    if (!noMapUpdate)
                     {
-                        data = {angle: 0, riseName: "", setName: ""};
+                        updateMap();
                     }
+                });
 
-                    angle.spinner("value", data.angle);
-                    riseName.val(data.riseName);
-                    setName.val(data.setName);
-
-                    item[0].appendChild(fragment);
-                }
-            });
-
-            latitudeInput.on("change", function(event, type, value)
-            {
-                if (!noMapUpdate)
+                longitudeInput.on("change", function(event, type, value)
                 {
-                    updateMap();
-                }
-            });
+                    if (!noMapUpdate)
+                    {
+                        updateMap();
+                    }
+                });
 
-            longitudeInput.on("change", function(event, type, value)
-            {
-                if (!noMapUpdate)
+                if (!node.sunPositions)  // backward compatibility to v1.1.0
                 {
-                    updateMap();
+                    node.sunPositions = [];
                 }
-            });
 
-            if (!node.sunPositions)  // backward compatibility to v1.1.0
+                node.sunPositions.forEach(data =>
+                {
+                    sunPositionList.editableList("addItem", data);
+                });
+            },
+            oneditsave: function()
             {
+                const node = this;
+                const sunPositionList = $("#node-input-sunPositionList").editableList("items");
+
                 node.sunPositions = [];
+                sunPositionList.each(function(index)
+                {
+                    const data = {};
+
+                    const angle = $(this).find(".node-input-angle");
+                    const riseName = $(this).find(".node-input-riseName");
+                    const setName = $(this).find(".node-input-setName");
+
+                    data.angle = angle.spinner("value");
+                    data.riseName = riseName.val();
+                    data.setName = setName.val();
+
+                    node.sunPositions.push(data);
+                });
+            },
+            oneditresize: function(size)
+            {
+                let height = size.height;
+                const sunPositionListRow = $("#node-config-dialog-edit-form>div.node-input-sunPositionList-row");
+                const otherRows = $("#node-config-dialog-edit-form>div:not(.node-input-sunPositionList-row)");
+
+                for (let i=0; i<otherRows.length; ++i)
+                {
+                    height -= $(otherRows[i]).outerHeight(true);
+                }
+
+                height -= (parseInt(sunPositionListRow.css("marginTop")) + parseInt(sunPositionListRow.css("marginBottom")));
+                height -= $("#node-config-dialog-edit-form>div.node-input-sunPositionList-row>label").outerHeight(true);
+
+                $("#node-input-sunPositionList").editableList("height", height);
             }
-
-            node.sunPositions.forEach(data =>
-            {
-                sunPositionList.editableList("addItem", data);
-            });
-        },
-        oneditsave: function()
-        {
-            let node = this;
-            let sunPositionList = $("#node-input-sunPositionList").editableList("items");
-
-            node.sunPositions = [];
-            sunPositionList.each(function(index)
-            {
-                let data = {};
-
-                let angle = $(this).find(".node-input-angle");
-                let riseName = $(this).find(".node-input-riseName");
-                let setName = $(this).find(".node-input-setName");
-
-                data.angle = angle.spinner("value");
-                data.riseName = riseName.val();
-                data.setName = setName.val();
-
-                node.sunPositions.push(data);
-            });
-        },
-        oneditresize: function(size)
-        {
-            let height = size.height;
-            let sunPositionListRow = $("#node-config-dialog-edit-form>div.node-input-sunPositionList-row");
-            let otherRows = $("#node-config-dialog-edit-form>div:not(.node-input-sunPositionList-row)");
-
-            for (let i=0; i<otherRows.length; ++i)
-            {
-                height -= $(otherRows[i]).outerHeight(true);
-            }
-
-            height -= (parseInt(sunPositionListRow.css("marginTop")) + parseInt(sunPositionListRow.css("marginBottom")));
-            height -= $("#node-config-dialog-edit-form>div.node-input-sunPositionList-row>label").outerHeight(true);
-
-            $("#node-input-sunPositionList").editableList("height", height);
-        }
-    });
+        });
+    })();
 </script>

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -39,8 +39,25 @@ module.exports = function(RED)
 
         RED.nodes.createNode(this, config);
 
+        this.RED = RED;
         this.name = config.name;
-        this.timezone = config.timezone;
+
+        if (config.timezoneType == "env")
+        {
+            this.timezone = RED.util.evaluateNodeProperty(
+                                        config.timezone,
+                                        config.timezoneType,
+                                        this);
+        }
+        else
+        {
+            this.timezone = config.timezone;
+        }
+
+        this.tzFromContext =
+            (config.timezoneType == "global")
+                ? true
+                : false;
 
         if (config.latitudeType === "global")
         {

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -42,6 +42,7 @@ module.exports = function(RED)
         let node = this;
         RED.nodes.createNode(node, settings);
 
+        node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
@@ -101,7 +102,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!chronos.validateConfiguration(RED, node))
+        if (!chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -141,7 +142,7 @@ module.exports = function(RED)
         {
             try
             {
-                node.expression = chronos.getJSONataExpression(RED, node, node.customDelayValue);
+                node.expression = chronos.getJSONataExpression(node, node.customDelayValue);
             }
             catch(e)
             {
@@ -537,7 +538,7 @@ module.exports = function(RED)
 
             const now = chronos.getCurrentTime(node);
 
-            node.sendTime = chronos.getTime(RED, node, now.clone(), type, value);
+            node.sendTime = chronos.getTime(node, now.clone(), type, value);
             node.sendTime.add(chronos.getRandomizedOffset(offset, random), "minutes");
 
             if (node.sendTime.isBefore(now))
@@ -550,7 +551,7 @@ module.exports = function(RED)
                 }
                 else
                 {
-                    node.sendTime = chronos.getTime(RED, node, node.sendTime.add(1, "days"), type, value);
+                    node.sendTime = chronos.getTime(node, node.sendTime.add(1, "days"), type, value);
                     node.sendTime.add(chronos.getRandomizedOffset(offset, random), "minutes");
                 }
             }

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -31,6 +31,7 @@ module.exports = function(RED)
         let node = this;
         RED.nodes.createNode(this, settings);
 
+        node.RED = RED;
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
@@ -44,7 +45,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!node.chronos.validateConfiguration(RED, node))
+        if (!node.chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -143,7 +144,7 @@ module.exports = function(RED)
                     return;
                 }
 
-                let baseTime = sfUtils.getBaseTime(RED, node, msg);
+                let baseTime = sfUtils.getBaseTime(node, msg);
                 if (baseTime)
                 {
                     node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
@@ -155,7 +156,7 @@ module.exports = function(RED)
                     {
                         try
                         {
-                            result = await sfUtils.evaluateCondition(RED, node, msg, baseTime, node.conditions[i], i+1);
+                            result = await sfUtils.evaluateCondition(node, msg, baseTime, node.conditions[i], i+1);
                         }
                         catch (e)
                         {

--- a/nodes/locales/de/change.json
+++ b/nodes/locales/de/change.json
@@ -77,7 +77,6 @@
             "noTasks":           "Keine Regeln kongiguriert",
             "invalidProperty":   "Ungültige Eigenschaft angegeben: __property__",
             "invalidFormat":     "Ungültiges Format",
-            "invalidTimeZone":   "Ungültige Zeitzone",
             "invalidUTCOffset":  "Ungültiger UTC-Versatz",
             "invalidPrecision":  "Ungültige Genauigkeit der Fließkommazahl",
             "invalidNumber":     "Ungültige Zahl"

--- a/nodes/locales/de/config.html
+++ b/nodes/locales/de/config.html
@@ -73,9 +73,11 @@ SOFTWARE.
     <dt>Zeitzone</dt>
     <dd>
         <p>
-            Der Name einer <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">internationalen Zeitzone</a>.
-            Wenn nicht angegeben, wird die konfigurierte Zeitzone des Hosts
-            verwendet, auf dem Node-RED ausgeführt wird.
+            Der Name einer <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">internationalen Zeitzone</a>
+            oder der Name einer Umgebungs- oder globalen Kontextvariablen,
+            die die Zeitzone enthält. Wenn nicht angegeben, wird die
+            konfigurierte Zeitzone des Hosts verwendet, auf dem Node-RED
+            ausgeführt wird.
         </p>
         <p>
             <b>Hinweis:</b> Es findet keine automatische Berechnung der Zeitzone

--- a/nodes/locales/de/config.json
+++ b/nodes/locales/de/config.json
@@ -189,6 +189,7 @@
             "invalidTime":         "Ungültige Uhrzeit",
             "invalidDate":         "Ungültiges Datum",
             "invalidCoordinate":   "Ungültige Positionskoordinate",
+            "invalidTimeZone":     "Ungültige Zeitzone",
             "invalidBaseTime":     "Ungültige Basiszeit: __baseTime__",
             "invalidCondition":    "Ungültige Bedingung",
             "invalidName":         "Ungültiger benutzerdefinierter Sonnenstand",

--- a/nodes/locales/en-US/change.json
+++ b/nodes/locales/en-US/change.json
@@ -77,7 +77,6 @@
             "noTasks":           "No rules configured",
             "invalidProperty":   "Invalid property specified: __property__",
             "invalidFormat":     "Invalid format",
-            "invalidTimeZone":   "Invalid time zone",
             "invalidUTCOffset":  "Invalid UTC offset",
             "invalidPrecision":  "Invalid floating point precision",
             "invalidNumber":     "Invalid number"

--- a/nodes/locales/en-US/config.html
+++ b/nodes/locales/en-US/config.html
@@ -68,9 +68,10 @@ SOFTWARE.
     <dt>Time Zone</dt>
     <dd>
         <p>
-            The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>.
-            If omitted, the time zone configured on the host which runs Node-RED
-            is used.
+            The name of a valid <a href="https://en.wikipedia.org/wiki/List_of_tz_database_time_zones">time zone identifier</a>
+            or the name of an environment or global context variable containing
+            the time zone identifier. If omitted, the time zone configured on
+            the host which runs Node-RED is used.
         </p>
         <p>
             <b>Note:</b> A programmatic calculation of the time zone from the

--- a/nodes/locales/en-US/config.json
+++ b/nodes/locales/en-US/config.json
@@ -189,6 +189,7 @@
             "invalidTime":         "Invalid time",
             "invalidDate":         "Invalid date",
             "invalidCoordinate":   "Invalid location coordinate",
+            "invalidTimeZone":     "Invalid time zone",
             "invalidBaseTime":     "Invalid base time: __baseTime__",
             "invalidCondition":    "Invalid condition",
             "invalidName":         "Invalid custom sun position",

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -35,6 +35,7 @@ module.exports = function(RED)
         const node = this;
         RED.nodes.createNode(node, settings);
 
+        node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
@@ -78,7 +79,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!chronos.validateConfiguration(RED, node))
+        if (!chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -119,7 +120,7 @@ module.exports = function(RED)
         {
             try
             {
-                node.expression = chronos.getJSONataExpression(RED, node, node.customRepetitionValue);
+                node.expression = chronos.getJSONataExpression(node, node.customRepetitionValue);
             }
             catch(e)
             {
@@ -134,7 +135,7 @@ module.exports = function(RED)
         {
             try
             {
-                node.untilExpression = chronos.getJSONataExpression(RED, node, node.untilValue);
+                node.untilExpression = chronos.getJSONataExpression(node, node.untilValue);
             }
             catch(e)
             {
@@ -521,9 +522,9 @@ module.exports = function(RED)
             }
             else
             {
-                const base = date ? chronos.getUserDate(RED, node, date) : now.clone();
+                const base = date ? chronos.getUserDate(node, date) : now.clone();
 
-                ret.time = chronos.getTime(RED, node, base, type, value);
+                ret.time = chronos.getTime(node, base, type, value);
                 ret.time.add(chronos.getRandomizedOffset(offset, random), "minutes");
 
                 if (!date && !ret.time.hasUserDate() && ret.time.isBefore(now))
@@ -534,7 +535,7 @@ module.exports = function(RED)
                     }
                     else
                     {
-                        ret.time = chronos.getTime(RED, node, ret.time.add(1, "days"), type, value);
+                        ret.time = chronos.getTime(node, ret.time.add(1, "days"), type, value);
                         ret.time.add(chronos.getRandomizedOffset(offset, random), "minutes");
                     }
                 }

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -32,6 +32,7 @@ module.exports = function(RED)
         const node = this;
         RED.nodes.createNode(node, settings);
 
+        node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
@@ -47,7 +48,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!chronos.validateConfiguration(RED, node))
+        if (!chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -134,7 +135,7 @@ module.exports = function(RED)
                     {
                         try
                         {
-                            data.expression = chronos.getJSONataExpression(RED, node, data.config.output.value);
+                            data.expression = chronos.getJSONataExpression(node, data.config.output.value);
                         }
                         catch (e)
                         {
@@ -165,7 +166,7 @@ module.exports = function(RED)
                     {
                         try
                         {
-                            data.expression = chronos.getJSONataExpression(RED, node, data.config.output.property.value);
+                            data.expression = chronos.getJSONataExpression(node, data.config.output.property.value);
                         }
                         catch (e)
                         {
@@ -577,7 +578,7 @@ module.exports = function(RED)
                 else
                 {
                     const now = chronos.getCurrentTime(node);
-                    data.triggerTime = chronos.getTime(RED, node, repeat ? now.clone().add(1, "days") : now.clone(), data.config.trigger.type, data.config.trigger.value);
+                    data.triggerTime = chronos.getTime(node, repeat ? now.clone().add(1, "days") : now.clone(), data.config.trigger.type, data.config.trigger.value);
 
                     if (typeof data.config.trigger.offset == "number")
                     {
@@ -595,7 +596,7 @@ module.exports = function(RED)
                         }
                         else
                         {
-                            data.triggerTime = chronos.getTime(RED, node, data.triggerTime.add(1, "days"), data.config.trigger.type, data.config.trigger.value);
+                            data.triggerTime = chronos.getTime(node, data.triggerTime.add(1, "days"), data.config.trigger.type, data.config.trigger.value);
 
                             if (typeof data.config.trigger.offset == "number")
                             {
@@ -777,10 +778,7 @@ module.exports = function(RED)
 
             if (type)
             {
-                ret = await chronos.evaluateNodeProperty(
-                                        RED, node,
-                                        value, type,
-                                        {});
+                ret = await chronos.evaluateNodeProperty(node, value, type, {});
             }
             else
             {

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -32,6 +32,7 @@ module.exports = function(RED)
         const node = this;
         RED.nodes.createNode(node, settings);
 
+        node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
         node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
@@ -44,7 +45,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!chronos.validateConfiguration(RED, node))
+        if (!chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -109,7 +110,7 @@ module.exports = function(RED)
             {
                 try
                 {
-                    node.outputValue = chronos.getJSONataExpression(RED, node, settings.outputValue);
+                    node.outputValue = chronos.getJSONataExpression(node, settings.outputValue);
                 }
                 catch (e)
                 {
@@ -354,7 +355,7 @@ module.exports = function(RED)
                                 {
                                     try
                                     {
-                                        node.conditions[i] = sfUtils.convertCondition(RED, node, msg.payload.conditions[i], i+1);
+                                        node.conditions[i] = sfUtils.convertCondition(node, msg.payload.conditions[i], i+1);
                                         reset = true;
                                     }
                                     catch (e)
@@ -605,7 +606,7 @@ module.exports = function(RED)
                     {
                         try
                         {
-                            let triggerTime = chronos.getTime(RED, node, baseTime.clone(), data.trigger.type, data.trigger.value);
+                            let triggerTime = chronos.getTime(node, baseTime.clone(), data.trigger.type, data.trigger.value);
 
                             if ((data.trigger.offset != 0) && (!data.trigger.random || !ignoreRandomOffset))
                             {
@@ -839,7 +840,7 @@ module.exports = function(RED)
                 if (node.currentState.data.state.type)
                 {
                     value = await chronos.evaluateNodeProperty(
-                                            RED, node,
+                                            node,
                                             node.currentState.data.state.value,
                                             node.currentState.data.state.type,
                                             {});

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -31,6 +31,7 @@ module.exports = function(RED)
         let node = this;
         RED.nodes.createNode(this, settings);
 
+        node.RED = RED;
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
@@ -44,7 +45,7 @@ module.exports = function(RED)
             return;
         }
 
-        if (!node.chronos.validateConfiguration(RED, node))
+        if (!node.chronos.validateConfiguration(node))
         {
             node.status({fill: "red", shape: "dot", text: "node-red-contrib-chronos/chronos-config:common.status.invalidConfig"});
             node.error(RED._("node-red-contrib-chronos/chronos-config:common.error.invalidConfig"));
@@ -128,7 +129,7 @@ module.exports = function(RED)
                     return;
                 }
 
-                let baseTime = sfUtils.getBaseTime(RED, node, msg);
+                let baseTime = sfUtils.getBaseTime(node, msg);
                 if (baseTime)
                 {
                     node.debug("Base time: " + baseTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
@@ -153,7 +154,7 @@ module.exports = function(RED)
                                 node.debug("[Condition:" + (i+1) + "] Otherwise");
                                 otherwiseIndex = i;
                             }
-                            else if (await sfUtils.evaluateCondition(RED, node, msg, baseTime, cond, i+1))
+                            else if (await sfUtils.evaluateCondition(node, msg, baseTime, cond, i+1))
                             {
                                 ports[i] = true;
                                 numMatches++;


### PR DESCRIPTION
This pull request adds the possibility to specify the time zone as environment or global context variable. When specified as global context variable, the time zone will be retrieved on-the-fly when needed which makes it possible to change the time zone at any time.

Additionally, the three new JSONata functions `$getLatitude()`, `$getLongitude()` and `$getTimeZone()` have been added. These functions must be used particularly if the latitude, longitude or time zone have been configured as global context variable as the corresponding members from the JSONata variable `$config` are set to `null` in this case.

Resolves #219