### PR TITLE
Retrieve time zone from environment and (on-the-fly) from context (fix)

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -98,22 +98,24 @@ function initCustomTimes(times)
 
 function validateTimeZone(node)
 {
-    try
+    if (node.config.tzFromContext)
     {
-        const tz = getTimeZone(node);
-        if (tz)
+        // only check for non-empty key in case of context variable
+        const ctx = node.RED.util.parseContextStore(node.config.timezone);
+        if (!ctx.key)
         {
-            return (moment.tz.zone(tz) != null);
+            return false;
         }
-        else
-        {
-            return true;
-        }
+
+        return true;
     }
-    catch
+
+    if (node.config.timezone)
     {
-        return false;
+        return (moment.tz.zone(node.config.timezone) != null);
     }
+
+    return true;
 }
 
 function printNodeInfo(node)


### PR DESCRIPTION
Small fix for pull request #223 to not validate a global context variable containing the time zone at node start as the context variable might not yet exist at that time.