### PR TITLE
Bump version to 1.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # node-red-contrib-chronos
 
 <a href="https://www.npmjs.com/package/node-red-contrib-chronos"><img title="npm version" src="https://badgen.net/npm/v/node-red-contrib-chronos"></a>
-<a href="https://www.npmjs.com/package/node-red-contrib-chronos"><img title="npm downloads" src="https://badgen.net/npm/dt/node-red-contrib-chronos"></a>
+<a href="https://www.npmjs.com/package/node-red-contrib-chronos"><img title="npm downloads" src="https://badgen.net/npm/dw/node-red-contrib-chronos"></a>
 
 A collection of Node-RED nodes for date and time based scheduling, repeating, queueing, routing, filtering and manipulating. Automatically calculated times from sun events (sunrise, sunset, dusk, dawn, ...) or moon events (moonrise, moonset) are supported as well.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.27.0",
+    "version": "1.28.0",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -44,12 +44,12 @@
     "dependencies": {
         "cronosjs": "^1.7.1",
         "moment": "^2.30.1",
-        "moment-timezone": "^0.5.47",
+        "moment-timezone": "^0.5.48",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^9.22.0",
+        "eslint": "^9.25.0",
         "jsonata": "^2.0.6",
         "mocha": "^11.1.0",
         "node-red": "^4.0.9",
@@ -57,7 +57,7 @@
         "nyc": "^17.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^19.0.2"
+        "sinon": "^20.0.0"
     },
     "main": "none",
     "scripts": {


### PR DESCRIPTION
This pull request bumps the node-red-contrib-chronos component version to 1.28.0. Additionally it updates dependencies to latest versions as far as possible and changes the downloads counter to weekly downloads instead of total downloads.