### PR TITLE
Two events fired when defining an event for 0:00 a.m.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,17 +19,18 @@ module.exports =
         ignores: ["test/**"],
         rules:
         {
-            "no-trailing-spaces":   "error",
-            "no-lonely-if":         "error",
-            "no-tabs":              "error",
-            "new-cap":              "error",
-            "space-in-parens":      "error",
-            "space-unary-ops":      "error",
-            "semi-spacing":         "error",
-            "func-call-spacing":    "error",
-            "switch-colon-spacing": "error",
-            "arrow-spacing":        "error",
-            "camelcase":            "error",
+            "multiline-comment-style": "off",
+            "no-trailing-spaces":      "error",
+            "no-lonely-if":            "error",
+            "no-tabs":                 "error",
+            "new-cap":                 "error",
+            "space-in-parens":         "error",
+            "space-unary-ops":         "error",
+            "semi-spacing":            "error",
+            "func-call-spacing":       "error",
+            "switch-colon-spacing":    "error",
+            "arrow-spacing":           "error",
+            "camelcase":               "error",
             "indent":
             [
                 "error", 4,
@@ -88,11 +89,6 @@ module.exports =
             [
                 "error",
                 "unix"
-            ],
-            "multiline-comment-style":
-            [
-                "error",
-                "starred-block"
             ],
             "spaced-comment":
             [

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -794,9 +794,13 @@ module.exports = function(RED)
                     cancelTimer();
 
                     node.debug("[State:" + state.data.id + "] Starting timer for trigger at " + state.triggerTime.format("YYYY-MM-DD HH:mm:ss (Z)"));
+
+                    const now = chronos.getCurrentTime(node);
+                    const delay = state.triggerTime.diff(now);
+
                     node.currentState.timer = setTimeout(async() =>
                     {
-                        node.trace("[State:" + state.data.id + "] Timer with ID " + node.currentState.timer + " expired");
+                        node.debug("[State:" + state.data.id + "] Timer with ID " + node.currentState.timer + " expired");
                         delete node.currentState.timer;
 
                         if (await evalConditions(state.triggerTime))
@@ -814,9 +818,9 @@ module.exports = function(RED)
 
                         setUpTimer();
                         updateStatus();
-                    }, state.triggerTime.diff(chronos.getCurrentTime(node)));
+                    }, delay);
 
-                    node.debug("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer);
+                    node.debug("[State:" + state.data.id + "] Successfully started timer with ID " + node.currentState.timer + " at " + now.format("YYYY-MM-DD HH:mm:ss.SSS (Z)") + " waiting " + delay + " milliseconds");
                 }
             }
         }


### PR DESCRIPTION
Fixes a bug that occurs when scheduling a message for midnight (or slightly after midnight) and Node-RED runs within a Docker environment. Due to timers running too fast and therefore expiring too early in such environments, the events were fired too early and in case of midnight also twice as the calculation of the next trigger time was wrong.

Additionally, some trace output is enhanced.

Resolves #232