### PR TITLE
Bump version to 1.28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.28.0",
+    "version": "1.28.1",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -44,20 +44,20 @@
     "dependencies": {
         "cronosjs": "^1.7.1",
         "moment": "^2.30.1",
-        "moment-timezone": "^0.5.48",
+        "moment-timezone": "^0.6.0",
         "os-locale": "^5.0.0",
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^9.25.0",
-        "jsonata": "^2.0.6",
-        "mocha": "^11.1.0",
-        "node-red": "^4.0.9",
-        "node-red-node-test-helper": "^0.3.4",
+        "eslint": "^9.33.0",
+        "jsonata": "^2.1.0",
+        "mocha": "^11.7.1",
+        "node-red": "^4.1.0",
+        "node-red-node-test-helper": "^0.3.5",
         "nyc": "^17.1.0",
         "should": "^13.2.3",
         "should-sinon": "^0.0.6",
-        "sinon": "^20.0.0"
+        "sinon": "^21.0.0"
     },
     "main": "none",
     "scripts": {


### PR DESCRIPTION
This pull request bumps the node-red-contrib-chronos component version to 1.28.1.