### PR TITLE
Add preview for sun and moon times

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -224,6 +224,52 @@ SOFTWARE.
             {
                 const node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_change", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_change", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -1269,6 +1315,9 @@ SOFTWARE.
             oneditsave: function()
             {
                 const node = this;
+
+                $("body").off(".chronos_change");
+
                 node.rules = [];
 
                 if ($("#node-input-mode").val() == "moment")
@@ -1396,6 +1445,10 @@ SOFTWARE.
                         node.rules.push(data);
                     });
                 }
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_change");
             },
             oneditresize: function(size)
             {

--- a/nodes/change.js
+++ b/nodes/change.js
@@ -35,7 +35,6 @@ module.exports = function(RED)
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {

--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -129,7 +129,7 @@ function printNodeInfo(node)
 function getCurrentTime(node)
 {
     const ret = getMoment(node);
-    ret.locale(node.locale);
+    ret.locale(node.config.locale);
 
     return ret;
 }
@@ -150,7 +150,7 @@ function getTimeFrom(node, source)
                     "L LT",                     // locale-specific date and time
                     "L LTS",                    // locale-specific date and time (incl. seconds)
                     moment.ISO_8601],           // ISO 8601 datetime
-                node.locale,
+                node.config.locale,
                 true);
     }
     else if ((typeof source == "number") && (source >= 0))
@@ -176,7 +176,7 @@ function getTimeFrom(node, source)
         ret = moment.invalid();
     }
 
-    ret.locale(node.locale);
+    ret.locale(node.config.locale);
     return ret;
 }
 
@@ -213,7 +213,7 @@ function getUserTime(node, day, value, timeOnly = false)
                         "L LT",            // locale-specific date and time
                         "L LTS",           // locale-specific date and time (incl. seconds)
                         moment.ISO_8601],  // ISO 8601 datetime
-                    node.locale,
+                    node.config.locale,
                     true);
             ret.hasUserDate(true);
         }
@@ -237,7 +237,7 @@ function getUserTime(node, day, value, timeOnly = false)
         throw new TimeError(node.RED._("node-red-contrib-chronos/chronos-config:common.error.invalidTime"), {type: "time", value: value});
     }
 
-    ret.locale(node.locale);
+    ret.locale(node.config.locale);
     return ret;
 }
 
@@ -248,7 +248,7 @@ function getUserDate(node, value)
     if (PATTERN_DATE.test(value))
     {
         ret = getMoment(node, value, "YYYY-MM-DD");
-        ret.locale(node.locale);
+        ret.locale(node.config.locale);
     }
 
     if (!ret || !ret.isValid())
@@ -295,7 +295,7 @@ function getSunTime(node, day, type)
                 ret.tz(tz);
             }
 
-            ret.locale(node.locale);
+            ret.locale(node.config.locale);
         }
     }
 
@@ -327,7 +327,7 @@ function getMoonTime(node, day, type)
                 ret.tz(tz);
             }
 
-            ret.locale(node.locale);
+            ret.locale(node.config.locale);
         }
     }
 
@@ -372,7 +372,7 @@ function getTime(node, day, type, value)
                             matches[1], [
                                 "L",            // locale-specific date
                                 "YYYY-MM-DD"],  // ISO 8601 date
-                            node.locale,
+                            node.config.locale,
                             true);
                 }
 
@@ -509,7 +509,7 @@ function retrieveTime(node, msg, baseTime, type, value)
 function getDuration(node, input, unit)
 {
     const ret = moment.duration(input, unit);
-    ret.locale(node.locale);
+    ret.locale(node.config.locale);
 
     return ret;
 }
@@ -611,7 +611,7 @@ function getJSONataExpression(node, expr)
             latitude: (typeof node.config.latitude == "number") ? node.config.latitude : null,
             longitude: (typeof node.config.longitude == "number") ? node.config.longitude : null,
             timezone: node.config.tzFromContext ? null : node.config.timezone,
-            locale: node.locale});
+            locale: node.config.locale});
 
     expression.registerFunction("getLatitude", () => { return getLatitude(node); }, "<:n>");
     expression.registerFunction("getLongitude", () => { return getLongitude(node); }, "<:n>");

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -395,6 +395,52 @@ SOFTWARE.
             {
                 const node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_delay", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_delay", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -781,8 +827,14 @@ SOFTWARE.
             },
             oneditsave: function()
             {
+                $("body").off(".chronos_delay");
+
                 $("#node-input-whenValue").val($("#node-input-when").typedInput("value"));
                 $("#node-input-customDelayValue").val($("#node-input-customDelay").typedInput("value"));
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_delay");
             }
         });
     })();

--- a/nodes/delay.js
+++ b/nodes/delay.js
@@ -45,7 +45,6 @@ module.exports = function(RED)
         node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         // backward compatibility to v1.17.x and earlier
         if (typeof settings.delayType == "undefined")

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -312,6 +312,52 @@ SOFTWARE.
             {
                 let node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_filter", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_filter", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -1339,6 +1385,8 @@ SOFTWARE.
             {
                 const node = this;
 
+                $("body").off(".chronos_filter");
+
                 node.conditions = [];
 
                 if ($("#node-input-reference").typedInput("type") == "absTime")
@@ -1506,6 +1554,10 @@ SOFTWARE.
                         node.conditions.push(data);
                     });
                 }
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_filter");
             },
             oneditresize: function(size)
             {

--- a/nodes/filter.js
+++ b/nodes/filter.js
@@ -35,7 +35,6 @@ module.exports = function(RED)
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {

--- a/nodes/locales/de/change.html
+++ b/nodes/locales/de/change.html
@@ -130,10 +130,10 @@ SOFTWARE.
                         <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12- oder 24-Stunden-Format eingegeben werden..
                     </li>
                     <li>
-                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden. Wenn mit der Maus über den Button gefahren wird, wird eine Vorschau der Zeit angezeigt.
                     </li>
                     <li>
-                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden. Wenn mit der Maus über den Button gefahren wird, wird eine Vorschau der Zeit angezeigt.
                     </li>
                     <li>
                         <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte Sonnenstände kann eingegeben werden.
@@ -145,10 +145,10 @@ SOFTWARE.
                         <i>Uhrzeit</i>: Eine beliebige Uhrzeit kann direkt im 12- oder 24-Stunden-Format eingegeben werden. Optional ist die Eingabe eines Datums und einer Zeit in Region-spezifischem oder ISO 8601 Format möglich.
                     </li>
                     <li>
-                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                        <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste vorgegebener Werte ausgewählt werden. Wenn mit der Maus über den Button gefahren wird, wird eine Vorschau der Zeit angezeigt.
                     </li>
                     <li>
-                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden.
+                        <i>Mondstand</i>: Der Mondstand kann aus einer Liste vorgegebener Werte ausgewählt werden. Wenn mit der Maus über den Button gefahren wird, wird eine Vorschau der Zeit angezeigt.
                     </li>
                     <li>
                         <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte Sonnenstände kann eingegeben werden.

--- a/nodes/locales/de/delay.html
+++ b/nodes/locales/de/delay.html
@@ -104,11 +104,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -64,11 +64,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte
@@ -275,11 +279,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte

--- a/nodes/locales/de/repeat.html
+++ b/nodes/locales/de/repeat.html
@@ -98,11 +98,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte

--- a/nodes/locales/de/scheduler.html
+++ b/nodes/locales/de/scheduler.html
@@ -68,11 +68,15 @@ SOFTWARE.
                         </li>
                         <li>
                             <i>Sonnenstand</i>: Der Sonnenstand kann aus einer
-                            Liste vorgegebener Werte ausgewählt werden.
+                            Liste vorgegebener Werte ausgewählt werden. Wenn mit
+                            der Maus über den Button gefahren wird, wird eine
+                            Vorschau der Zeit angezeigt.
                         </li>
                         <li>
                             <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                            vorgegebener Werte ausgewählt werden.
+                            vorgegebener Werte ausgewählt werden. Wenn mit der
+                            Maus über den Button gefahren wird, wird eine Vorschau
+                            der Zeit angezeigt.
                         </li>
                         <li>
                             <i>Sonnenstand (benutzerdf.)</i>: Einer der Namen für

--- a/nodes/locales/de/state.html
+++ b/nodes/locales/de/state.html
@@ -75,11 +75,15 @@ SOFTWARE.
                         </li>
                         <li>
                             <i>Sonnenstand</i>: Der Sonnenstand kann aus einer
-                            Liste vorgegebener Werte ausgewählt werden.
+                            Liste vorgegebener Werte ausgewählt werden. Wenn mit
+                            der Maus über den Button gefahren wird, wird eine
+                            Vorschau der Zeit angezeigt.
                         </li>
                         <li>
                             <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                            vorgegebener Werte ausgewählt werden.
+                            vorgegebener Werte ausgewählt werden. Wenn mit der
+                            Maus über den Button gefahren wird, wird eine Vorschau
+                            der Zeit angezeigt.
                         </li>
                         <li>
                             <i>Sonnenstand (benutzerdf.)</i>: Einer der Namen für

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -66,11 +66,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte
@@ -254,11 +258,15 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>Sonnenstand</i>: Der Sonnenstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Mondstand</i>: Der Mondstand kann aus einer Liste
-                    vorgegebener Werte ausgewählt werden.
+                    vorgegebener Werte ausgewählt werden. Wenn mit der Maus
+                    über den Button gefahren wird, wird eine Vorschau der Zeit
+                    angezeigt.
                 </li>
                 <li>
                     <i>Sonnenstand (benutzerdef.)</i>: Einer der Namen für benutzerdefinierte

--- a/nodes/locales/en-US/change.html
+++ b/nodes/locales/en-US/change.html
@@ -129,10 +129,10 @@ SOFTWARE.
                         <i>time of day</i>: A specific time can be entered directly in 12 or 24 hour format.
                     </li>
                     <li>
-                        <i>sun position</i>: The sun position can be selected from a list of predefined values.
+                        <i>sun position</i>: The sun position can be selected from a list of predefined values. A preview of the time is shown when hovering over the button.
                     </li>
                     <li>
-                        <i>moon position</i>: The moon position can be selected from a list of predefined values.
+                        <i>moon position</i>: The moon position can be selected from a list of predefined values. A preview of the time is shown when hovering over the button.
                     </li>
                     <li>
                         <i>custom sun position</i>: One of the user-defined sun position names can be entered.
@@ -144,10 +144,10 @@ SOFTWARE.
                         <i>time of day</i>: A specific time can be entered directly in 12 or 24 hour format. Optionally it is possible to specify a date and a time using regional or ISO 8601 format.
                     </li>
                     <li>
-                        <i>sun position</i>: The sun position can be selected from a list of predefined values.
+                        <i>sun position</i>: The sun position can be selected from a list of predefined values. A preview of the time is shown when hovering over the button.
                     </li>
                     <li>
-                        <i>moon position</i>: The moon position can be selected from a list of predefined values.
+                        <i>moon position</i>: The moon position can be selected from a list of predefined values. A preview of the time is shown when hovering over the button.
                     </li>
                     <li>
                         <i>custom sun position</i>: One of the user-defined sun position names can be entered.

--- a/nodes/locales/en-US/delay.html
+++ b/nodes/locales/en-US/delay.html
@@ -101,11 +101,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from a list
-                    of predefined values.
+                    of predefined values. A preview of the time is shown when hovering
+                    over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from a list
-                    of predefined values.
+                    of predefined values. A preview of the time is shown when hovering
+                    over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names can be

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -59,11 +59,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names
@@ -246,11 +248,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names

--- a/nodes/locales/en-US/repeat.html
+++ b/nodes/locales/en-US/repeat.html
@@ -94,11 +94,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from a list
-                    of predefined values.
+                    of predefined values. A preview of the time is shown when hovering
+                    over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from a list
-                    of predefined values.
+                    of predefined values. A preview of the time is shown when hovering
+                    over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names can be

--- a/nodes/locales/en-US/scheduler.html
+++ b/nodes/locales/en-US/scheduler.html
@@ -62,12 +62,14 @@ SOFTWARE.
                             directly in the form <code>hh:mm[:ss] [am|pm]</code>.
                         </li>
                         <li>
-                            <i>sun position</i>: The sun position can be
-                            selected from a list of predefined values.
+                            <i>sun position</i>: The sun position can be selected
+                            from a list of predefined values. A preview of the time
+                            is shown when hovering over the button.
                         </li>
                         <li>
-                            <i>moon position</i>: The moon position can be
-                            selected from a list of predefined values.
+                            <i>moon position</i>: The moon position can be selected
+                            from a list of predefined values. A preview of the time
+                            is shown when hovering over the button.
                         </li>
                         <li>
                             <i>custom sun position</i>: One of the user-defined sun position

--- a/nodes/locales/en-US/state.html
+++ b/nodes/locales/en-US/state.html
@@ -69,12 +69,14 @@ SOFTWARE.
                             directly in the form <code>hh:mm[:ss] [am|pm]</code>.
                         </li>
                         <li>
-                            <i>sun position</i>: The sun position can be
-                            selected from a list of predefined values.
+                            <i>sun position</i>: The sun position can be selected
+                            from a list of predefined values. A preview of the time
+                            is shown when hovering over the button.
                         </li>
                         <li>
-                            <i>moon position</i>: The moon position can be
-                            selected from a list of predefined values.
+                            <i>moon position</i>: The moon position can be selected
+                            from a list of predefined values. A preview of the time
+                            is shown when hovering over the button.
                         </li>
                         <li>
                             <i>custom sun position</i>: One of the user-defined

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -60,11 +60,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names
@@ -225,11 +227,13 @@ SOFTWARE.
                 </li>
                 <li>
                     <i>sun position</i>: The sun position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>moon position</i>: The moon position can be selected from
-                    a list of predefined values.
+                    a list of predefined values. A preview of the time is shown
+                    when hovering over the button.
                 </li>
                 <li>
                     <i>custom sun position</i>: One of the user-defined sun position names

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -308,6 +308,52 @@ SOFTWARE.
             {
                 const node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_repeat", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_repeat", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -641,8 +687,14 @@ SOFTWARE.
             },
             oneditsave: function()
             {
+                $("body").off(".chronos_repeat");
+
                 $("#node-input-customRepetitionValue").val($("#node-input-customRepetition").typedInput("value"));
                 $("#node-input-untilValue").val($("#node-input-until").typedInput("value"));
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_repeat");
             }
         });
     })();

--- a/nodes/repeat.js
+++ b/nodes/repeat.js
@@ -38,7 +38,6 @@ module.exports = function(RED)
         node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         // backward compatibility to v1.14.x and earlier
         if (typeof settings.mode == "undefined")

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -238,6 +238,52 @@ SOFTWARE.
             {
                 const node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_scheduler", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_scheduler", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const tabs = RED.tabs.create(
                 {
                     id: "tab-row",
@@ -574,6 +620,8 @@ SOFTWARE.
                 const multiPort = $("#node-input-multiPort").prop("checked");
                 const nextEventPort = $("#node-input-nextEventPort").prop("checked");
 
+                $("body").off(".chronos_scheduler");
+
                 node.schedule = [];
                 node.outputs = 0;
 
@@ -668,6 +716,10 @@ SOFTWARE.
                 {
                     ++node.outputs;
                 }
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_scheduler");
             },
             oneditresize: function(size)
             {

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -35,7 +35,6 @@ module.exports = function(RED)
         node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         node.initializing = true;
         node.eventTimesPending = false;

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -241,6 +241,52 @@ SOFTWARE.
             {
                 const node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_state", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_state", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -816,6 +862,8 @@ SOFTWARE.
                 const stateList = $("#node-input-stateList").editableList("items");
                 const conditionList = $("#node-input-conditionList").editableList("items");
 
+                $("body").off(".chronos_state");
+
                 node.states = [];
                 node.conditions = [];
 
@@ -888,6 +936,10 @@ SOFTWARE.
 
                     node.conditions.push(data);
                 });
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_state");
             },
             oneditresize: function(size)
             {

--- a/nodes/state.js
+++ b/nodes/state.js
@@ -35,7 +35,6 @@ module.exports = function(RED)
         node.RED = RED;
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -310,6 +310,52 @@ SOFTWARE.
             {
                 let node = this;
 
+                let tokenCounter = 0;
+
+                $("body").on("mouseenter.chronos_switch", ".red-ui-typedInput-option-trigger", function()
+                {
+                    const _this = this;
+
+                    const input = $(_this).parent().parent().find("input");
+                    if (input.length >= 3)
+                    {
+                        const type = input.eq(2).val();
+                        if ((type == "sun") || (type == "moon"))
+                        {
+                            const token = tokenCounter++;
+                            _this._chronos_lastToken = token;
+
+                            $.getJSON(
+                                "chronos_config", {
+                                    command: "gettime",
+                                    timeType: type,
+                                    timeName: input.eq(0).val(),
+                                    config: $("#node-input-config").val()})
+                                    .done(result =>
+                            {
+                                if (_this._chronos_lastToken === token)
+                                {
+                                    const label = $(_this).find("span.red-ui-typedInput-option-label");
+
+                                    _this._chronos_lastOptionLabel = label.html();
+                                    label.html(result);
+                                }
+                            });
+                        }
+                    }
+                }).on("mouseleave.chronos_switch", ".red-ui-typedInput-option-trigger", function()
+                {
+                    delete this._chronos_lastToken;
+
+                    if (this._chronos_lastOptionLabel)
+                    {
+                        const label = $(this).find("span.red-ui-typedInput-option-label");
+                        label.html(this._chronos_lastOptionLabel);
+
+                        delete this._chronos_lastOptionLabel;
+                    }
+                });
+
                 const sunTimes =
                 [
                     {
@@ -1377,6 +1423,8 @@ SOFTWARE.
 
                 function fmtOffset(offset) { return (offset > 0) ? ("+" + offset) : offset; }
 
+                $("body").off(".chronos_switch");
+
                 node.conditions = [];
                 node.outputs = 0;
 
@@ -1853,6 +1901,10 @@ SOFTWARE.
                         node.outputs++;
                     });
                 }
+            },
+            oneditcancel: function()
+            {
+                $("body").off(".chronos_switch");
             },
             oneditresize: function(size)
             {

--- a/nodes/switch.js
+++ b/nodes/switch.js
@@ -35,7 +35,6 @@ module.exports = function(RED)
         node.chronos = require("./common/chronos.js");
         node.name = settings.name;
         node.config = RED.nodes.getNode(settings.config);
-        node.locale = ("lang" in RED.settings) ? RED.settings.lang : require("os-locale").sync();
 
         if (!node.config)
         {


### PR DESCRIPTION
Adds a preview for sun and moon times in the configuration UI of all nodes. This is the next time represented by the corresponding sun/moon time name. It appears on the sun/moon time selector when hovering with the mouse over it.

Resolves #231