### PR TITLE
Show sun/moon preview time always on current day for time switch/filter/change nodes

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -244,6 +244,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: true,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/config.js
+++ b/nodes/config.js
@@ -51,7 +51,7 @@ module.exports = function(RED)
                                                 req.query.timeType,
                                                 req.query.timeName);
 
-                    if (now.isAfter(time))
+                    if ((req.query.currentDay !== "true") && now.isAfter(time))
                     {
                         time = context.chronos.getTime(
                                                 context,

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -415,6 +415,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: false,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -332,6 +332,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: true,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/repeat.html
+++ b/nodes/repeat.html
@@ -328,6 +328,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: false,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/scheduler.html
+++ b/nodes/scheduler.html
@@ -258,6 +258,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: false,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/state.html
+++ b/nodes/state.html
@@ -261,6 +261,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: false,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -330,6 +330,7 @@ SOFTWARE.
                                     command: "gettime",
                                     timeType: type,
                                     timeName: input.eq(0).val(),
+                                    currentDay: true,
                                     config: $("#node-input-config").val()})
                                     .done(result =>
                             {


### PR DESCRIPTION
For time switch, filter and changes nodes, the preview time for sun and moon positions will now be calculated always for the current day, even if it is in the past. For the other nodes, the preview time will always be in the future, as before.