### PR TITLE
Bump version to 1.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.29.0",
+    "version": "1.29.1",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",


### PR DESCRIPTION
This pull request bumps the node-red-contrib-chronos component version to 1.29.1.