### PR TITLE
Rename JSONata attribute 'duration' to 'baseDuration'

### DIFF
--- a/nodes/common/sfutils.js
+++ b/nodes/common/sfutils.js
@@ -755,7 +755,10 @@ async function evaluateCondition(node, msg, reference, baseTime, cond, id)
             // time switch/filter node specific JSONata extensions
             expression.assign("baseTime", baseTime.valueOf());
             expression.assign("refTime", reference.valueOf());
-            expression.assign("duration", node.chronos.getDuration(node, baseTime.diff(reference)).asMilliseconds());
+
+            const baseDuration = node.chronos.getDuration(node, baseTime.diff(reference)).asMilliseconds();
+            expression.assign("duration", baseDuration);  // backward compatibility to version 1.29.1 and below
+            expression.assign("baseDuration", baseDuration);
 
             result = await node.chronos.evaluateJSONataExpression(node.RED, expression, msg);
         }

--- a/nodes/locales/de/filter.html
+++ b/nodes/locales/de/filter.html
@@ -391,7 +391,7 @@ SOFTWARE.
                     über die Variable <code>$refTime</code> und die Basiszeit über die
                     Variable <code>$baseTime</code> abgefragt werden. Zusätzlich kann
                     die Zeitspanne zwischen Referenzzeit und Basiszeit über die Variable
-                    <code>$duration</code> abgerufen werden.
+                    <code>$baseDuration</code> abgerufen werden.
                 </li>
                 <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen

--- a/nodes/locales/de/switch.html
+++ b/nodes/locales/de/switch.html
@@ -370,7 +370,7 @@ SOFTWARE.
                     über die Variable <code>$refTime</code> und die Basiszeit über die
                     Variable <code>$baseTime</code> abgefragt werden. Zusätzlich kann
                     die Zeitspanne zwischen Referenzzeit und Basiszeit über die Variable
-                    <code>$duration</code> abgerufen werden.
+                    <code>$baseDuration</code> abgerufen werden.
                 </li>
                 <li>
                     Quelle <i>Kontext</i>: Lädt die Bedingung aus der angegebenen

--- a/nodes/locales/en-US/filter.html
+++ b/nodes/locales/en-US/filter.html
@@ -345,7 +345,7 @@ SOFTWARE.
                     variable <code>$refTime</code> and the base time can be accessed through
                     variable <code>$baseTime</code>. Additionally, the time span between
                     reference time and base time  can be accessed through variable
-                    <code>$duration</code>.
+                    <code>$baseDuration</code>.
                 </li>
                 <li>
                     Source <i>context</i>: Loads the condition from the specified

--- a/nodes/locales/en-US/switch.html
+++ b/nodes/locales/en-US/switch.html
@@ -328,7 +328,7 @@ SOFTWARE.
                     variable <code>$refTime</code> and the base time can be accessed through
                     variable <code>$baseTime</code>. Additionally, the time span between
                     reference time and base time  can be accessed through variable
-                    <code>$duration</code>.
+                    <code>$baseDuration</code>.
                 </li>
                 <li>
                     Source <i>context</i>: Loads the condition from the specified


### PR DESCRIPTION
JSONata attribute `duration` has been renamed to `baseDuration` to make its purpose clearer. This is not a breaking change, the old name is still supported for backward compatibility.