### PR TITLE
Bump version to 1.29.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-chronos",
-    "version": "1.29.1",
+    "version": "1.29.2",
     "description": "Time-based Node-RED scheduling, repeating, queueing, routing, filtering and manipulating nodes",
     "author": {
         "name": "Jens-Uwe Rossbach",
@@ -49,9 +49,9 @@
         "suncalc": "^1.9.0"
     },
     "devDependencies": {
-        "eslint": "^9.35.0",
+        "eslint": "^9.36.0",
         "jsonata": "^2.1.0",
-        "mocha": "^11.7.2",
+        "mocha": "^11.7.4",
         "node-red": "^4.1.0",
         "node-red-node-test-helper": "^0.3.5",
         "nyc": "^17.1.0",


### PR DESCRIPTION
This pull request bumps the node-red-contrib-chronos component version to 1.29.2. Additionally it updates dependencies to latest versions as far as possible.