### PR TITLE
Fix scheduling loop for nadir

### DIFF
--- a/nodes/common/chronos.js
+++ b/nodes/common/chronos.js
@@ -44,7 +44,7 @@ class TimeError extends Error
 
 
 const moment = require("moment-timezone");
-const sunCalc = require("suncalc");
+const sunCalc = require("suncalc2");
 
 require("./moment_locales.js");
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "moment": "^2.30.1",
         "moment-timezone": "^0.6.0",
         "os-locale": "^5.0.0",
-        "suncalc": "^1.9.0"
+        "suncalc2": "^1.8.1"
     },
     "devDependencies": {
         "eslint": "^9.36.0",

--- a/test/common/chronos_spec.js
+++ b/test/common/chronos_spec.js
@@ -26,7 +26,7 @@
 const sinon = require("sinon");
 const chronos = require("../../nodes/common/chronos.js");
 const moment = require("moment");
-const sunCalc = require("suncalc");
+const sunCalc = require("suncalc2");
 const jsonata = require("jsonata");
 
 require("should-sinon");


### PR DESCRIPTION
Fixes an endless loop when scheduling an event for nadir sun time. Using [suncalc2](https://github.com/andiling/suncalc2) instead of [suncalc](https://github.com/mourner/suncalc) to calculate nadir correctly in the future and adding further checks to prevent scheduling in case of negative delays.

Resolves #249