### PR TITLE
Fix loop variables on global scope

### DIFF
--- a/nodes/change.html
+++ b/nodes/change.html
@@ -1308,7 +1308,7 @@ SOFTWARE.
                     momentRules.editableList("addItem", {});
                 }
 
-                for (data of node.rules)
+                for (const data of node.rules)
                 {
                     rules.editableList("addItem", data);
                 }

--- a/nodes/delay.html
+++ b/nodes/delay.html
@@ -571,7 +571,7 @@ SOFTWARE.
                     {
                         case "milliseconds":
                         {
-                            for (elem of elements)
+                            for (const elem of elements)
                             {
                                 elem.spinner("option", "max", 60000);
                             }
@@ -580,7 +580,7 @@ SOFTWARE.
                         }
                         case "seconds":
                         {
-                            for (elem of elements)
+                            for (const elem of elements)
                             {
                                 elem.spinner("option", "max", 3600);
                             }
@@ -589,7 +589,7 @@ SOFTWARE.
                         }
                         case "minutes":
                         {
-                            for (elem of elements)
+                            for (const elem of elements)
                             {
                                 elem.spinner("option", "max", 1440);
                             }
@@ -598,7 +598,7 @@ SOFTWARE.
                         }
                         case "hours":
                         {
-                            for (elem of elements)
+                            for (const elem of elements)
                             {
                                 elem.spinner("option", "max", 168);
                             }
@@ -607,7 +607,7 @@ SOFTWARE.
                         }
                         case "days":
                         {
-                            for (elem of elements)
+                            for (const elem of elements)
                             {
                                 elem.spinner("option", "max", 7);
                             }
@@ -616,7 +616,7 @@ SOFTWARE.
                         }
                     }
 
-                    for (elem of elements)
+                    for (const elem of elements)
                     {
                         validateNumericInput.call(elem);
                     }

--- a/nodes/filter.html
+++ b/nodes/filter.html
@@ -188,7 +188,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands.type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -207,7 +207,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[0].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -224,7 +224,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[1].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -243,7 +243,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands.type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -262,7 +262,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[0].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -279,7 +279,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[1].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -288,7 +288,7 @@ SOFTWARE.
                             }
                             else if (item.operator == "expression")
                             {
-                                const res = RED.utils.validateTypedProperty(item.expression, "jsonata", opt)
+                                const res = RED.utils.validateTypedProperty(item.expression, "jsonata", opt);
                                 if (res !== true)
                                 {
                                     errors.push(res);
@@ -296,7 +296,7 @@ SOFTWARE.
                             }
                             else if (item.operator == "context")
                             {
-                                const res = RED.utils.validateTypedProperty(item.context.value, item.context.type, opt)
+                                const res = RED.utils.validateTypedProperty(item.context.value, item.context.type, opt);
                                 if (res !== true)
                                 {
                                     errors.push(res);
@@ -1377,7 +1377,7 @@ SOFTWARE.
                     momentConditions.editableList("addItem", {});
                 }
 
-                for (data of node.conditions)
+                for (const data of node.conditions)
                 {
                     conditions.editableList("addItem", data);
                 }

--- a/nodes/scheduler.js
+++ b/nodes/scheduler.js
@@ -338,7 +338,7 @@ module.exports = function(RED)
 
                 if (node.startQueue)
                 {
-                    for (let entry of node.startQueue)
+                    for (const entry of node.startQueue)
                     {
                         sendMessage(entry);
                     }
@@ -358,7 +358,7 @@ module.exports = function(RED)
         {
             node.debug("Starting events");
 
-            for (let data of node.schedule)
+            for (const data of node.schedule)
             {
                 startEvent(data);
             }
@@ -370,7 +370,7 @@ module.exports = function(RED)
         {
             node.debug("Stopping events");
 
-            for (let data of node.schedule)
+            for (const data of node.schedule)
             {
                 stopEvent(data);
             }
@@ -383,7 +383,7 @@ module.exports = function(RED)
             node.debug("Toggling events");
 
             let enabled = true;
-            for (let data of node.schedule)
+            for (const data of node.schedule)
             {
                 toggleEvent(data);
 
@@ -401,7 +401,7 @@ module.exports = function(RED)
         {
             node.debug("Rescheduling events");
 
-            for (let data of node.schedule)
+            for (const data of node.schedule)
             {
                 reloadEvent(data);
             }
@@ -413,7 +413,7 @@ module.exports = function(RED)
         {
             node.debug("Triggering events" + (forced ? " (forced)" : ""));
 
-            for (let data of node.schedule)
+            for (const data of node.schedule)
             {
                 await triggerEvent(data, forced);
             }
@@ -642,7 +642,7 @@ module.exports = function(RED)
 
             if (!node.disabledSchedule)
             {
-                for (let data of node.schedule)
+                for (const data of node.schedule)
                 {
                     if ((data.config.trigger.type != "crontab") && data.triggerTime)
                     {
@@ -695,7 +695,7 @@ module.exports = function(RED)
                             }
                             else
                             {
-                                for (let data of events)
+                                for (const data of events)
                                 {
                                     await produceOutput(data);
                                     setUpEvent(data, next);

--- a/nodes/switch.html
+++ b/nodes/switch.html
@@ -178,7 +178,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands.type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -197,7 +197,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[0].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -214,7 +214,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[1].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -233,7 +233,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands.type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands.value, item.operands.type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -252,7 +252,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[0].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[0].value, item.operands[0].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -269,7 +269,7 @@ SOFTWARE.
                                 }
                                 else if (/^env|global|flow|msg$/.test(item.operands[1].type))
                                 {
-                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt)
+                                    const res = RED.utils.validateTypedProperty(item.operands[1].value, item.operands[1].type, opt);
                                     if (res !== true)
                                     {
                                         errors.push(res);
@@ -278,7 +278,7 @@ SOFTWARE.
                             }
                             else if (item.operator == "expression")
                             {
-                                const res = RED.utils.validateTypedProperty(item.expression, "jsonata", opt)
+                                const res = RED.utils.validateTypedProperty(item.expression, "jsonata", opt);
                                 if (res !== true)
                                 {
                                     errors.push(res);
@@ -286,7 +286,7 @@ SOFTWARE.
                             }
                             else if (item.operator == "context")
                             {
-                                const res = RED.utils.validateTypedProperty(item.context.value, item.context.type, opt)
+                                const res = RED.utils.validateTypedProperty(item.context.value, item.context.type, opt);
                                 if (res !== true)
                                 {
                                     errors.push(res);
@@ -734,7 +734,7 @@ SOFTWARE.
                         const exclude = $("<input/>", {type: "checkbox", class: "node-input-exclude", style: "width: auto; margin-left: 4px; margin-top: 0px; margin-bottom: 3px;"})
                                             .appendTo(excludeLabel);
 
-                                            const weekdayInputs = new Array(6);
+                        const weekdayInputs = new Array(6);
                         const monthInputs = new Array(12);
 
                         for (let i=0; i<7; ++i)
@@ -1386,7 +1386,7 @@ SOFTWARE.
                     momentConditions.editableList("addItem", {});
                 }
 
-                for (data of node.conditions)
+                for (const data of node.conditions)
                 {
                     conditions.editableList("addItem", data);
                 }


### PR DESCRIPTION
Restricts the scope of some loop variables to the loop scope which were previously on global scope. This can potentially lead to conflicts if variables with the same name already exist on global scope.

Resolves #253